### PR TITLE
Optimize search for larger datasets

### DIFF
--- a/LEAF_Request_Portal/api/controllers/FormController.php
+++ b/LEAF_Request_Portal/api/controllers/FormController.php
@@ -83,6 +83,24 @@ class FormController extends RESTfulResponse
             return $form->query($_GET['q']);
         });
 
+        $this->index['GET']->register('form/queryIndicator', function ($args) use ($form) {
+            if (isset($_GET['debug']))
+            {
+                return $query = XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
+            }
+
+            return $form->queryIndicator($_GET['q']);
+        });
+
+        $this->index['GET']->register('form/queryWorkflowState', function ($args) use ($form) {
+            if (isset($_GET['debug']))
+            {
+                return $query = XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
+            }
+
+            return $form->queryWorkflowState($_GET['q']);
+        });
+
         $this->index['GET']->register('form/search/indicator/[digit]', function ($args) use ($form) {
             $query = '{"terms":[{"id":"data","indicatorID":"' . $args[0] . '","operator":"=","match":"' . $_GET['q'] . '"}]}';
 

--- a/LEAF_Request_Portal/db_mysql.php
+++ b/LEAF_Request_Portal/db_mysql.php
@@ -51,7 +51,8 @@ class DB
         {
             trigger_error('DB conn: ' . $e->getMessage());
             if(!$abortOnError) {
-                echo '<div style="background-color: white; line-height: 200%; position: absolute; top: 50%; height: 200px; width: 750px; margin-top: -100px; left: 20%; font-size: 200%"><img src="../libs/dynicons/?img=edit-clear.svg&w=96" alt="Server Maintenance" style="float: left" /> Database connection error.<br />Please try again in 15 minutes.</div>';
+                echo '<script>var min=5,max=10,timeWait=Math.ceil(Math.random()*(max-min))+min;function tryAgain(){timeWait--;let t=document.querySelector("#tryAgain");t.innerHTML="Loading in "+timeWait+" seconds...",t.style.pointerEvents="none",setTimeout(function(){timeWait>1?tryAgain():location.reload()},1e3)}</script>';
+                echo '<div style="background-color: white; font-family: \'Source Sans Pro\', helvetica;line-height: 200%; position: absolute; top: 50%; height: 200px; width: 750px; margin-top: -100px; left: 20%; font-size: 200%">⛈️ We are experiencing heavy database traffic<p style="margin-left: 54px">Please come back at your next convenience</p><button id="tryAgain" onclick="tryAgain()" style="font-size: 14pt; padding: 8px; margin-left: 54px">Try again now</button></div>';
                 echo '<!-- Database Error: ' . $e->getMessage() . ' -->';
                 http_response_code(503);
                 exit();

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3009,6 +3009,13 @@ class Form
             $joins .= "LEFT JOIN (SELECT userName, lastName, firstName FROM {$this->oc_dbName}.employee) lj_OCinitiatorNames ON records.userID = lj_OCinitiatorNames.userName ";
         }
 
+        if(isset($_GET['debugQuery'])) {
+            $debugQuery = str_replace(["\r", "\n"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
+            $vars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
+            header('X-LEAF-Query: '. str_replace(array_keys($vars), $vars, $debugQuery));
+            
+            return XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
+        }
         $res = $this->db->prepared_query('SELECT * FROM records
     										' . $joins . '
                                             WHERE ' . $conditions . $sort . $limit, $vars);

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3458,10 +3458,23 @@ class Form
             $conditions = '';
         }
 
+        $conditions = $conditions == '' ? '1=1' : $conditions;
+        $limit = '';
+        if (isset($query['limit']) && is_numeric($query['limit']))
+        {
+            $offset = '';
+            if (isset($query['limitOffset']) && is_numeric($query['limitOffset']))
+            {
+                $offset = "{$query['limitOffset']},";
+            }
+            $limit = ' LIMIT ' . $offset . $query['limit'];
+        }
+
         $output = [];
         $output['joins'] = $joins;
         $output['conditions'] = $conditions;
         $output['vars'] = $vars;
+        $output['limit'] = $limit;
 
         return $output;
     }
@@ -3479,11 +3492,12 @@ class Form
         $joins = $params['joins'];
         $conditions = $params['conditions'];
         $vars = $params['vars'];
+        $limit = $params['limit'];
 
         $strSQL = "SELECT recordID, indicatorID, series, data, timestamp, data.userID FROM data ".
                     "LEFT JOIN records USING (recordID) ".
                     $joins .
-                    "WHERE ". $conditions;
+                    "WHERE ". $conditions . $limit;
 
         $res = $this->db->prepared_query($strSQL, $vars);
 
@@ -3513,11 +3527,12 @@ class Form
         $joins = $params['joins'];
         $conditions = $params['conditions'];
         $vars = $params['vars'];
+        $limit = $params['limit'];
 
         $strSQL = "SELECT recordID, stepID, blockingStepID FROM records_workflow_state ".
                     "LEFT JOIN records USING (recordID) ".
                     $joins .
-                    "WHERE ". $conditions;
+                    "WHERE ". $conditions . $limit;
 
         $res = $this->db->prepared_query($strSQL, $vars);
 

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2899,7 +2899,7 @@ class Form
 
                         break;
                     case 'status':
-                        $joins .= 'LEFT JOIN (SELECT * FROM records_workflow_state GROUP BY recordID) lj_status USING (recordID)
+                        $joins .= 'LEFT JOIN (SELECT * FROM records_workflow_state) lj_status USING (recordID)
 							   LEFT JOIN (SELECT stepID, stepTitle FROM workflow_steps) lj_steps ON (lj_status.stepID = lj_steps.stepID) ';
 
                         break;


### PR DESCRIPTION
This includes two new endpoints, form/queryIndicator and form/queryWorkflowState. These are lightweight versions of form/query, which include the same query syntax but with reduced features. Combined with a new index, it is significantly faster when searching for data associated with a particular indicator or workflow state ID.


*Querying a set containing 2.7M rows, no query cache, searching for data+indicator:
- Before: ~30 seconds
- After: 0.006 seconds 
