### PR TITLE
Attempt to improve handling of usernames

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -234,10 +234,14 @@ var LeafFormQuery = function() {
     		delete query.getData;
     	}
     	
+        let el = document.createElement('div');
+        el.innerHTML = JSON.stringify(query);
+        let queryUrl = el.innerText;
+
     	if(useJSONP == false) {
         	return $.ajax({
         		type: 'GET',
-        		url: rootURL + 'api/?a=form/query&q=' + JSON.stringify(query) + extraParams,
+        		url: rootURL + 'api/?a=form/query&q=' + queryUrl + extraParams,
         		dataType: 'json',
         		success: successCallback,
         		cache: false
@@ -246,7 +250,7 @@ var LeafFormQuery = function() {
     	else {
         	return $.ajax({
         		type: 'GET',
-        		url: rootURL + 'api/?a=form/query&q=' + JSON.stringify(query) + '&format=jsonp' + extraParams,
+        		url: rootURL + 'api/?a=form/query&q=' + queryUrl + '&format=jsonp' + extraParams,
         		dataType: 'jsonp',
         		success: successCallback,
         		cache: false

--- a/LEAF_Request_Portal/templates/view_search.tpl
+++ b/LEAF_Request_Portal/templates/view_search.tpl
@@ -53,7 +53,7 @@ $(function() {
              var year = now.getFullYear() != date.getFullYear() ? ' ' + date.getFullYear() : '';
              var formattedDate = months[date.getMonth()] + ' ' + parseFloat(date.getDate()) + year;
              $('#'+data.cellContainerID).html(formattedDate);
-             if(blob[data.recordID].userID == '<!--{$userID}-->') {
+             if(blob[data.recordID].userID == "<!--{$userID|unescape|escape:'quotes'}-->") {
                  $('#'+data.cellContainerID).css('background-color', '#feffd1');
              }
          }},
@@ -84,7 +84,7 @@ $(function() {
          }},
          {name: 'Service', indicatorID: 'service', editable: false, callback: function(data, blob) {
              $('#'+data.cellContainerID).html(blob[data.recordID].service);
-             if(blob[data.recordID].userID == '<!--{$userID}-->') {
+             if(blob[data.recordID].userID == '<!--{$userID|unescape|escape:'quotes'}-->') {
                  $('#'+data.cellContainerID).css('background-color', '#feffd1');
              }
          }},
@@ -110,7 +110,7 @@ $(function() {
              }
 
              $('#'+data.cellContainerID).html(status);
-             if(blob[data.recordID].userID == '<!--{$userID}-->') {
+             if(blob[data.recordID].userID == '<!--{$userID|unescape|escape:'quotes'}-->') {
                  $('#'+data.cellContainerID).css('background-color', '#feffd1');
              }
          }}
@@ -120,7 +120,7 @@ $(function() {
             for(var i in data) {
                 <!--{if !$is_admin}-->
                 if(data[i].submitted == '0'
-                    && data[i].userID == '<!--{$userID}-->') {
+                    && data[i].userID == '<!--{$userID|unescape|escape:'quotes'}-->') {
                     data2.push(data[i]);
                 }
                 else if(data[i].submitted != '0') {


### PR DESCRIPTION
Usernames with apostrophes (') cause issues when the ' is turned into an html entity. When using formQuery.js, It prevents search on the userID field because the & symbol would truncate the rest of the query in the URL.