### PR TITLE
leaf-2513 remove triangle chars before export

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -693,6 +693,10 @@ var LeafFormGrid = function(containerID, options) {
             }
             var output = [];
             var headers = [];
+            //removes triangle symbols so that ascii chars are not present in exported headers.
+            $('#' + prefixID + 'thead>tr>th>span').each(function(idx, val) {
+                $(val).html('');
+            });
             $('#' + prefixID + 'thead>tr>th').each(function(idx, val) {
                 headers.push($(val).text().trim());
             });


### PR DESCRIPTION
Removes the html in the header spans that contain the triangle icons when the export button is clicked, so that ascii symbols do not appear in the headers after export.