### PR TITLE
Rewrite method to compute user upload directory size using only PHP.

### DIFF
--- a/LEAF_Request_Portal/sources/Telemetry.php
+++ b/LEAF_Request_Portal/sources/Telemetry.php
@@ -8,8 +8,6 @@
     Date Created: March 3, 2016
 
 */
-// For testing purposes
-error_reporting(E_ALL);
 
 $currDir = __DIR__;
 

--- a/LEAF_Request_Portal/sources/Telemetry.php
+++ b/LEAF_Request_Portal/sources/Telemetry.php
@@ -146,7 +146,7 @@ class Telemetry
      * Purpose: Get total size of all uploads in user upload directory
      * @return string
      */
-    public function getRequestUploadStorage():String
+    public function getRequestUploadStorage():string
     {
         $size = 0;
         foreach(new DirectoryIterator(Config::$uploadDir) as $file){

--- a/LEAF_Request_Portal/sources/Telemetry.php
+++ b/LEAF_Request_Portal/sources/Telemetry.php
@@ -8,6 +8,9 @@
     Date Created: March 3, 2016
 
 */
+// For testing purposes
+error_reporting(E_ALL);
+
 $currDir = __DIR__;
 
 include_once $currDir . '/../globals.php';
@@ -142,23 +145,15 @@ class Telemetry
     }
 
     /**
-     * Purpose: Get total size of all uploads in portal folder
-     * @param $visn
-     * @param $facility
-     * @param $name
+     * Purpose: Get total size of all uploads in user upload directory
      * @return string
      */
-    public function getRequestUploadStorage() {
-
-        $command = 'du -sb ' . Config::$uploadDir;
-        $output = shell_exec($command);
-        if ($output) {
-            $sizeOutput = explode("\t", $output);
-            return $sizeOutput[0];
-
-        } else {
-            return '';
+    public function getRequestUploadStorage():String
+    {
+        $size = 0;
+        foreach(new DirectoryIterator(Config::$uploadDir) as $file){
+            $size += $file->getSize();
         }
+        return (String)$size;
     }
-
 }


### PR DESCRIPTION
Rewrite a method to accurately compute user uploads directory size.

A permissions modification is required to fully enable this feature. The following command must be run:

`chmod u+r vaccination_data_reporting/` to allow the script to read files in that directory.