### PR TITLE
Simplify query debugging process

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3014,7 +3014,14 @@ class Form
             $vars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
             header('X-LEAF-Query: '. str_replace(array_keys($vars), $vars, $debugQuery));
             
-            return XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
+            if($this->login->checkGroup(1)) {
+                return $res = $this->db->prepared_query('EXPLAIN SELECT * FROM records
+                                                        ' . $joins . '
+                                                        WHERE ' . $conditions . $sort . $limit, $vars);
+            }
+            else {
+                return XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
+            }
         }
         $res = $this->db->prepared_query('SELECT * FROM records
     										' . $joins . '

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3009,6 +3009,13 @@ class Form
             $joins .= "LEFT JOIN (SELECT userName, lastName, firstName FROM {$this->oc_dbName}.employee) lj_OCinitiatorNames ON records.userID = lj_OCinitiatorNames.userName ";
         }
 
+        if(isset($_GET['debugQuery'])) {
+            $debugQuery = str_replace(["\r", "\n"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
+            $vars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
+            header('X-LEAF-Query: '. str_replace(array_keys($vars), $vars, $debugQuery));
+            
+            return XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
+        }
         $res = $this->db->prepared_query('SELECT * FROM records
     										' . $joins . '
                                             WHERE ' . $conditions . $sort . $limit, $vars);

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3012,7 +3012,17 @@ class Form
         if(isset($_GET['debugQuery'])) {
             if($this->login->checkGroup(1)) {
                 $debugQuery = str_replace(["\r", "\n"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
-                $debugVars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
+                $debugVars = [];
+                foreach($vars as $key => $value) {
+                    if(strpos($key, ':data') !== false
+                        || !is_numeric($value)) {
+                        $debugVars[$key] = '"'.$value.'"';
+                    }
+                    else {
+                        $debugVars[$key] = $value;
+                    }
+                }
+
                 header('X-LEAF-Query: '. str_replace(array_keys($debugVars), $debugVars, $debugQuery));
 
                 return $res = $this->db->prepared_query('EXPLAIN SELECT * FROM records

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3010,11 +3010,11 @@ class Form
         }
 
         if(isset($_GET['debugQuery'])) {
-            $debugQuery = str_replace(["\r", "\n"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
-            $debugVars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
-            header('X-LEAF-Query: '. str_replace(array_keys($debugVars), $debugVars, $debugQuery));
-            
             if($this->login->checkGroup(1)) {
+                $debugQuery = str_replace(["\r", "\n"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
+                $debugVars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
+                header('X-LEAF-Query: '. str_replace(array_keys($debugVars), $debugVars, $debugQuery));
+
                 return $res = $this->db->prepared_query('EXPLAIN SELECT * FROM records
                                                         ' . $joins . '
                                                         WHERE ' . $conditions . $sort . $limit, $vars);

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -3011,8 +3011,8 @@ class Form
 
         if(isset($_GET['debugQuery'])) {
             $debugQuery = str_replace(["\r", "\n"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
-            $vars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
-            header('X-LEAF-Query: '. str_replace(array_keys($vars), $vars, $debugQuery));
+            $debugVars = array_map(fn($val):string => is_numeric($val) ? $val : '"'.$val.'"', $vars);
+            header('X-LEAF-Query: '. str_replace(array_keys($debugVars), $debugVars, $debugQuery));
             
             if($this->login->checkGroup(1)) {
                 return $res = $this->db->prepared_query('EXPLAIN SELECT * FROM records


### PR DESCRIPTION
This introduces a parameter &debugQuery, which has the same effect as adding &debug to any form/query call, except it also shows information about the actual SQL query.

This simplifies debugging of form/query by returning EXPLAIN output. The EXPLAIN output is restricted to admins as it can contain information about of the size of the database. Non-admins will only be able to see the query and standard &debug output.