### PR TITLE
LEAF-2626 edge case inbox error fix

### DIFF
--- a/LEAF_Request_Portal/Inbox.php
+++ b/LEAF_Request_Portal/Inbox.php
@@ -111,6 +111,7 @@ class Inbox
                 $resPersonDesignatedRecords[$indicatorID] = $this->db->prepared_query("SELECT * FROM data
                                                                     LEFT JOIN indicators USING (indicatorID)
                                                                     WHERE recordID IN ({$recordIDs})
+                                                                        AND data.data REGEXP '^[0-9]+$' = 1
                                                                         AND indicatorID=:indicatorID
                                                                         AND series=1", $vars);
             }

--- a/LEAF_Request_Portal/Inbox.php
+++ b/LEAF_Request_Portal/Inbox.php
@@ -111,9 +111,11 @@ class Inbox
                 $resPersonDesignatedRecords[$indicatorID] = $this->db->prepared_query("SELECT * FROM data
                                                                     LEFT JOIN indicators USING (indicatorID)
                                                                     WHERE recordID IN ({$recordIDs})
-                                                                        AND data.data REGEXP '^[0-9]+$' = 1
+                                                                        AND data.data REGEXP '^[0-9]+$'
                                                                         AND indicatorID=:indicatorID
                                                                         AND series=1", $vars);
+                //var_dump($resPersonDesignatedRecords);
+                //die();
             }
             foreach ($groupDesignatedRecords as $indicatorID => $recordIDList)
             {
@@ -259,10 +261,9 @@ class Inbox
                                 require_once 'VAMC_Directory.php';
                                 $this->dir = new VAMC_Directory;
                             }
-
                             $user = $this->dir->lookupEmpUID($empUID);
 
-                            $approverName = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : $field['userID'];
+                            $approverName = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : "Unknown User";
                             $out[$res[$i]['dependencyID']]['approverName'] = $approverName;
                         }
                     }
@@ -291,7 +292,7 @@ class Inbox
     
                                 $user = $this->dir->lookupEmpUID($empUID);
     
-                                $approverName = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : "unknown user";
+                                $approverName = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : "Unknown User";
                                 
                                 $out[$res[$i]['dependencyID']]['approverName'] = 'Backup for '.$approverName;
                             }

--- a/LEAF_Request_Portal/Inbox.php
+++ b/LEAF_Request_Portal/Inbox.php
@@ -114,8 +114,6 @@ class Inbox
                                                                         AND data.data REGEXP '^[0-9]+$'
                                                                         AND indicatorID=:indicatorID
                                                                         AND series=1", $vars);
-                //var_dump($resPersonDesignatedRecords);
-                //die();
             }
             foreach ($groupDesignatedRecords as $indicatorID => $recordIDList)
             {


### PR DESCRIPTION
Adds a regexp to 'person designated' cases in Inbox.php so that non-numeric data will not be returned. 
Covers an edge case scenario where an indicator with prior format and data is updated to an orgchart format, and methods in the front end template cannot correctly handle the value.  In this case, user would see that there was a request, but not be able to expand/view it because the resulting error would break that functionality.  

These requests will still go to the inbox after this update, but they will have a blank table header.