### PR TITLE
LEAF-2698 update logic to handle usernames with spaces

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -698,7 +698,7 @@ class Employee extends Data
 
                 break;
             // Format: First Last
-            case ($idx = strpos($input, ' ')) > 0:
+            case ($idx = strpos($input, ' ')) > 0 && strpos(strtolower($input), 'username:') === false:
                 if ($this->debug)
                 {
                     $this->log[] = 'Format Detected: First Last';
@@ -732,7 +732,7 @@ class Employee extends Data
             // Format: Loginname
             case strpos(strtolower($input), 'vha') !== false:
             case strpos(strtolower($input), 'vaco') !== false:
-            case strpos(strtolower($input), 'userName:') !== false:
+            case strpos(strtolower($input), 'username:') !== false:
                    if ($this->debug)
                    {
                        $this->log[] = 'Format Detected: Loginname';

--- a/LEAF_Nexus/sources/NationalEmployee.php
+++ b/LEAF_Nexus/sources/NationalEmployee.php
@@ -347,7 +347,7 @@ class NationalEmployee extends NationalData
 
                 break;
             // Format: First Last
-            case ($idx = strpos($input, ' ')) > 0:
+            case ($idx = strpos($input, ' ')) > 0 && strpos(strtolower($input), 'username:') === false:
                 if ($this->debug)
                 {
                     $this->log[] = 'Format Detected: First Last';


### PR DESCRIPTION
Fixes a condition that causes an orgchart employee search to fail if the username contains a space (rare circumstance).