### PR TITLE
Group Backup Sync Fix

### DIFF
--- a/LEAF_Request_Portal/scripts/updateServicesFromOrgChart.php
+++ b/LEAF_Request_Portal/scripts/updateServicesFromOrgChart.php
@@ -49,7 +49,7 @@ $db->beginTransaction();
 
 echo 'Clearing out existing users/groups.<br />';
 
-$db->prepared_query('DELETE FROM users WHERE groupID > 1 AND locallyManaged != 1 AND active != 0', array());
+$db->prepared_query('DELETE FROM users WHERE groupID > 1 AND locallyManaged != 1', array());
 $db->prepared_query('DELETE FROM `groups` WHERE groupID > 1', array());
 
 // import quadrads


### PR DESCRIPTION
Changed the behavior of the 'Sync Services' button in the admin panel. It now syncs members of groups that are not marked as 'active'. Previously, it would ignore 'inactive' members of the group. The problem in ticket LEAF-2668 can now be resolved with the 'Sync Services' button.