### PR TITLE
Clarify API

### DIFF
--- a/LEAF_Request_Portal/Inbox.php
+++ b/LEAF_Request_Portal/Inbox.php
@@ -141,7 +141,9 @@ class Inbox
                         $res[$i]['categoryNames'] = trim($res[$i]['categoryNames'], ' | ');
                     }
 
-                    // Initialize to full access to everything by default,
+                    // Initialize to no access to everything by default,
+                    $res[$i]['hasAccess'] = false;
+
                     // Unless function is passed variable to tell it not to do so
                     if (!$nonAdmin) {
                         $res[$i]['hasAccess'] = $this->login->checkGroup(1);

--- a/LEAF_Request_Portal/Inbox.php
+++ b/LEAF_Request_Portal/Inbox.php
@@ -35,7 +35,7 @@ class Inbox
      * @param int Optional dependencyID to filter inbox based on the dependencyID
      * @return array database result
      */
-    public function getInbox($dependencyID = 0, $nonAdmin = false)
+    public function getInbox($dependencyID = 0)
     {
         $vars = array();
         $tmpQuery = '';
@@ -141,13 +141,9 @@ class Inbox
                         $res[$i]['categoryNames'] = trim($res[$i]['categoryNames'], ' | ');
                     }
 
-                    // Initialize to no access to everything by default,
-                    $res[$i]['hasAccess'] = false;
+                    // Initialize to no access to everything by default, unless the user is an admin
+                    $res[$i]['hasAccess'] = $this->login->checkGroup(1);
 
-                    // Unless function is passed variable to tell it not to do so
-                    if (!$nonAdmin) {
-                        $res[$i]['hasAccess'] = $this->login->checkGroup(1);
-                    }
                     // check permissions
                     $res2 = null;
                     if (isset($this->cache["dependency_privs_{$res[$i]['dependencyID']}"]))

--- a/LEAF_Request_Portal/api/controllers/InboxController.php
+++ b/LEAF_Request_Portal/api/controllers/InboxController.php
@@ -35,8 +35,11 @@ class InboxController extends RESTfulResponse
             return $inbox->getInbox($args[0]);
         });
 
+        // TODO: This endpoint should be removed. Implementations of this in prod will need to be replaced
+        // with inbox/dependency/[text]?masquerade=nonAdmin before this can be deleted.
         $this->index['GET']->register('inbox/dependency/[text]/nonadmin', function ($args) use ($inbox) {
-            return $inbox->getInbox($args[0], true);
+            $_GET['masquerade'] = 'nonAdmin';
+            return $inbox->getInbox($args[0]);
         });
 
         return $this->index['GET']->runControl($act['key'], $act['args']);

--- a/LEAF_Request_Portal/templates/reports/LEAF_inbox_combined.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_inbox_combined.tpl
@@ -205,7 +205,7 @@
         let siteURL = site + './api/?a=inbox/dependency/_';
 
         if (nonadmin) {
-            siteURL += '/nonadmin';
+            siteURL += '&masquerade=nonAdmin';
         }
         $.ajax({
             type: 'GET',


### PR DESCRIPTION
This deprecates the /nonadmin endpoint. Using the masquerade modifier clarifies the intent of the request. This is left as a modifer since it communicates the the Login system: "I'm an admin and want to masquerade as a non-admin".

The /nonadmin endpoint should be removed in the future, after implementations to it are updated in prod. Implementations of need to be replaced with inbox/dependency/[text]?masquerade=nonAdmin