### PR TITLE
LEAF-2783: menu_links, menu_help template customization

### DIFF
--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -51,6 +51,8 @@ function customTemplate($tpl)
 }
 
 $t_login->assign('name', XSSHelpers::xscrub($login->getName()));
+$t_menu->assign('menu_links', customTemplate('menu_links.tpl'));
+$t_menu->assign('menu_help', customTemplate('menu_help.tpl'));
 $t_menu->assign('is_admin', $login->checkGroup(1));
 
 $main->assign('useUI', false);

--- a/LEAF_Request_Portal/report.php
+++ b/LEAF_Request_Portal/report.php
@@ -69,6 +69,8 @@ function customTemplate($tpl)
 
 $t_login->assign('name', $login->getName());
 $t_menu->assign('is_admin', $login->checkGroup(1));
+$t_menu->assign('menu_links', customTemplate('menu_links.tpl'));
+$t_menu->assign('menu_help', customTemplate('menu_help.tpl'));
 
 $main->assign('useUI', false);
 

--- a/LEAF_Request_Portal/templates/menu.tpl
+++ b/LEAF_Request_Portal/templates/menu.tpl
@@ -4,13 +4,13 @@
 <div id="headerMenu_container" style="display: inline-block">
     <a id="button_showLinks" tabindex="0" class="buttonNorm" alt="Links Dropdown" title="Links" aria-haspopup="true" aria-expanded="false" role="button">Links</a>
     <div id="headerMenu_links">
-    {include file="menu_links.tpl"}
+    {include file={$menu_links}}
     </div>
 </div>
 <div id="headerMenuHelp_container" style="display: inline-block">
     <a id="button_showHelp" tabindex="0" class="buttonNorm" alt="Help Popup" title="Help" aria-haspopup="true" aria-expanded="false" role="button"><img style="vertical-align: sub;" src="../libs/dynicons/?img=help-browser.svg&amp;w=16">&nbsp;Help</a>
     <div id="headerMenu_help" tabindex="0">
-    {include file="menu_help.tpl"}
+    {include file={$menu_help}}
     </div>
 </div>
 {if $is_admin == true}
@@ -20,7 +20,6 @@
 {/if}
 
 <script>
-
     menu508($('#button_showLinks'), $('#headerMenu_links'), $('#headerMenu_links').find('a'));
     menu508($('#button_showHelp'), $('#headerMenu_help'), $('#headerMenu_help'));
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_sitemaps_template.tpl
@@ -279,7 +279,7 @@
     <div class="main-content-noRight">
 
         <h1>
-            <a href="/LEAF_Request_Portal/admin" class="leaf-crumb-link">Admin</a><i class="fas fa-caret-right leaf-crumb-caret"></i> Sitemap Editor
+            <a href="./admin" class="leaf-crumb-link">Admin</a><i class="fas fa-caret-right leaf-crumb-caret"></i> Sitemap Editor
             <span id="sitemap-alert" class="leaf-sitemap-alert"><i class="fas fa-check"></i> Sitemap updated</span>
         </h1>
         <div id="sortable" class="leaf-displayFlexRow">


### PR DESCRIPTION
Updates to allow the non-admin menu to use the customized menu_links and menu_help templates.
Also includes a fix to the admin link in the sitemap section. 