### PR TITLE
updated logic for grid splitter

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_table_input_report.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_table_input_report.tpl
@@ -75,7 +75,7 @@ function populateIndicators(categoryID)
                 const format = data[i].format;
                 if (format.match(/^grid/) && data[i].isDisabled === 0) {
                     anyTables = true;
-                    $('select#dataField').append($('<option />').val(data[i].indicatorID).text(data[i].name));
+                    $('select#dataField').append($('<option />').val(data[i].indicatorID).text(data[i].name.replace( /(<([^>]+)>)/ig, '').replace('&nbsp;', ' ')));
                     indicatorFormats[data[i].indicatorID] = JSON.parse(format.substring(5));
                 }
             }


### PR DESCRIPTION
had to repeal the start of work on the issues in the report builder since carrie had fixed some of the logic there when she removed the icheck on another branch