### PR TITLE
LEAF-2794: Fix PIV card requests

### DIFF
--- a/LEAF_Nexus/auth_domain/index.php
+++ b/LEAF_Nexus/auth_domain/index.php
@@ -105,15 +105,15 @@ if (isset($_SERVER['REMOTE_USER']))
         }
         else
         {
-            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-            echo 'Unable to log in: User not found in global database.  Redirecting back to PIV login screen.';
+            echo 'Unable to log in: User not found in global database.  Redirecting back to login screen.';
         }
     }
 }
 else
 {
-    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-    echo 'Unable to log in: Domain logon issue.  Redirecting back to PIV login screen.';
+    echo 'Unable to log in: Domain logon issue.  Redirecting back to login screen.';
 }

--- a/LEAF_Nexus/auth_token/index.php
+++ b/LEAF_Nexus/auth_token/index.php
@@ -104,15 +104,15 @@ if ($_SERVER['SSL_CLIENT_VERIFY'] == 'SUCCESS')
         }
         else
         {
-            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-            echo 'Unable to log in: ' . $_SERVER['SSL_CLIENT_S_DN_UID'] . ' not found in database.  Redirecting back to PIV login screen.';
+            echo 'Unable to log in: ' . $_SERVER['SSL_CLIENT_S_DN_UID'] . ' not found in database.  Redirecting back to login screen.';
         }
     }
 }
 else
 {
-    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-    echo 'Unable to log in: Client Verification issue.  Redirecting back to PIV login screen.';
+    echo 'Unable to log in: Client Verification issue.  Redirecting back to login screen.';
 }

--- a/LEAF_Request_Portal/auth_domain/index.php
+++ b/LEAF_Request_Portal/auth_domain/index.php
@@ -106,15 +106,15 @@ if (isset($_SERVER['REMOTE_USER']))
         }
         else
         {
-            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-            echo 'Unable to log in: User not found in global database.  Redirecting back to PIV login screen.';
+            echo 'Unable to log in: User not found in global database.  Redirecting back to login screen.';
         }
     }
 }
 else
 {
-    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-    echo 'Unable to log in: Domain logon issue.  Redirecting back to PIV login screen.';
+    echo 'Unable to log in: Domain logon issue.  Redirecting back to login screen.';
 }

--- a/LEAF_Request_Portal/auth_token/index.php
+++ b/LEAF_Request_Portal/auth_token/index.php
@@ -105,15 +105,15 @@ if ($_SERVER['SSL_CLIENT_VERIFY'] == 'SUCCESS')
         }
         else
         {
-            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+            header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-            echo 'Unable to log in: SSL_CLIENT_S_DN_UID not found in database.  Redirecting back to PIV login screen.';
+            echo 'Unable to log in: SSL_CLIENT_S_DN_UID not found in database.  Redirecting back to login screen.';
         }
     }
 }
 else
 {
-    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/login/index.php');
+    header('Refresh: 4;URL=' . $login->parseURL(dirname($_SERVER['PHP_SELF'])) . '/..' . '/index.php');
 
-    echo 'Unable to log in: Client Verification issue.  Redirecting back to PIV login screen.';
+    echo 'Unable to log in: Client Verification issue.  Redirecting back to login screen.';
 }


### PR DESCRIPTION
Update page forward URLs from login errors not due to unsupported browsers to point towards `\index.php`, not the PIV login page.