### PR TITLE
LEAF-2806 - Set upload folder permissions properly.

### DIFF
--- a/LEAF_Nexus/sources/Data.php
+++ b/LEAF_Nexus/sources/Data.php
@@ -403,7 +403,8 @@ abstract class Data
                         // $sanitizedFileName = XSSHelpers::scrubFilename($sanitizedFileName);
                         if (!is_dir(Config::$uploadDir))
                         {
-                            mkdir(Config::$uploadDir, 755, true);
+                            mkdir(Config::$uploadDir);
+                            chmod(Config::$uploadDir, 0755);
                         }
                         move_uploaded_file($_FILES[$indicator]['tmp_name'], Config::$uploadDir . $sanitizedFileName);
                     }

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1079,7 +1079,8 @@ class Form
                         $uploadDir = isset(Config::$uploadDir) ? Config::$uploadDir : UPLOAD_DIR;
                         if (!is_dir($uploadDir))
                         {
-                            mkdir($uploadDir, 755, true);
+                            mkdir($uploadDir);
+                            chmod($uploadDir, 0755);
                         }
 
                         $sanitizedFileName = $this->getFileHash($recordID, $indicator, $series, $this->sanitizeInput($_FILES[$indicator]['name']));


### PR DESCRIPTION
Update the way permissions are set on folders due to umask configuration. See [this thread](https://stackoverflow.com/questions/6229353/permissions-with-mkdir-wont-work) for more information. Allows PORTAL_URL/api/telemetry/upload/storage to work.