### PR TITLE
LEAF 2821 mod_form format change detection

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -1517,16 +1517,18 @@ function getForm(indicatorID, series) {
         }
 
         let calls = [];
-        let nameChanged = (indicatorEditing.name || "") != $('#name').val();
-        let formatChanged = (indicatorEditing.format || "") != $('#format').val();
-        let descriptionChanged = (indicatorEditing.description || "") != $('#description').val();
-        let defaultChanged = (indicatorEditing.default || "") != $('#default').val();
-        let requiredChanged = (indicatorEditing.required || "") != requiredIndicator;
-        let sensitiveChanged = (indicatorEditing.is_sensitive || "") != sensitiveIndicator;
-        let parentIDChanged = (indicatorEditing.parentID || "") != $("#parentID").val();
-        let sortChanged = (indicatorEditing.sort || "") != $("#sort").val();
-        let htmlChanged = (indicatorEditing.html || "") != codeEditorHtml.getValue();
-        let htmlPrintChanged =  (indicatorEditing.htmlPrint || "") != codeEditorHtmlPrint.getValue();
+        let nameChanged = (indicatorEditing.name || "") !== $('#name').val();
+        let options = '';
+        if (indicatorEditing?.options) indicatorEditing.options.forEach(o => options += `\n${o}`);
+        let formatChanged = (indicatorEditing.format + options || "") !== $('#format').val();
+        let descriptionChanged = (indicatorEditing.description || "") !== $('#description').val();
+        let defaultChanged = (indicatorEditing.default || "") !== $('#default').val();
+        let requiredChanged = (indicatorEditing.required || "") !== requiredIndicator.toString();
+        let sensitiveChanged = (indicatorEditing.is_sensitive || "") !== sensitiveIndicator.toString();
+        let parentIDChanged = (indicatorEditing.parentID || "") !== $("#parentID").val();
+        let sortChanged = (indicatorEditing.sort || "") !== $("#sort").val();
+        let htmlChanged = (indicatorEditing.html || "") !== codeEditorHtml.getValue();
+        let htmlPrintChanged =  (indicatorEditing.htmlPrint || "") !== codeEditorHtmlPrint.getValue();
         
         if(nameChanged){
             calls.push(
@@ -1544,8 +1546,10 @@ function getForm(indicatorID, series) {
                 $.ajax({
                     type: 'POST',
                     url: '../api/?a=formEditor/' + indicatorID + '/format',
-                    data: {format: $('#format').val(),
-                        CSRFToken: '<!--{$CSRFToken}-->'}
+                    data: {
+                        format: $('#format').val(),
+                        CSRFToken: '<!--{$CSRFToken}-->'
+                    }
                 })
             );
         }

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -1519,8 +1519,10 @@ function getForm(indicatorID, series) {
         let calls = [];
         let nameChanged = (indicatorEditing.name || "") !== $('#name').val();
         let options = '';
-        if (indicatorEditing?.options) indicatorEditing.options.forEach(o => options += `\n${o}`);
-        let formatChanged = (indicatorEditing.format + options || "") !== $('#format').val();
+        if (indicatorEditing?.options) { 
+            indicatorEditing.options.forEach(o => options += `\n${o}`);
+        }
+        let formatChanged = (indicatorEditing.format || "") + options !== $('#format').val();
         let descriptionChanged = (indicatorEditing.description || "") !== $('#description').val();
         let defaultChanged = (indicatorEditing.default || "") !== $('#default').val();
         let requiredChanged = (indicatorEditing.required || "") !== requiredIndicator.toString();


### PR DESCRIPTION
Form Editor: 
Updates logic used to compare an edited indicator's selected format to account for indicators that have options (eg radio, dropdown, multiselect, grid, checkboxes).  Also updates strictness of comparison operators for other potentially edited fields. 