### PR TITLE
LEAF 2879 handle empty unsaved 'checkboxes' values

### DIFF
--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -485,8 +485,8 @@ var printer = function() {
                                     }
                                     doc.rect(horizontalShift, verticalShift + 6, 5, 5);
                                     //make selected values consistently arrays for checkboxes, multisel, radio, checkbox, dropdown
-                                    let selectedVals = indicator.format === 'checkboxes' ? indicator.value.slice() 
-                                        : indicator.format === 'multiselect' ? indicator.value.split(/,(?!\s)/) : [indicator.value];
+                                    let selectedVals = indicator.format === 'checkboxes' ? indicator.value.slice() || []
+                                        : indicator.format === 'multiselect' ? indicator.value.split(/,(?!\s)/) || [] : [indicator.value];
                                     selectedVals = selectedVals.filter(v => v !== '');
                                     if (!blank && selectedVals.indexOf(indicator.options[i]) > -1) {
                                         doc.text('x', horizontalShift + 1.5, verticalShift + 9.5);
@@ -726,8 +726,8 @@ var printer = function() {
                                     doc.setTextColor(0);
                                     doc.setFont("helvetica");
                                     //make selected values consistently arrays for checkboxes, multisel, radio, checkbox, dropdown
-                                    let selectedVals = indicator.format === 'checkboxes' ? indicator.value.slice() 
-                                        : indicator.format === 'multiselect' ? indicator.value.split(/,(?!\s)/) : [indicator.value];
+                                    let selectedVals = indicator.format === 'checkboxes' ? indicator.value.slice() || []
+                                        : indicator.format === 'multiselect' ? indicator.value.split(/,(?!\s)/) || [] : [indicator.value];
                                     selectedVals = selectedVals.filter(v => v !== '');
                                     if (!blank && selectedVals.indexOf(indicator.options[i]) > -1) {
                                         doc.text('x', horizontalShift - 3.5, verticalShift + 9.5);


### PR DESCRIPTION
If a form with 'checkboxes' format items is immediately viewed as a single page (without entering data / clicking next question), validation to enter the 'no' values does not run.  The respective 'checkboxes' input element's value is an empty string instead of an array, which in turn causes the code associated with the 'print to PDF' feature to error.

Adds an or operator to ensure that the returned value for checkboxes format questions is an array if there are unentered/unsaved data.