### PR TITLE
LEAF 2896 move multiselect format queries to default case

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -700,7 +700,6 @@ var LeafFormSearch = function(containerID) {
 											chosenOptions();
 											createGroupSelectorWidget(widgetID);
 											break;
-										case 'multiselect':
 										case 'dropdown':
 										case 'radio':
 											$('#' + prefixID + 'widgetCondition_' + widgetID).html('<select id="'+prefixID+'widgetCod_'+widgetID+'" class="chosen" aria-label="condition" style="width: 120px">\


### PR DESCRIPTION
Quick fix to give multiselect format questions CONTAINS/DOES NOT CONTAIN (LIKE) operators for searches