### PR TITLE
LEAF-2958: Include full field name in PDF export

### DIFF
--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -120,12 +120,12 @@ var printer = function() {
                 var title = typeof (indicator.description) !== "undefined"
                 && indicator.description !== null
                 && indicator.description.length > 0
-                    ? number + ': ' + decodeHTMLEntities(indicator.description) + ' ' + required
+                    ? number + ': ' + decodeHTMLEntities(indicator.description) + ' - ' + decodeHTMLEntities(indicator.name) + ' ' + required
                     : number + ': ' + decodeHTMLEntities(indicator.name) + ' ' + required;
                 var titleContinued = typeof (indicator.description) !== "undefined"
                 && indicator.description !== null
                 && indicator.description.length > 0
-                    ? decodeHTMLEntities(indicator.description) + ' continued ' + required
+                    ? decodeHTMLEntities(indicator.description) + ' - ' + decodeHTMLEntities(indicator.name) + ' continued ' + required
                     : decodeHTMLEntities(indicator.name) + ' continued ' + required;
                 var storedSubCount = subCount;
                 var sizeOfBox = 0;


### PR DESCRIPTION
The original behavior would exclude the full field name if a short label exists. Since the full field name often includes instructions, it should be included in the PDF.