### PR TITLE
LEAF-2919 improve initial form selection display

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -56,7 +56,9 @@ span.leaf_check {
     background-color: transparent;
     border: 1px solid rgb(151, 150, 149);
 }
-span.leaf_check:hover, span.leaf_check:focus, span.leaf_check:active {
+span.leaf_check:hover, span.leaf_check:focus, span.leaf_check:active,
+input[class*="ischecked"][class*="leaf_check"]:focus ~ span.leaf_check,
+input[class*="icheck"][class*="leaf_check"]:focus ~ span.leaf_check {
     border: 2px solid #47e;
 }
 input[type="radio"][class*="icheck"][class*="leaf_check"] ~ span.leaf_check {
@@ -1117,6 +1119,7 @@ button.buttonNorm {
     width: -moz-fit-content;
     width: fit-content;
     max-width: 600px;
+    margin-bottom: 0.2em;
 }
 
 .ui-datepicker {

--- a/LEAF_Request_Portal/templates/initial_form.tpl
+++ b/LEAF_Request_Portal/templates/initial_form.tpl
@@ -116,6 +116,7 @@ $(function() {
             &nbsp;(<!--{$category.categoryDescription|sanitize}-->)
             <!--{/if}-->
         </label>
+        <hr />
     <!--{/foreach}-->
     <!--{if count($categories) == 0}-->
         <span style="color: red">Your forms must have an associated workflow before they can be selected here.<br /><br />Open the Form Editor, select your form, and click on "Edit Properties" to set a workflow.</span>


### PR DESCRIPTION
Adds a bottom margin to checkbox/radio containers, and hr elements between each form type listed on initial_form.tpl, to make selections more distinct for options with long titles and/or descriptions. 
Also adds additional css selectors to facilitate tab selection.