### PR TITLE
LEAF 2354 Wrap certain non-date format patterns in quotes

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2189,9 +2189,6 @@ class Form
                                 {
                                     if ($tItem != 'no')
                                     {
-                                        if (preg_match('/^\d+[\/-]\d+([\/-]\d+)?$/', $tItem)) {
-                                            $tItem = "'".$tItem."'";
-                                        }
                                         $item['data'] .= "{$tItem}, ";
                                         $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID'] . '_array'][] = $tItem;
                                     }
@@ -2205,11 +2202,6 @@ class Form
                             $format = json_decode(substr($indicators[$item['indicatorID']]['format'], 5, -1) . ']', true);
                             $item['gridInput'] = array_merge($values, array("format" => $format));
                             $item['data'] = 'id' . $item['indicatorID'] . '_gridInput';
-                        }
-                        //avoid problems with excel auto formatting for non date items 
-                        if (substr($indicators[$item['indicatorID']]['format'], 0, 4) !== 'date'
-                            && preg_match('/^\d+[\/-]\d+([\/-]\d+)?$/', $item['data'])) {
-                                $item['data'] = "'".trim($item['data'])."'";
                         }
                         break;
                 }

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2189,6 +2189,9 @@ class Form
                                 {
                                     if ($tItem != 'no')
                                     {
+                                        if (preg_match('/^\d+[\/-]\d+([\/-]\d+)?$/', $tItem)) {
+                                            $tItem = "'".$tItem."'";
+                                        }
                                         $item['data'] .= "{$tItem}, ";
                                         $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID'] . '_array'][] = $tItem;
                                     }
@@ -2202,6 +2205,11 @@ class Form
                             $format = json_decode(substr($indicators[$item['indicatorID']]['format'], 5, -1) . ']', true);
                             $item['gridInput'] = array_merge($values, array("format" => $format));
                             $item['data'] = 'id' . $item['indicatorID'] . '_gridInput';
+                        }
+                        //avoid problems with excel auto formatting for non date items 
+                        if (substr($indicators[$item['indicatorID']]['format'], 0, 4) !== 'date'
+                            && preg_match('/^\d+[\/-]\d+([\/-]\d+)?$/', $item['data'])) {
+                                $item['data'] = "'".trim($item['data'])."'";
                         }
                         break;
                 }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -121,6 +121,11 @@ var LeafFormGrid = function(containerID, options) {
                         month: "2-digit",
                         day: "2-digit",
                     });
+                } else {
+                    //wrap non dates that would be interpreted as dates by excel in quotes
+                    if(/^\d+[\/-]\d+([\/-]\d+)?$/.test(data)){
+                        data = "'" + data + "'"
+                    }
                 }
                 $('#' + prefixID+recordID+'_'+indicatorID).empty().html(data);
                 $('#' + prefixID+recordID+'_'+indicatorID).fadeOut(250, function() {

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -716,6 +716,10 @@ var LeafFormGrid = function(containerID, options) {
 
                 var trimmedText = val.innerText.trim();
                 line[i] = trimmedText;
+                //wrap text that could be interpretted as dates by excel in quotes
+                const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
+                line[i] = testDateFormat.test(line[i]) ? "'" + line[i] + "'": line[i];
+
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -716,10 +716,6 @@ var LeafFormGrid = function(containerID, options) {
 
                 var trimmedText = val.innerText.trim();
                 line[i] = trimmedText;
-                //wrap text that could be interpretted as dates by excel in quotes
-                const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
-                line[i] = testDateFormat.test(line[i]) ? "'" + line[i] + "'": line[i];
-
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -121,11 +121,6 @@ var LeafFormGrid = function(containerID, options) {
                         month: "2-digit",
                         day: "2-digit",
                     });
-                } else {
-                    //wrap non dates that would be interpreted as dates by excel in quotes
-                    if(/^\d+[\/-]\d+([\/-]\d+)?$/.test(data)){
-                        data = "'" + data + "'"
-                    }
                 }
                 $('#' + prefixID+recordID+'_'+indicatorID).empty().html(data);
                 $('#' + prefixID+recordID+'_'+indicatorID).fadeOut(250, function() {

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -716,6 +716,9 @@ var LeafFormGrid = function(containerID, options) {
 
                 var trimmedText = val.innerText.trim();
                 line[i] = trimmedText;
+                //wrap text that could be interpretted as dates by excel in quotes
+                const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
+                line[i] = testDateFormat.test(line[i]) ? line[i] + '\t' : line[i];
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }
@@ -740,7 +743,8 @@ var LeafFormGrid = function(containerID, options) {
 
             var download = document.createElement('a');
             var now = new Date().getTime();
-            download.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(rows));
+            let encodedURI = encodeURI('data:text/csv;charset=utf-8,' + rows);
+            download.setAttribute('href', encodedURI);
             download.setAttribute('download', 'Exported_' + now + '.csv');
             download.style.display = 'none';
 


### PR DESCRIPTION
Wraps certain patterns of digits and slashes/dashes from Report Builder query results in quotes if they are not explicitly date format.  This prevents excel from interpreting these entries as dates and altering them.