### PR TITLE
LEAF 2963 gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ test_logins.txt
 */admin/templates_c/
 LEAF_Request_Portal/templates/email/custom_override/*
 LEAF_Request_Portal/templates_c/email/custom_override/*
+LEAF_Request_Portal/templates/custom_override/*.tpl
+LEAF_Request_Portal/templates/reports/custom_dev*
+LEAF_Request_Portal/files/custom_dev*
 
 db_config.php
 config.php

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ test_logins.txt
 */admin/templates_c/
 LEAF_Request_Portal/templates/email/custom_override/*
 LEAF_Request_Portal/templates_c/email/custom_override/*
-LEAF_Request_Portal/templates/custom_override/*.tpl
 LEAF_Request_Portal/templates/reports/custom_dev*
 LEAF_Request_Portal/files/custom_dev*
 


### PR DESCRIPTION
Development related update to .gitignore

Excludes custom_override template files.

Also excludes files in the request_portal/templates/reports or request_portal/files directories if they contain 'custom_dev'.