### PR TITLE
LEAF 2971 Report Builder exports: implement format check

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2206,6 +2206,8 @@ class Form
                 }
 
                 $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID']] = isset($indicatorMasks[$item['indicatorID']]) && $indicatorMasks[$item['indicatorID']] == 1 ? '[protected data]' : $item['data'];
+                $indFormat = explode("\n", $indicators[$item['indicatorID']]['format'])[0];
+                $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID'] . '_format'] = $indFormat;
                 if (isset($item['dataOrgchart']))
                 {
                     $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID'] . '_orgchart'] = $item['dataOrgchart'];

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -721,7 +721,7 @@ var LeafFormGrid = function(containerID, options) {
 
                 var trimmedText = val.innerText.trim();
                 line[i] = trimmedText;
-                //add \t to data that could be interpretted as dates by excel
+                //add quotes to data that could be interpretted as dates by excel
                 const dataFormat = val.getAttribute('data-format');
                 const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
                 line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? `'${line[i]}'` : line[i];

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -724,7 +724,7 @@ var LeafFormGrid = function(containerID, options) {
                 //prevent some values from being interpretted as dates by excel
                 const dataFormat = val.getAttribute('data-format');
                 const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
-                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? `=VALUETOTEXT("${line[i]}")` : line[i];
+                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? `="${line[i]}"` : line[i];
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -721,10 +721,10 @@ var LeafFormGrid = function(containerID, options) {
 
                 var trimmedText = val.innerText.trim();
                 line[i] = trimmedText;
-                //add quotes to data that could be interpretted as dates by excel
+                //prevent some values from being interpretted as dates by excel
                 const dataFormat = val.getAttribute('data-format');
                 const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
-                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? `'${line[i]}'` : line[i];
+                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? `=VALUETOTEXT("${line[i]}")` : line[i];
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -724,7 +724,7 @@ var LeafFormGrid = function(containerID, options) {
                 //add \t to data that could be interpretted as dates by excel
                 const dataFormat = val.getAttribute('data-format');
                 const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
-                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? line[i] + '\t' : line[i];
+                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? `'${line[i]}'` : line[i];
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -515,7 +515,12 @@ var LeafFormGrid = function(containerID, options) {
                                     data.data = printTableReportBuilder(currentData[i].s1[data.data], null);
                                 }
                             }
-                            buffer += '<td id="'+prefixID+currentData[i].recordID+'_'+headers[j].indicatorID+'" data-editable="'+ editable +'" data-record-id="'+currentData[i].recordID+'" data-indicator-id="'+headers[j].indicatorID+'">' + data.data + '</td>';
+                            buffer += `<td id="${prefixID+currentData[i].recordID}_${headers[j].indicatorID}" 
+                                           data-editable="${editable}" 
+                                           data-record-id="${currentData[i].recordID}" 
+                                           data-indicator-id="${headers[j].indicatorID}"
+                                           data-format="${currentData[i].s1['id'+headers[j].indicatorID+'_format']}">
+                                            ${data.data}</td>`;
                         }
                     }
                     else if(headers[j].callback != undefined) {
@@ -716,9 +721,10 @@ var LeafFormGrid = function(containerID, options) {
 
                 var trimmedText = val.innerText.trim();
                 line[i] = trimmedText;
-                //wrap text that could be interpretted as dates by excel in quotes
+                //add \t to data that could be interpretted as dates by excel
+                const dataFormat = val.getAttribute('data-format');
                 const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
-                line[i] = testDateFormat.test(line[i]) ? line[i] + '\t' : line[i];
+                line[i] = dataFormat !== 'date' && testDateFormat.test(line[i]) ? line[i] + '\t' : line[i];
                 if(i == 0 && headers[i] == 'UID') {
                     line[i] = '=HYPERLINK("'+ window.location.origin + window.location.pathname + '?a=printview&recordID=' + trimmedText +'", "'+ trimmedText +'")';
                 }


### PR DESCRIPTION
Adds the 'data-format' data property to report builder table cells.
A format check is now used in combination with a date-pattern regex so that date format questions are not affected by an earlier changed intended to prevent Excel from auto-formatting non-date input as dates.