### PR TITLE
Speed up admin/?a=mod_groups page load

### DIFF
--- a/LEAF_Request_Portal/admin/Group.php
+++ b/LEAF_Request_Portal/admin/Group.php
@@ -71,7 +71,7 @@ class Group
         return 'Cannot remove group.';
     }
 
-    // return array of userIDs
+    // getMembers returns a list of members associated with $groupID
     public function getMembers($groupID)
     {
         if (!is_numeric($groupID))
@@ -88,7 +88,7 @@ class Group
             $dir = new VAMC_Directory();
             foreach ($res as $member)
             {
-                $dirRes = $dir->lookupLogin($member['userID'], false, true);
+                $dirRes = $dir->lookupLogin($member['userID'], true, false);
 
                 if (isset($dirRes[0]))
                 {
@@ -96,10 +96,6 @@ class Group
                     if($groupID == 1)
                     {
                       $dirRes[0]['primary_admin'] = $member['primary_admin'];  
-                    }
-                    foreach ($dirRes[0]['groups'] as $group)
-                    {
-                        $dirRes[0]['regionallyManaged'] = $groupID == $group['groupID'];
                     }
                     if($member['locallyManaged'] == 1) {
                         $dirRes[0]['backupID'] = null;


### PR DESCRIPTION
On sites with large numbers of groups and members, it takes too long to open the User Access Groups page.

Part of the reason for this seems to be that api/group/members is returning redundant data: it returns a list of all groups + all members + **all groups for each member**.

Since "all groups for each member" can be derived from all groups + all members, this patch removes the redundancy.