### PR TITLE
Enable post-render customizations

### DIFF
--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -397,7 +397,7 @@ var LeafWorkflow = function(containerID, CSRFToken) {
             masquerade = '&masquerade=nonAdmin';
         }
 
-        $.ajax({
+        return $.ajax({
             type: 'GET',
             url: rootURL + 'api/?a=formWorkflow/'+ recordID +'/currentStep' + masquerade,
             dataType: 'json',


### PR DESCRIPTION
This provides better support for customization of the workflow UI, particularly with visibility of buttons. Adding a return here provides access to the JS Promise interface, enabling reliable transformations.

Example use:
```js
let workflow = new LeafWorkflow('workflowContainer', '_CSRFTOKEN_');
workflow.getWorkflow(1234).then(function() {
    // custom transformations
});
```