### PR TITLE
Return false only on malformed requests

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2030,9 +2030,12 @@ class Form
         return $res;
     }
 
-    // recordID_list: array from view.php
-    // indicatorID_list: ID#'s delimited by ','
-    public function getCustomData($recordID_list, $indicatorID_list)
+    /* getCustomData iterates through an array of $recordID_list and incorporates any associated data
+     * specified by $indicatorID_list (string of ID#'s delimited by ',')
+     * 
+     * @return array on success | false on malformed input
+     */ 
+    public function getCustomData(array $recordID_list, string|null $indicatorID_list)
     {
         if (count($recordID_list) == 0) {
             return $recordID_list;

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2034,9 +2034,9 @@ class Form
     // indicatorID_list: ID#'s delimited by ','
     public function getCustomData($recordID_list, $indicatorID_list)
     {
-	if (!count($recordID_list)) {
-	    return false;
-	}
+        if (count($recordID_list) == 0) {
+            return $recordID_list;
+        }
 	    
         $indicatorID_list = trim($indicatorID_list, ',');
         $tempIndicatorIDs = explode(',', $indicatorID_list);


### PR DESCRIPTION
This resolves an issue where valid queries would return false instead of an empty array.

This function should only return a non-array (false or error message) if the request is malformed.