### PR TITLE
LEAF 3092: fixes for carriage returns and remaining data type issue

### DIFF
--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -138,21 +138,21 @@ var LeafForm = function(containerID) {
 				let arrCompVals = [];
 				arrConditions.map(c => {
 					if (cond.selectedOutcome === c.selectedOutcome &&
-						((cond.selectedOutcome === "Pre-fill" && cond.selectedChildValue === c.selectedChildValue) ||
+						((cond.selectedOutcome === "Pre-fill" && cond.selectedChildValue.trim() === c.selectedChildValue.trim()) ||
 						cond.selectedOutcome !== "Pre-fill"
 						)
-					) arrCompVals.push({[c.parentIndID]:c.selectedParentValue});
+					) arrCompVals.push({[c.parentIndID]:c.selectedParentValue.trim()});
 				});
 
 				switch (cond.selectedOp) {
 					case '==':
 						arrCompVals.forEach(entry => {
 							let id = Object.keys(entry)[0];
-							let val = document.getElementById(id).value;
+							let val = document.getElementById(id).value.trim();
 							if (sanitize(val) === entry[id]) {
 								comparisonResult = true;
 								if (cond.selectedOutcome === "Pre-fill") {
-									prefillValue = cond.selectedChildValue;
+									prefillValue = cond.selectedChildValue.trim();
 								}
 							}
 						});
@@ -160,7 +160,7 @@ var LeafForm = function(containerID) {
 					case '!=':  //TODO: SOME or EVERY?
 						arrCompVals.forEach(entry => {
 							let id = Object.keys(entry)[0];
-							let val = document.getElementById(id).value;
+							let val = document.getElementById(id).value.trim();
 							if (sanitize(val) !== entry[id]) {
 								comparisonResult = true;
 							}
@@ -182,10 +182,6 @@ var LeafForm = function(containerID) {
 					case 'Hide':
 						if (comparisonResult === true) {
 							elJQChildID.val('');
-							if (chosenShouldUpdate) {
-								elJQChildID.chosen().val('');
-								elJQChildID.trigger('chosen:updated');
-							}
 							//if this is a required question, re-point validator
 							$('.blockIndicator_' + childID).hide();
 							if (currentChildInfo[childID].validator !== undefined) {
@@ -200,10 +196,6 @@ var LeafForm = function(containerID) {
 							$('.blockIndicator_' + childID).show();
 						} else {
 							elJQChildID.val('');
-							if (chosenShouldUpdate) {
-								elJQChildID.chosen().val('');
-								elJQChildID.trigger('chosen:updated');
-							}
 							$('.blockIndicator_' + childID).hide();
 							if (currentChildInfo[childID].validator !== undefined) {
 								form.dialog().requirements[childID] = hideShowValidator;
@@ -215,23 +207,21 @@ var LeafForm = function(containerID) {
 							const text = $('<div/>').html(prefillValue).text();
 							elJQChildID.val(text);
 							elJQChildID.attr('disabled', 'disabled');
-							if (chosenShouldUpdate) {
-								elJQChildID.chosen().val(text);
-								elJQChildID.trigger('chosen:updated');
-							}
 						} else {
 							elJQChildID.removeAttr('disabled');
 							elJQChildID.val('');
-							if (chosenShouldUpdate) {
-								elJQChildID.chosen().val('');
-								elJQChildID.trigger('chosen:updated');
-							}
 						}
 						break; 
 					default:
 						console.log(cond.selectedOutcome);
 						break;
-				} 
+				}
+				if (chosenShouldUpdate) {
+					const val = elJQChildID.val();
+					elJQChildID.chosen().val(val);
+					elJQChildID.chosen({ width: '100%' });
+					elJQChildID.trigger('chosen:updated');
+				}
 			});
 		}
 

--- a/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
+++ b/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
@@ -88,7 +88,7 @@ const ConditionsEditor = Vue.createApp({
 
             let formatNameAndOptions = indicator.format.split("\n");  //format field has the format name followed by options, separator is \n
             let valueOptions = formatNameAndOptions.length > 1 ? formatNameAndOptions.slice(1) : [];
-            valueOptions = valueOptions.map(o => o.replaceAll('\r', '').trim());  //these are ending up in the array
+            valueOptions = valueOptions.map(o => o.trim());  //there are sometimes carriage returns in the array
 
             this.selectedParentIndicator = {...indicator};
             this.selectedParentValueOptions = valueOptions.filter(vo => vo !== '');
@@ -261,7 +261,14 @@ const ConditionsEditor = Vue.createApp({
                 
                 if (childIndID !== undefined) {
                     const conditionsJSON = JSON.stringify(this.conditionInputObject);
-                    const currConditions = JSON.parse(this.indicators.find(i => parseInt(i.indicatorID) === parseInt(childIndID)).conditions) || [];
+
+                    let currConditions = JSON.parse(this.indicators.find(i => parseInt(i.indicatorID) === parseInt(childIndID)).conditions) || [];
+                    currConditions.forEach(c => {
+                        c.childIndID = parseInt(c.childIndID);   //fixes an issue where older conditions could not be deleted due to data type change
+                        c.parentIndID = parseFloat(c.parentIndID);
+                    });
+
+                    console.log('confirm del', currConditions, conditionsJSON); //NOTE:
                     let newConditions = currConditions.filter(c => JSON.stringify(c) !== conditionsJSON);
                     if (newConditions.length === 0) newConditions = null;
                     

--- a/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
+++ b/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
@@ -86,8 +86,10 @@ const ConditionsEditor = Vue.createApp({
                 return;
             } else this.parentFound = true;
 
-            const valueOptions = indicator.format.indexOf("\n") === -1 ? [] : indicator.format.slice(indicator.format.indexOf("\n")+1).split("\n");
-           
+            let formatNameAndOptions = indicator.format.split("\n");  //format field has the format name followed by options, separator is \n
+            let valueOptions = formatNameAndOptions.length > 1 ? formatNameAndOptions.slice(1) : [];
+            valueOptions = valueOptions.map(o => o.replaceAll('\r', '').trim());  //these are ending up in the array
+
             this.selectedParentIndicator = {...indicator};
             this.selectedParentValueOptions = valueOptions.filter(vo => vo !== '');
 
@@ -595,7 +597,7 @@ ConditionsEditor.component('editor-main', {
                 <option v-if="conditions.selectedChildValue===''" value="" selected>Select a value</option>    
                 <option v-for="val in selectedChildValueOptions" 
                 :value="val"
-                :selected="textValueDisplay(conditions.selectedChildValue)===val"> 
+                :selected="textValueDisplay(conditions.selectedChildValue)===val">
                 {{ val }} 
                 </option>
             </select>
@@ -614,7 +616,7 @@ ConditionsEditor.component('editor-main', {
                     <option v-for="i in selectableParents" 
                     :title="i.name" 
                     :value="i.indicatorID"
-                    :selected="conditions.parentIndID===i.indicatorID"
+                    :selected="parseInt(conditions.parentIndID)===parseInt(i.indicatorID)"
                     key="i.indicatorID">
                     {{getIndicatorName(i.indicatorID) }} (indicator {{i.indicatorID}})
                     </option>

--- a/docker/mysql/leaf_portal.sql
+++ b/docker/mysql/leaf_portal.sql
@@ -7778,7 +7778,7 @@ CREATE TABLE `settings` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 INSERT INTO `settings` (`setting`, `data`) VALUES
-('dbversion',	'2021062800'),
+('dbversion',	'2022050300'),
 ('heading',	'Academy Demo Site (Test site)'),
 ('leafSecure',	'1568216371'),
 ('national_linkedPrimary',	''),


### PR DESCRIPTION
Adds trim to remove possible carriage returns from options, which had been causing some dropdowns on the saved condition info panel not to populate.

Adds a parseInt to update the childIndID and parentIndID properties of older saved conditions prior to the comparison used for condition removal