### PR TITLE
These need to be ints

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -738,8 +738,8 @@ function linkDependencyDialog(stepID) {
             buffer = 'Select an existing requirement ';
             buffer += '<br /><div><select id="dependencyID" name="dependencyID">';
 
-            var reservedDependencies = ['-3', '-2', '-1', '1', '8'];
-            var maskedDependencies = ['5'];
+            var reservedDependencies = [-3, -2, -1, 1, 8];
+            var maskedDependencies = [5];
 
             buffer += '<optgroup label="Custom Requirements">';
             for(let i in res) {


### PR DESCRIPTION
This resolves an issue where the API returns ints but was being compared as strings, causing comparisons to fail.