### PR TITLE
LEAF-3100 Remove client-side cache workaround

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -243,8 +243,7 @@ var LeafFormQuery = function() {
         		type: 'GET',
         		url: rootURL + 'api/form/query?q=' + queryUrl + extraParams,
         		dataType: 'json',
-        		success: successCallback,
-        		cache: false
+        		success: successCallback
         	});
     	}
     	else {
@@ -252,8 +251,7 @@ var LeafFormQuery = function() {
         		type: 'GET',
         		url: rootURL + 'api/form/query?q=' + queryUrl + '&format=jsonp' + extraParams,
         		dataType: 'jsonp',
-        		success: successCallback,
-        		cache: false
+        		success: successCallback
         	});
     	}
     }


### PR DESCRIPTION
This reduces data transfer when a cached result can be used, improving UX on slow connections.

Tested with Edge/Chrome/Safari in a prod sandbox, and Firefox in dev