### PR TITLE
LEAF-3103: Hotfix: Left out timestamp

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -267,6 +267,7 @@ function addHeader(column) {
             break;
         case 'days_since_last_action':
         case 'days_since_last_step_movement':
+            filterData['action_history.time'] = 1;
             filterData['action_history.stepID'] = 1;
             filterData['action_history.actionType'] = 1;
             filterData['stepFulfillmentOnly'] = 1;


### PR DESCRIPTION
This reincorporates a timestamp that was mistakenly left out of the previous hotfix.