### PR TITLE
LEAF 3188 fileupload and image format template updates

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -96,7 +96,6 @@ switch ($action) {
                 $t_form->assign('orgchartImportTag', Config::$orgchartImportTags[0]);
                 $t_form->assign('subindicatorsTemplate', customTemplate('subindicators.tpl'));
                 $t_form->display(customTemplate('ajaxForm.tpl'));
-
             }
             else
             {

--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -81,6 +81,7 @@ switch ($action) {
 
             $indicator = $form->getIndicator($indicatorID, $series, $recordID);
             $recordInfo = $form->getRecordInfo($recordID);
+            $t_form->assign('max_filesize', ini_get('upload_max_filesize'));
             if ($indicator[$_GET['indicatorID']]['isWritable'] == 1)
             {
                 $t_form->left_delimiter = '<!--{';
@@ -95,6 +96,7 @@ switch ($action) {
                 $t_form->assign('orgchartImportTag', Config::$orgchartImportTags[0]);
                 $t_form->assign('subindicatorsTemplate', customTemplate('subindicators.tpl'));
                 $t_form->display(customTemplate('ajaxForm.tpl'));
+
             }
             else
             {
@@ -263,7 +265,7 @@ switch ($action) {
         //$approval = new Action($db, $login, $_GET['recordID']);
         //$approval->addApproval($_POST['groupID'], $_POST['status'], $_POST['comment'], $_POST['dependencyID']);
         break;
-    case 'doupload': // handle file upload
+    case 'doupload': // legacy handle file upload (retained for older custom files)
         require 'form.php';
         $uploadOk = true;
         $uploadedFilename = '';

--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -1066,7 +1066,7 @@ fieldset.iefix {
 
 fieldset.iefix p { margin: 0 }
 
-legend { color: #999999; padding: 0 .25em; font-size: 90%; font-weight: bold }
+legend { color: #747474; padding: 0 .25em; font-size: 90%; font-weight: bold }
 
 div#search > div {
     float: left;

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1104,7 +1104,6 @@ class Form
                     if (in_array($fileExtension, $fileExtensionWhitelist) && $_FILES[$indicator]['error'] === UPLOAD_ERR_OK)
                     {
                         $uploadDir = isset(Config::$uploadDir) ? Config::$uploadDir : UPLOAD_DIR;
-                        
                         if (!is_dir($uploadDir))
                         {
                             mkdir($uploadDir, 0755, true);

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1105,9 +1105,6 @@ class Form
                     {
                         $uploadDir = isset(Config::$uploadDir) ? Config::$uploadDir : UPLOAD_DIR;
                         
-                        if(isset($_POST['isAPI']) && $_POST['series'] == true) {
-                            $uploadDir = '../'. $uploadDir;
-                        }
                         if (!is_dir($uploadDir))
                         {
                             mkdir($uploadDir, 0755, true);

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1101,7 +1101,7 @@ class Form
                     $filenameParts = explode('.', $_FILES[$indicator]['name']);
                     $fileExtension = array_pop($filenameParts);
                     $fileExtension = strtolower($fileExtension);
-                    if (in_array($fileExtension, $fileExtensionWhitelist))
+                    if (in_array($fileExtension, $fileExtensionWhitelist) && $_FILES[$indicator]['error'] === UPLOAD_ERR_OK)
                     {
                         $uploadDir = isset(Config::$uploadDir) ? Config::$uploadDir : UPLOAD_DIR;
                         

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1104,6 +1104,10 @@ class Form
                     if (in_array($fileExtension, $fileExtensionWhitelist))
                     {
                         $uploadDir = isset(Config::$uploadDir) ? Config::$uploadDir : UPLOAD_DIR;
+                        
+                        if(isset($_POST['isAPI']) && $_POST['series'] == true) {
+                            $uploadDir = '../'. $uploadDir;
+                        }
                         if (!is_dir($uploadDir))
                         {
                             mkdir($uploadDir, 0755, true);

--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -320,36 +320,6 @@ var LeafForm = function(containerID) {
         });
         
     }
-    function uploadFile(file = {}, indicatorID = 0, series = 1) {
-        if(recordID == 0) {
-            console.log('recordID not set');
-            return 0;
-        }
-        
-        let formData = new FormData();
-        formData.append(`${indicatorID}`, file);
-        formData.append('CSRFToken', CSRFToken);
-        formData.append('indicatorID', indicatorID);
-        formData.append('series', series);
-
-        return new Promise((resolve, reject) => {
-            $.ajax({
-                type: 'POST',
-                url: `./api/form/${recordID}`,
-                data: formData,
-                success: function(res) {
-                    resolve(res);
-                },
-                error: function(err) {
-                    reject(err);
-                },
-                processData: false,
-                contentType: false,
-                cache: false
-            });
-        });
-        
-    }
 
     function doModify() {
         if(recordID == 0) {
@@ -364,7 +334,6 @@ var LeafForm = function(containerID) {
         $('#' + htmlFormID).find(':input:disabled').removeAttr('disabled');
         var data = {recordID: recordID};
         $('#' + htmlFormID).serializeArray().map(function(x) {
-            console.log(x);
             if (x.name.includes('_multiselect')) {
                 const i = x.name.indexOf('_multiselect');
                 if (x.value === '') { //selected if no options are chosen
@@ -502,7 +471,6 @@ var LeafForm = function(containerID) {
         doModify: doModify,
         getForm: getForm,
         initCustom: initCustom,
-        setHtmlFormID: setHtmlFormID,
-        uploadFile: uploadFile
+        setHtmlFormID: setHtmlFormID
     }
 };

--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -320,6 +320,36 @@ var LeafForm = function(containerID) {
         });
         
     }
+    function uploadFile(file = {}, indicatorID = 0, series = 1) {
+        if(recordID == 0) {
+            console.log('recordID not set');
+            return 0;
+        }
+        
+        let formData = new FormData();
+        formData.append(`${indicatorID}`, file);
+        formData.append('CSRFToken', CSRFToken);
+        formData.append('indicatorID', indicatorID);
+        formData.append('series', series);
+
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                type: 'POST',
+                url: `./api/form/${recordID}`,
+                data: formData,
+                success: function(res) {
+                    resolve(res);
+                },
+                error: function(err) {
+                    reject(err);
+                },
+                processData: false,
+                contentType: false,
+                cache: false
+            });
+        });
+        
+    }
 
     function doModify() {
         if(recordID == 0) {
@@ -334,6 +364,7 @@ var LeafForm = function(containerID) {
         $('#' + htmlFormID).find(':input:disabled').removeAttr('disabled');
         var data = {recordID: recordID};
         $('#' + htmlFormID).serializeArray().map(function(x) {
+            console.log(x);
             if (x.name.includes('_multiselect')) {
                 const i = x.name.indexOf('_multiselect');
                 if (x.value === '') { //selected if no options are chosen
@@ -471,6 +502,7 @@ var LeafForm = function(containerID) {
         doModify: doModify,
         getForm: getForm,
         initCustom: initCustom,
-        setHtmlFormID: setHtmlFormID
+        setHtmlFormID: setHtmlFormID,
+        uploadFile: uploadFile
     }
 };

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -149,7 +149,7 @@
             <!--{assign var='idx' value=0}-->
             <!--{foreach from=$indicator.value item=file}-->
                 <!--{if $indicator.value != '[protected data]'}-->
-                <img src="image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" style="max-width: 200px" onclick="window.open('image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
+                <img src="image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" style="max-width: 200px" onclick="window.open('image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" alt="image upload: <!--{$file}-->"/>
                 <!--{assign var='idx' value=$idx+1}-->
                 <!--{else}-->
                 [protected data]

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -634,7 +634,7 @@
                 <!--{$indicator.html}-->
                 
         <!--{/if}-->
-        <!--{if $indicator.format == 'fileupload' && ($indicator.isMasked == 0 || $indicator.value == '')}-->
+        <!--{if ($indicator.format == 'fileupload' || $indicator.format == 'image') && ($indicator.isMasked == 0 || $indicator.value == '')}-->
             <script>
                 function addFile(indicatorID = 0, series = 1) {
                     const inputEl = document.getElementById(`file${indicatorID}`);
@@ -716,7 +716,8 @@
                 <!--{/if}-->  
                 <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select File to attach: 
                     <input id="file<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
-                        onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" />
+                        onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" 
+                        <!--{if $indicator.format == 'image'}-->accept="image/*"<!--{/if}--> />
                 </div>
                 <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px">
                     <img src="images/indicator.gif" alt="loading..." /> Attaching file...
@@ -725,76 +726,6 @@
                     <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
                 </div>
                                 
-                </span>
-            </fieldset>
-            <!--{if $indicator.required == 1}-->
-            <script>
-                formRequired["id<!--{$indicator.indicatorID}-->"] = {
-                    setRequired: function() {
-                        var oldFiles = $('[id*="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_"]:visible');
-                        var iFrameDOM = $('.blockIndicator_<!--{$indicator.indicatorID|strip_tags}--> iframe').contents();
-                        var newFiles = iFrameDOM.find('.newFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->');
-                        
-                        return oldFiles.length === 0 && newFiles.length === 0;
-                    },
-                    setSubmitError: function() {
-                        $([document.documentElement, document.body]).animate({
-                            scrollTop: $('#<!--{$indicator.indicatorID|strip_tags}-->_required').offset().top
-                        }, 700).clearQueue();
-                    },
-                    setRequiredError: function() {
-                        $('#<!--{$indicator.indicatorID|strip_tags}-->_required').addClass('input-required-error');
-                    },
-                    setRequiredOk: function() {
-                        $('#<!--{$indicator.indicatorID|strip_tags}-->_required').removeClass('input-required-error');
-                    }
-                };
-            </script>
-            <!--{/if}-->
-        <!--{/if}-->
-        <!--{if $indicator.format == 'image' && ($indicator.isMasked == 0 || $indicator.value == '')}-->
-            <fieldset>
-                <legend>Image Attachment(s)</legend>
-                <span class="text">
-                <!--{if $indicator.value[0] != ''}-->
-                <!--{assign "counter" 0}-->
-                <!--{foreach from=$indicator.value item=file}-->
-                <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" style="background-color: #b7c5ff; padding: 4px"><img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" /> <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
-                    <span style="float: right; padding: 4px">
-                    [ <button type="button" class="link" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">Delete</button> ]
-                    </span>
-                </div>
-                <script>
-                    function deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->() {
-                        dialog_confirm.setTitle('Delete File?');
-                        dialog_confirm.setContent('Are you sure you want to delete:<br /><br /><b><!--{$file}--></b>');
-                        dialog_confirm.setSaveHandler(function() {
-                            $.ajax({
-                                type: 'POST',
-                                url: "ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
-                                data: {recordID: <!--{$recordID|strip_tags}-->,
-                                       indicatorID: <!--{$indicator.indicatorID|strip_tags}-->,
-                                       series: <!--{$indicator.series|strip_tags}-->,
-                                       file: '<!--{$counter}-->',
-                                       CSRFToken: '<!--{$CSRFToken}-->'},
-                                success: function(response) {
-                                    $('#file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->').css('display', 'none');
-                                    dialog_confirm.hide();
-                                }
-                            });
-                        });
-                        dialog_confirm.show();
-                    }
-                </script>
-                <!--{assign "counter" $counter+1}-->
-                <!--{/foreach}-->
-                <!-- TODO: whenever we can drop support for old browsers IE9, use modern method -->
-                <iframe id="fileIframe_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->" style="visibility: hidden; display: none" src="ajaxIframe.php?a=getimageuploadprompt&amp;recordID=<!--{$recordID|strip_tags}-->&amp;indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->" frameborder="0" width="500px"></iframe>
-                <br />
-                <button type="button" id="fileAdditional" class="buttonNorm" onclick="$('#fileIframe_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').css('display', 'inline'); $('#fileIframe_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').css('visibility', 'visible'); $('#fileAdditional').css('visibility', 'hidden')"><img src="../libs/dynicons/?img=document-open.svg&amp;w=32" /> Attach Additional File</button>
-                <!--{else}-->
-                    <iframe src="ajaxIframe.php?a=getimageuploadprompt&amp;recordID=<!--{$recordID|strip_tags}-->&amp;indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->" frameborder="0" width="480px" height="100px"></iframe><br />
-                <!--{/if}-->
                 </span>
             </fieldset>
             <!--{if $indicator.required == 1}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -28,7 +28,7 @@
                 <!--{else}-->
         <div class="sublabel blockIndicator_<!--{$indicator.indicatorID|strip_tags}-->">
 
-            <label <!--{if !$indicator.format|in_array:['text','date','currency','number']}--> tabIndex="0" <!--{/if}--> for="<!--{$indicator.indicatorID|strip_tags}-->">
+            <label <!--{if !$indicator.format|in_array:['text','date','currency','number','fileupload','image']}--> tabIndex="0" <!--{/if}--> for="<!--{$indicator.indicatorID|strip_tags}-->">
                     <!--{if $indicator.format == null}-->
                         <br /><b><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--></b><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
                     <!--{else}-->
@@ -674,7 +674,7 @@
                 }
             </script>
             <fieldset>
-                <legend>File Attachment(s)</legend>
+                <legend><!--{if $indicator.format == 'fileupload'}-->File<!--{else}-->Image<!--{/if}--> Attachment(s)</legend>
                 <span class="text">
                 <!--{assign "counter" 0}-->
                 <!--{if $indicator.value[0] != ''}-->
@@ -716,18 +716,16 @@
                         <!--{assign "counter" $counter+1}-->
                     <!--{/foreach}-->
                 <!--{/if}-->  
-                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select <!--{if $counter > 0}-->additional <!--{/if}-->File to attach: 
-                    <input id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
-                        onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" 
-                        <!--{if $indicator.format === 'image'}-->accept="image/*"<!--{/if}--> />
-                </div>
-                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px; font-weight: bolder; margin-top:0.2rem;">
-                    <img src="images/indicator.gif" alt="loading..." /> Attaching file...
-                </div>
-                <div style="font-family: verdana; font-size: 10px">
-                    <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
-                </div>
-                                
+                    <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select <!--{if $counter > 0}-->additional <!--{/if}-->File to attach: 
+                        <input id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
+                            onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" <!--{if $indicator.format === 'image'}-->accept="image/*"<!--{/if}--> />
+                    </div>
+                    <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px; font-weight: bolder; margin-top:0.2rem;">
+                        <img src="images/indicator.gif" alt="loading..." /> Attaching file...
+                    </div>
+                    <div style="font-family: verdana; font-size: 10px">
+                        <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
+                    </div>
                 </span>
             </fieldset>
             <!--{if $indicator.required == 1}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -648,7 +648,6 @@
                         formData.append('CSRFToken', CSRFToken);
                         formData.append('indicatorID', indicatorID);
                         formData.append('series', series);
-                        formData.append('isAPI', true);
 
                         $.ajax({
                             type: 'POST',
@@ -662,7 +661,11 @@
                                 }
                             },
                             error: (err) => {
-                                statusEl.innerHTML = `${err.responseText}`;
+                                if (err?.status === 413) {
+                                    statusEl.innerHTML = '<span style="color:#d00;">File upload error:</span><br/>The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form';
+                                } else {
+                                    statusEl.innerHTML = `${err?.responseText ? err?.responseText : ''}`;
+                                }
                             },
                             processData: false,
                             contentType: false

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -713,6 +713,9 @@
                                         success: function(response) {
                                             $('#file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->').css('display', 'none');
                                             dialog_confirm.hide();
+                                        },
+                                        error: function(err) {
+                                            console.log(err);
                                         }
                                     });
                                 });

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -637,16 +637,14 @@
         <!--{if ($indicator.format == 'fileupload' || $indicator.format == 'image') && ($indicator.isMasked == 0 || $indicator.value == '')}-->
             <script>
                 function addFile(indicatorID = 0, series = 1) {
-                    const inputEl = document.getElementById(`file${indicatorID}`);
-                    if (inputEl?.files[0]) {
+                    const inputEl = document.getElementById(`${indicatorID}`);
+                    if (inputEl?.files !== null) {
+                        const fileName = inputEl.files[0].name;
                         const statusEl = document.getElementById(`file${indicatorID}_status`);
                         statusEl.style.display = 'block';
 
-                        const file = inputEl?.files[0];
-                        const fileName = inputEl.files[0].name;
-                        
                         let formData = new FormData();
-                        formData.append(`${indicatorID}`, file);
+                        formData.append(`${indicatorID}`, inputEl?.files[0]);
                         formData.append('CSRFToken', CSRFToken);
                         formData.append('indicatorID', indicatorID);
                         formData.append('series', series);
@@ -656,19 +654,16 @@
                             type: 'POST',
                             url: `./api/form/${recordID}`,
                             data: formData,
-                            success: function(res) {
-                                if(res === 1) {
+                            success: (res) => {
+                                if(parseInt(res) === 1) {
                                     statusEl.innerText = `File ${fileName} has been attached`;
                                 } else {
-                                    statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span> Please make sure the file you are uploading is either a PDF, Word Document or similar format.`;
+                                    statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span><br/>Please make sure the file you are uploading is either a PDF, Word Document or similar format.`;
                                 }
                             },
-                            error: function(err) {
-                                console.log(err);
-                            },
+                            error: (err) => console.log(err),
                             processData: false,
-                            contentType: false,
-                            cache: false
+                            contentType: false
                         });
                     }
                 }
@@ -676,15 +671,17 @@
             <fieldset>
                 <legend>File Attachment(s)</legend>
                 <span class="text">
+                <!--{assign "counter" 0}-->
                 <!--{if $indicator.value[0] != ''}-->
-                    <!--{assign "counter" 0}-->
                     <!--{foreach from=$indicator.value item=file}-->
                         <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" 
                         style="background-color: #d7e5ff; padding: 4px; display: flex; align-items: center" >
-                            <img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" /> 
+                            <img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" alt="" /> 
                             <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
-                            <span style="display: inline-block; margin-left: auto; padding: 4px">
-                            [ <button type="button" class="link" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">Delete</button> ]
+                            <span style="display: inline-block; margin-left: auto; padding: 4px">[ 
+                                <button type="button" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">
+                                    Delete
+                                </button> ]
                             </span>
                         </div>
                         <script>
@@ -714,12 +711,12 @@
                         <!--{assign "counter" $counter+1}-->
                     <!--{/foreach}-->
                 <!--{/if}-->  
-                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select File to attach: 
-                    <input id="file<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
+                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select <!--{if $counter > 0}-->additional <!--{/if}-->File to attach: 
+                    <input id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
                         onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" 
-                        <!--{if $indicator.format == 'image'}-->accept="image/*"<!--{/if}--> />
+                        <!--{if $indicator.format === 'image'}-->accept="image/*"<!--{/if}--> />
                 </div>
-                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px">
+                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px; font-weight: bolder; margin-top:0.2rem;">
                     <img src="images/indicator.gif" alt="loading..." /> Attaching file...
                 </div>
                 <div style="font-family: verdana; font-size: 10px">

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -661,7 +661,9 @@
                                     statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span><br/>Please make sure the file you are uploading is either a PDF, Word Document or similar format.`;
                                 }
                             },
-                            error: (err) => console.log(err),
+                            error: (err) => {
+                                statusEl.innerHTML = `${err.responseText}`;
+                            },
                             processData: false,
                             contentType: false
                         });
@@ -679,7 +681,7 @@
                             <img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" alt="" /> 
                             <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
                             <span style="display: inline-block; margin-left: auto; padding: 4px">[ 
-                                <button type="button" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">
+                                <button type="button" class="link" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">
                                     Delete
                                 </button> ]
                             </span>

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -28,7 +28,7 @@
                 <!--{else}-->
         <div class="sublabel blockIndicator_<!--{$indicator.indicatorID|strip_tags}-->">
 
-            <label <!--{if !$indicator.format|in_array:['text','date','currency','number','fileupload','image']}--> tabIndex="0" <!--{/if}--> for="<!--{$indicator.indicatorID|strip_tags}-->">
+            <label <!--{if !$indicator.format|in_array:['text','date','currency','number']}--> tabIndex="0" <!--{/if}--> for="<!--{$indicator.indicatorID|strip_tags}-->">
                     <!--{if $indicator.format == null}-->
                         <br /><b><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--></b><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
                     <!--{else}-->
@@ -639,7 +639,7 @@
                 function addFile(indicatorID = 0, series = 1) {
                     const inputEl = document.getElementById(`${indicatorID}`);
                     if (inputEl?.files !== null) {
-                        const fileName = inputEl.files[0].name;
+                        const fileName = XSSHelpers.stripAllTags(inputEl.files[0].name);
                         const statusEl = document.getElementById(`file${indicatorID}_status`);
                         statusEl.style.display = 'block';
 
@@ -655,7 +655,8 @@
                             data: formData,
                             success: (res) => {
                                 if(parseInt(res) === 1) {
-                                    statusEl.innerText = `File ${fileName} has been attached`;
+                                    const msg = `File ${fileName} has been attached\r\n`;
+                                    statusEl.innerText = statusEl.querySelector('img') !== null ? msg : statusEl.innerText + msg;
                                 } else {
                                     statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span><br/>Please make sure the file you are uploading is either a PDF, Word Document or similar format.`;
                                 }

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -659,6 +659,8 @@
                             success: function(res) {
                                 if(res === 1) {
                                     statusEl.innerText = `File ${fileName} has been attached`;
+                                } else {
+                                    statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span> Please make sure the file you are uploading is either a PDF, Word Document or similar format.`;
                                 }
                             },
                             error: function(err) {

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -668,13 +668,16 @@
                                     });
                                 });
                                 dialog_confirm.show();
-                            }
-                            function addFile(recordID=0, indicatorID=0, series=1) {
+                            } 
+                            function addFile(recordID = 0, indicatorID = 0, series = 1) {
+
                                 console.log(recordID, indicatorID, series, '<!--{$CSRFToken}-->');
+                                //$('#record_<!--{$indicator.indicatorID|strip_tags}-->').submit();
                             }
                         </script>
                         <!--{assign "counter" $counter+1}-->
                     <!--{/foreach}-->
+                <!--{/if}-->
                     <form id="record_<!--{$indicator.indicatorID|strip_tags}-->" enctype="multipart/form-data" 
                             action="ajaxIndex.php?a=doupload&amp;recordID=<!--{$recordID|strip_tags}-->" method="post">
                         <input name="CSRFToken" type="hidden" value="<!--{$CSRFToken}-->" />
@@ -682,7 +685,8 @@
                         <input type="hidden" name="indicatorID" value="<!--{$indicator.indicatorID|strip_tags}-->" />
                         <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control">Select File to attach: 
                             <input id="file<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" 
-                            type="file" onchange="$('#record_<!--{$indicator.indicatorID|strip_tags}-->').submit()" multiple />
+                            type="file"  multiple />
+                            <button type="submit">Submit Files</button>
                         </div>
                         <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="visibility: hidden; display: none; background-color: #fffcae; padding: 4px">
                             <img src="images/indicator.gif" alt="loading..." /> Attaching file...
@@ -690,10 +694,7 @@
                         <div style="font-family: verdana; font-size: 10px">
                             <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
                         </div>
-                    </form>                    
-                <!--{else}-->
-                    <iframe src="ajaxIframe.php?a=getuploadprompt&amp;recordID=<!--{$recordID|strip_tags}-->&amp;indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->" frameborder="0" width="480px" height="100px"></iframe><br />
-                <!--{/if}-->
+                    </form>                
                 </span>
             </fieldset>
             <!--{if $indicator.required == 1}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -639,41 +639,58 @@
                 <legend>File Attachment(s)</legend>
                 <span class="text">
                 <!--{if $indicator.value[0] != ''}-->
-                <!--{assign "counter" 0}-->
-                <!--{foreach from=$indicator.value item=file}-->
-                <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" style="background-color: #b7c5ff; padding: 4px"><img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" /> <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
-                    <span style="float: right; padding: 4px">
-                    [ <button type="button" class="link" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">Delete</button> ]
-                    </span>
-                </div>
-                <script>
-                    function deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->() {
-                    	dialog_confirm.setTitle('Delete File?');
-                    	dialog_confirm.setContent('Are you sure you want to delete:<br /><br /><b><!--{$file}--></b>');
-                    	dialog_confirm.setSaveHandler(function() {
-                    	    $.ajax({
-                    	        type: 'POST',
-                    	        url: "ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
-                    	        data: {recordID: <!--{$recordID|strip_tags}-->,
-                    	               indicatorID: <!--{$indicator.indicatorID|strip_tags}-->,
-                    	               series: <!--{$indicator.series|strip_tags}-->,
-                    	               file: '<!--{$counter}-->',
-                    	               CSRFToken: '<!--{$CSRFToken}-->'},
-                    	        success: function(response) {
-                    	            $('#file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->').css('display', 'none');
-                    	            dialog_confirm.hide();
-                    	        }
-                    	    });
-                    	});
-                    	dialog_confirm.show();
-                    }
-                </script>
-                <!--{assign "counter" $counter+1}-->
-                <!--{/foreach}-->
-                <!-- TODO: whenever we can drop support for old browsers IE9, use modern method -->
-                <iframe id="fileIframe_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->" style="visibility: hidden; display: none" src="ajaxIframe.php?a=getuploadprompt&amp;recordID=<!--{$recordID|strip_tags}-->&amp;indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->" frameborder="0" width="500px"></iframe>
-                <br />
-                <button type="button" id="fileAdditional" class="buttonNorm" onclick="$('#fileIframe_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').css('display', 'inline'); $('#fileIframe_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').css('visibility', 'visible'); $('#fileAdditional').css('visibility', 'hidden')"><img src="../libs/dynicons/?img=document-open.svg&amp;w=32" /> Attach Additional File</button>
+                    <!--{assign "counter" 0}-->
+                    <!--{foreach from=$indicator.value item=file}-->
+                        <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" style="background-color: #b7c5ff; padding: 4px"><img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" /> <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
+                            <span style="float: right; padding: 4px">
+                            [ <button type="button" class="link" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">Delete</button> ]
+                            </span>
+                        </div>
+                        <script>
+                            function deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->() {
+                                dialog_confirm.setTitle('Delete File?');
+                                dialog_confirm.setContent('Are you sure you want to delete:<br /><br /><b><!--{$file}--></b>');
+                                dialog_confirm.setSaveHandler(function() {
+                                    $.ajax({
+                                        type: 'POST',
+                                        url: "ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
+                                        data: {
+                                            recordID: <!--{$recordID|strip_tags}-->,
+                                            indicatorID: <!--{$indicator.indicatorID|strip_tags}-->,
+                                            series: <!--{$indicator.series|strip_tags}-->,
+                                            file: '<!--{$counter}-->',
+                                            CSRFToken: '<!--{$CSRFToken}-->'
+                                        },
+                                        success: function(response) {
+                                            $('#file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->').css('display', 'none');
+                                            dialog_confirm.hide();
+                                        }
+                                    });
+                                });
+                                dialog_confirm.show();
+                            }
+                            function addFile(recordID=0, indicatorID=0, series=1) {
+                                console.log(recordID, indicatorID, series, '<!--{$CSRFToken}-->');
+                            }
+                        </script>
+                        <!--{assign "counter" $counter+1}-->
+                    <!--{/foreach}-->
+                    <form id="record_<!--{$indicator.indicatorID|strip_tags}-->" enctype="multipart/form-data" 
+                            action="ajaxIndex.php?a=doupload&amp;recordID=<!--{$recordID|strip_tags}-->" method="post">
+                        <input name="CSRFToken" type="hidden" value="<!--{$CSRFToken}-->" />
+                        <input type="hidden" name="series" value="<!--{$indicator.series}-->" />
+                        <input type="hidden" name="indicatorID" value="<!--{$indicator.indicatorID|strip_tags}-->" />
+                        <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control">Select File to attach: 
+                            <input id="file<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" 
+                            type="file" onchange="$('#record_<!--{$indicator.indicatorID|strip_tags}-->').submit()" multiple />
+                        </div>
+                        <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="visibility: hidden; display: none; background-color: #fffcae; padding: 4px">
+                            <img src="images/indicator.gif" alt="loading..." /> Attaching file...
+                        </div>
+                        <div style="font-family: verdana; font-size: 10px">
+                            <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
+                        </div>
+                    </form>                    
                 <!--{else}-->
                     <iframe src="ajaxIframe.php?a=getuploadprompt&amp;recordID=<!--{$recordID|strip_tags}-->&amp;indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->" frameborder="0" width="480px" height="100px"></iframe><br />
                 <!--{/if}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -638,14 +638,35 @@
             <script>
                 function addFile(indicatorID = 0, series = 1) {
                     const inputEl = document.getElementById(`file${indicatorID}`);
-                    if (inputEl.files[0]) {
-                        const fileName = inputEl.files[0].name;
+                    if (inputEl?.files[0]) {
                         const statusEl = document.getElementById(`file${indicatorID}_status`);
                         statusEl.style.display = 'block';
-                        form.uploadFile(inputEl.files[0], parseInt(indicatorID), series).then(res => {
-                            if(res === 1) {
-                                statusEl.innerText = `File ${fileName} has been attached`;
-                            }
+
+                        const file = inputEl?.files[0];
+                        const fileName = inputEl.files[0].name;
+                        
+                        let formData = new FormData();
+                        formData.append(`${indicatorID}`, file);
+                        formData.append('CSRFToken', CSRFToken);
+                        formData.append('indicatorID', indicatorID);
+                        formData.append('series', series);
+                        formData.append('isAPI', true);
+
+                        $.ajax({
+                            type: 'POST',
+                            url: `./api/form/${recordID}`,
+                            data: formData,
+                            success: function(res) {
+                                if(res === 1) {
+                                    statusEl.innerText = `File ${fileName} has been attached`;
+                                }
+                            },
+                            error: function(err) {
+                                console.log(err);
+                            },
+                            processData: false,
+                            contentType: false,
+                            cache: false
                         });
                     }
                 }

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -636,7 +636,7 @@
         <!--{/if}-->
         <!--{if ($indicator.format == 'fileupload' || $indicator.format == 'image') && ($indicator.isMasked == 0 || $indicator.value == '')}-->
             <script>
-                function addFile(indicatorID = 0, series = 1) {
+                function addFile(indicatorID = 0, series = 1, indFormat = '') {
                     const inputEl = document.getElementById(`${indicatorID}`);
                     if (inputEl?.files !== null) {
                         const fileName = XSSHelpers.stripAllTags(inputEl.files[0].name);
@@ -656,17 +656,22 @@
                             success: (res) => {
                                 if(parseInt(res) === 1) {
                                     const msg = `File ${fileName} has been attached\r\n`;
-                                    statusEl.innerText = statusEl.querySelector('img') !== null ? msg : statusEl.innerText + msg;
+                                    statusEl.innerText = statusEl.querySelector('img') !== null || statusEl.classList.contains('status_error') ? msg : statusEl.innerText + msg;
+                                    statusEl.classList.remove('status_error');
                                 } else {
-                                    statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span><br/>Please make sure the file you are uploading is either a PDF, Word Document or similar format.`;
+                                    const msg = indFormat.toLowerCase() === 'fileupload' ? 'Please ensure the file you are uploading is either a PDF, Word Document or similar format' :
+                                                                                           `Please ensure the file you are uploading is a photo. &nbsp;Supported image formats are JPG, PNG`;
+                                    statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span><br/>${msg}`;
+                                    statusEl.classList.add('status_error');
                                 }
                             },
                             error: (err) => {
                                 if (err?.status === 413) {
-                                    statusEl.innerHTML = '<span style="color:#d00;">File upload error:</span><br/>The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form';
+                                    statusEl.innerHTML = '<span style="color:#d00;">File upload error:</span><br/>The file upload is too large.  The maximum upload size is <!--{$max_filesize|strip_tags}-->B';
                                 } else {
                                     statusEl.innerHTML = `${err?.responseText ? err?.responseText : ''}`;
                                 }
+                                statusEl.classList.add('status_error');
                             },
                             processData: false,
                             contentType: false
@@ -719,7 +724,8 @@
                 <!--{/if}-->  
                     <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select <!--{if $counter > 0}-->additional <!--{/if}-->File to attach: 
                         <input id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
-                            onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" <!--{if $indicator.format === 'image'}-->accept="image/*"<!--{/if}--> />
+                            onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->,'<!--{$indicator.format|strip_tags}-->')" 
+                                    <!--{if $indicator.format === 'image'}-->accept="image/*"<!--{/if}--> />
                     </div>
                     <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px; font-weight: bolder; margin-top:0.2rem;">
                         <img src="images/indicator.gif" alt="loading..." /> Attaching file...

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -635,14 +635,32 @@
                 
         <!--{/if}-->
         <!--{if $indicator.format == 'fileupload' && ($indicator.isMasked == 0 || $indicator.value == '')}-->
+            <script>
+                function addFile(indicatorID = 0, series = 1) {
+                    const inputEl = document.getElementById(`file${indicatorID}`);
+                    if (inputEl.files[0]) {
+                        const fileName = inputEl.files[0].name;
+                        const statusEl = document.getElementById(`file${indicatorID}_status`);
+                        statusEl.style.display = 'block';
+                        form.uploadFile(inputEl.files[0], parseInt(indicatorID), series).then(res => {
+                            if(res === 1) {
+                                statusEl.innerText = `File ${fileName} has been attached`;
+                            }
+                        });
+                    }
+                }
+            </script>
             <fieldset>
                 <legend>File Attachment(s)</legend>
                 <span class="text">
                 <!--{if $indicator.value[0] != ''}-->
                     <!--{assign "counter" 0}-->
                     <!--{foreach from=$indicator.value item=file}-->
-                        <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" style="background-color: #b7c5ff; padding: 4px"><img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" /> <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
-                            <span style="float: right; padding: 4px">
+                        <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" 
+                        style="background-color: #d7e5ff; padding: 4px; display: flex; align-items: center" >
+                            <img src="../libs/dynicons/?img=mail-attachment.svg&amp;w=16" /> 
+                            <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
+                            <span style="display: inline-block; margin-left: auto; padding: 4px">
                             [ <button type="button" class="link" onclick="deleteFile_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->();">Delete</button> ]
                             </span>
                         </div>
@@ -669,32 +687,21 @@
                                 });
                                 dialog_confirm.show();
                             } 
-                            function addFile(recordID = 0, indicatorID = 0, series = 1) {
-
-                                console.log(recordID, indicatorID, series, '<!--{$CSRFToken}-->');
-                                //$('#record_<!--{$indicator.indicatorID|strip_tags}-->').submit();
-                            }
                         </script>
                         <!--{assign "counter" $counter+1}-->
                     <!--{/foreach}-->
-                <!--{/if}-->
-                    <form id="record_<!--{$indicator.indicatorID|strip_tags}-->" enctype="multipart/form-data" 
-                            action="ajaxIndex.php?a=doupload&amp;recordID=<!--{$recordID|strip_tags}-->" method="post">
-                        <input name="CSRFToken" type="hidden" value="<!--{$CSRFToken}-->" />
-                        <input type="hidden" name="series" value="<!--{$indicator.series}-->" />
-                        <input type="hidden" name="indicatorID" value="<!--{$indicator.indicatorID|strip_tags}-->" />
-                        <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control">Select File to attach: 
-                            <input id="file<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" 
-                            type="file"  multiple />
-                            <button type="submit">Submit Files</button>
-                        </div>
-                        <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="visibility: hidden; display: none; background-color: #fffcae; padding: 4px">
-                            <img src="images/indicator.gif" alt="loading..." /> Attaching file...
-                        </div>
-                        <div style="font-family: verdana; font-size: 10px">
-                            <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
-                        </div>
-                    </form>                
+                <!--{/if}-->  
+                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_control" style="margin-top: 0.5rem;">Select File to attach: 
+                    <input id="file<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" type="file" 
+                        onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->)" />
+                </div>
+                <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px">
+                    <img src="images/indicator.gif" alt="loading..." /> Attaching file...
+                </div>
+                <div style="font-family: verdana; font-size: 10px">
+                    <br />Maximum attachment size is <b><!--{$max_filesize|strip_tags}-->B.</b>
+                </div>
+                                
                 </span>
             </fieldset>
             <!--{if $indicator.required == 1}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -660,7 +660,7 @@
                                     statusEl.classList.remove('status_error');
                                 } else {
                                     const msg = indFormat.toLowerCase() === 'fileupload' ? 'Please ensure the file you are uploading is either a PDF, Word Document or similar format' :
-                                                                                           `Please ensure the file you are uploading is a photo. &nbsp;Supported image formats are JPG, PNG`;
+                                                                                           'Please ensure the file you are uploading is a photo. &nbsp;Supported image formats are JPG, PNG';
                                     statusEl.innerHTML = `<span style="color:#d00;">File upload error:</span><br/>${msg}`;
                                     statusEl.classList.add('status_error');
                                 }
@@ -730,7 +730,7 @@
                             onchange="addFile(<!--{$indicator.indicatorID|strip_tags}-->,<!--{$indicator.series|strip_tags}-->,'<!--{$indicator.format|strip_tags}-->')" 
                                     <!--{if $indicator.format === 'image'}-->accept="image/*"<!--{/if}--> />
                     </div>
-                    <div id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px; font-weight: bolder; margin-top:0.2rem;">
+                    <div tabindex="0" id="file<!--{$indicator.indicatorID|strip_tags}-->_status" style="display: none; background-color: #fffcae; padding: 4px; font-weight: bolder; margin-top:0.2rem;">
                         <img src="images/indicator.gif" alt="loading..." /> Attaching file...
                     </div>
                     <div style="font-family: verdana; font-size: 10px">


### PR DESCRIPTION
PENDING:  uncovered during testing on demo1:
In the dev environment nginx will return a response in the case of error scenarios (some config variables also determine this state), whereas on live it does not.  Implementing fastcgi and config updates should resolve this difference.  However, until this occurs, the error handling sections of this branch cannot be properly tested on the live environment.

-----------------------

Replaces the iframes used for file attachments in the subindicators template with standard input type=file elements.  Associated prior code in other templates is being retained for use in custom subindicators files, which will continue to use these older templates.

Also adjusts some styling to meet contrast recommendations, fixes a button display issue and updates some error message verbiage.

Any code associated with file deletions will be handled in a future ticket to resolve uncovered issues that are unrelated to this update.
