### PR TITLE
LEAF 3238 add check if total was reduced to zero

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1478,7 +1478,11 @@ class Form
                         }
                     }
                 }
-                $returnValue = round(100 * ($resCountCompletedRequired/$countRequestRequired));
+                if ($countRequestRequired===0) {
+                    $returnValue = 100;
+                } else {
+                    $returnValue = round(100 * ($resCountCompletedRequired/$countRequestRequired));
+                }
             }
         } 
         return $returnValue;


### PR DESCRIPTION
Corrects an error that occurs if the total number of required questions on a form is reduced to zero when accounting for conditional display states.