### PR TITLE
LEAF-3253 Enable persistent database connection

### DIFF
--- a/LEAF_Nexus/db_mysql.php
+++ b/LEAF_Nexus/db_mysql.php
@@ -41,11 +41,19 @@ class DB
         $this->isConnected = true;
         try
         {
+
+            $pdo_options = [
+                // Error reporting mode of PDO. Can take one of the following values:
+                // PDO::ERRMODE_SILENT, PDO::ERRMODE_WARNING, PDO::ERRMODE_EXCEPTION
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_PERSISTENT => true
+            ];
+
             $this->db = new PDO(
                 "mysql:host={$this->dbHost};dbname={$this->dbName};charset=UTF8",
                 $this->dbUser,
                 $pass,
-                array()
+                $pdo_options
             );
         }
         catch (PDOException $e)

--- a/LEAF_Nexus/db_mysql.php
+++ b/LEAF_Nexus/db_mysql.php
@@ -65,6 +65,12 @@ class DB
 
     public function __destruct()
     {
+        try {
+            $this->db = null;
+        } catch (Exception $e) {
+            $this->logError('Connection normal closed: '.$e);
+        }
+
         if ($this->debug)
         {
             echo '<pre>';
@@ -89,12 +95,6 @@ class DB
             }
             echo '<hr />';
             echo "</pre><br />Time: {$this->time} sec<br />";
-        }
-        
-        try {
-            $this->db = null;
-        } catch (Exception $e) {
-            logError('Connection normal closed: '.$e);
         }
     }
 

--- a/LEAF_Nexus/db_mysql.php
+++ b/LEAF_Nexus/db_mysql.php
@@ -55,6 +55,13 @@ class DB
                 $pass,
                 $pdo_options
             );
+
+            // make sure there are no active transactions on script termination
+            register_shutdown_function(function() {
+                if($this->db->inTransaction()) {
+                    $this->db->rollBack();
+                }
+            });
         }
         catch (PDOException $e)
         {

--- a/LEAF_Request_Portal/db_mysql.php
+++ b/LEAF_Request_Portal/db_mysql.php
@@ -46,7 +46,8 @@ class DB
             $pdo_options = [
                 // Error reporting mode of PDO. Can take one of the following values:
                 // PDO::ERRMODE_SILENT, PDO::ERRMODE_WARNING, PDO::ERRMODE_EXCEPTION
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_PERSISTENT => true
             ];
 
             $this->db = new PDO(

--- a/LEAF_Request_Portal/db_mysql.php
+++ b/LEAF_Request_Portal/db_mysql.php
@@ -56,6 +56,13 @@ class DB
                 $pass,
                 $pdo_options
             );
+
+            // make sure there are no active transactions on script termination
+            register_shutdown_function(function() {
+                if($this->db->inTransaction()) {
+                    $this->db->rollBack();
+                }
+            });
         }
         catch (PDOException $e)
         {

--- a/LEAF_Request_Portal/db_mysql.php
+++ b/LEAF_Request_Portal/db_mysql.php
@@ -74,6 +74,12 @@ class DB
 
     public function __destruct()
     {
+        try {
+            $this->db = null;
+        } catch (Exception $e) {
+            $this->logError('Connection normal closed: '.$e);
+        }
+
         if ($this->debug)
         {
             echo '<pre>';
@@ -98,12 +104,6 @@ class DB
             }
             echo '<hr />';
             echo "</pre><br />Time: {$this->time} sec<br />";
-        }
-
-        try {
-            $this->db = null;
-        } catch (Exception $e) {
-            logError('Connection normal closed: '.$e);
         }
     }
 


### PR DESCRIPTION
This enables persistent database connections, and implements a mitigation for potential hanging transactions via PHP's register_shutdown_function().