### PR TITLE
LEAF-3330 - Filenames with & would not delete

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -4054,7 +4054,12 @@ class Form
                 AND disabled = 0';
 
         $data = $this->db->prepared_query($sql, $vars);
+
+        // values in this array would be decoded values so &amp;'s will be &
         $values = $this->fileToArray($data[0]['data']);
+
+        // right now we will have special chars encoded in the filename. We need this decoded.
+        $fileName = XSSHelpers::sanitizeHTML($fileName);
 
         for ($i = 0; $i < count($values); $i++) {
             if ($values[$i] == $fileName) {


### PR DESCRIPTION
Came in via a snow ticket, this is where filenames with & would not delete since on the file system and in the database they would be encoded however when they would be indexed for deletion that check had the files decoded. Since &amp; does not equal & it would not delete.