### PR TITLE
LEAF-3231 Update orgchart_* widget customization

### DIFF
--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -858,9 +858,7 @@
                 }
             };
             <!--{/if}-->
-            if(grpSel != undefined) {
-                var grpSel = {};
-            }
+            var leaf_groupSelector = leaf_groupSelector ?? {};
             $(function() {
                 function initGroupSelector() {
                     let grpSel = new groupSelector('grpSel_<!--{$indicator.indicatorID}-->');
@@ -882,20 +880,21 @@
                     return grpSel;
                 }
 
-                if(typeof groupSelector == 'undefined') {
-                    $('head').append('<link type="text/css" rel="stylesheet" href="<!--{$orgchartPath}-->/css/groupSelector.css" />');
-                    $.ajax({
-                        type: 'GET',
-                        url: "<!--{$orgchartPath}-->/js/groupSelector.js",
-                        dataType: 'script',
-                        success: function() {
-                        	grpSel[<!--{$indicator.indicatorID}-->] = initGroupSelector();
-                        }
-                    });
-                }
-                else {
-                	grpSel[<!--{$indicator.indicatorID}-->] = initGroupSelector();
-                }
+                leaf_groupSelector[<!--{$indicator.indicatorID}-->] = new Promise((resolve, reject) => {
+                    if(typeof groupSelector == 'undefined') {
+                        $('head').append('<link type="text/css" rel="stylesheet" href="<!--{$orgchartPath}-->/css/groupSelector.css" />');
+                        resolve($.ajax({
+                            type: 'GET',
+                            url: "<!--{$orgchartPath}-->/js/groupSelector.js",
+                            dataType: 'script'
+                        }).then(function() {
+                            return initGroupSelector();
+                        }));
+                    }
+                    else {
+                        resolve(initGroupSelector());
+                    }
+                });
             });
             </script>
             <!--{$indicator.html}-->
@@ -948,9 +947,7 @@
             <div id="posSel_<!--{$indicator.indicatorID|strip_tags}-->"></div>
             <input id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" style="visibility: hidden" />
             <script>
-            if(posSel == undefined) {
-                var posSel = {};
-            }
+            var leaf_positionSelector = leaf_positionSelector ?? {};
             $(function() {
                 function initPositionSelector() {
                     let posSel = new positionSelector('posSel_<!--{$indicator.indicatorID}-->');
@@ -973,20 +970,21 @@
                     return posSel;
                 }
 
-                if(typeof positionSelector == 'undefined') {
-                    $('head').append('<link type="text/css" rel="stylesheet" href="<!--{$orgchartPath}-->/css/positionSelector.css" />');
-                    $.ajax({
-                        type: 'GET',
-                        url: "<!--{$orgchartPath}-->/js/positionSelector.js",
-                        dataType: 'script',
-                        success: function() {
-                            posSel[<!--{$indicator.indicatorID}-->] = initPositionSelector();
-                        }
-                    });
-                }
-                else {
-                    posSel[<!--{$indicator.indicatorID}-->] = initPositionSelector();
-                }
+                leaf_positionSelector[<!--{$indicator.indicatorID}-->] = new Promise((resolve, reject) => {
+                    if(typeof positionSelector == 'undefined') {
+                        $('head').append('<link type="text/css" rel="stylesheet" href="<!--{$orgchartPath}-->/css/positionSelector.css" />');
+                        resolve($.ajax({
+                            type: 'GET',
+                            url: "<!--{$orgchartPath}-->/js/positionSelector.js",
+                            dataType: 'script'
+                        }).then(function() {
+                            return initPositionSelector();
+                        }));
+                    }
+                    else {
+                        resolve(initPositionSelector());
+                    }
+                });
             });
             <!--{if $indicator.required == 1}-->
             formRequired["id<!--{$indicator.indicatorID}-->"] = {
@@ -1015,9 +1013,7 @@
             <input id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" value="<!--{$indicator.value|sanitize}-->" style="display: none" />
 
             <script>
-            if(empSel == undefined) {
-                var empSel = {};
-            }
+            var leaf_employeeSelector = leaf_employeeSelector ?? {};
             $(function() {
                 if($('#<!--{$indicator.indicatorID|strip_tags}-->').val() != '') {
                     $('#btn_removeEmployee_<!--{$indicator.indicatorID}-->').css('display', 'inline');
@@ -1051,18 +1047,18 @@
                     }
                 }
 
-                function empSearchSuccess() {
-                    empSel[<!--{$indicator.indicatorID}-->] = new nationalEmployeeSelector('empSel_<!--{$indicator.indicatorID}-->');
-                    empSel[<!--{$indicator.indicatorID}-->].apiPath = '<!--{$orgchartPath}-->/api/';
-                    empSel[<!--{$indicator.indicatorID}-->].rootPath = '<!--{$orgchartPath}-->/';
+                function initEmployeeSelector() {
+                    let empSel = new nationalEmployeeSelector('empSel_<!--{$indicator.indicatorID}-->');
+                    empSel.apiPath = '<!--{$orgchartPath}-->/api/';
+                    empSel.rootPath = '<!--{$orgchartPath}-->/';
 
-                    empSel[<!--{$indicator.indicatorID}-->].setSelectHandler(function() {
-                        importFromNational(empSel[<!--{$indicator.indicatorID}-->]);
+                    empSel.setSelectHandler(function() {
+                        importFromNational(empSel);
                     });
-                    empSel[<!--{$indicator.indicatorID}-->].setResultHandler(function() {
-                        importFromNational(empSel[<!--{$indicator.indicatorID}-->]);
+                    empSel.setResultHandler(function() {
+                        importFromNational(empSel);
                     });
-                    empSel[<!--{$indicator.indicatorID}-->].initialize();
+                    empSel.initialize();
                     <!--{if $indicator.value != ''}-->
                     $.ajax({
                         type: 'GET',
@@ -1075,31 +1071,34 @@
                             var middle = res.employee.middleName;
 
                             var formatted = last + ", " + first + " " + middle;
-                            var query = empSel[<!--{$indicator.indicatorID}-->].runSearchQuery("userName:" + res.employee.userName);
+                            var query = empSel.runSearchQuery("userName:" + res.employee.userName);
                             //here, updates search field value when modal is opened
-                            $("#"+ empSel[<!--{$indicator.indicatorID}-->].prefixID+"input").val("userName:" + res.employee.userName);
+                            $("#"+ empSel.prefixID+"input").val("userName:" + res.employee.userName);
                             query.done(function() {
-                                empSel[<!--{$indicator.indicatorID}-->].select("<!--{$indicator.value|strip_tags|escape|trim}-->");
+                                empSel.select("<!--{$indicator.value|strip_tags|escape|trim}-->");
                             });
                         }
                     });
                     <!--{/if}-->
+
+                    return empSel;
                 }
 
-                if(typeof nationalEmployeeSelector == 'undefined') {
-                    $('head').append('<link type="text/css" rel="stylesheet" href="<!--{$orgchartPath}-->/css/employeeSelector.css" />');
-                    $.ajax({
-                        type: 'GET',
-                        url: "<!--{$orgchartPath}-->/js/nationalEmployeeSelector.js",
-                        dataType: 'script',
-                        success: function() {
-                            empSearchSuccess();
-                        }
-                    });
-                }
-                else {
-                    empSearchSuccess();
-                }
+                leaf_employeeSelector[<!--{$indicator.indicatorID}-->] = new Promise((resolve, reject) => {
+                    if(typeof nationalEmployeeSelector == 'undefined') {
+                        $('head').append('<link type="text/css" rel="stylesheet" href="<!--{$orgchartPath}-->/css/employeeSelector.css" />');
+                        resolve($.ajax({
+                            type: 'GET',
+                            url: "<!--{$orgchartPath}-->/js/nationalEmployeeSelector.js",
+                            dataType: 'script'
+                        }).then(function() {
+                            return initEmployeeSelector();
+                        }));
+                    }
+                    else {
+                        resolve(initEmployeeSelector());
+                    }
+                });
             });
             <!--{if $indicator.required == 1}-->
             formRequired["id<!--{$indicator.indicatorID}-->"] = {


### PR DESCRIPTION
This is an attempt to re-merge[ PR#1713](https://github.com/department-of-veterans-affairs/LEAF/pull/1713), which didn't make it into prod.

This implements JS promises in orgchart_* widgets, intended to be used within customizations. Promises must be used since the widget can potentially load asynchronously.

Example to disable the standard orgchart_group widget:
```js
    let fieldID = 5;
    leaf_groupSelector[fieldID].then(grpSel => {
    	grpSel.disableSearch();
    });
```