### PR TITLE
Leaf-3335 sync services added a db cleanup

### DIFF
--- a/LEAF_Request_Portal/admin/Group.php
+++ b/LEAF_Request_Portal/admin/Group.php
@@ -174,6 +174,25 @@ class Group
     }
 
     /**
+     *
+     * @return void
+     *
+     * Created at: 12/8/2022, 10:45:57 AM (America/New_York)
+     */
+    public function cleanDb(): void
+    {
+        $sql_vars = array(':locallyManaged' => 0,
+                          ':active' => 0);
+
+        $sql = 'DELETE
+                FROM users
+                WHERE locallyManaged = :locallyManaged
+                AND active = :active';
+
+        $this->db->prepared_query($sql, $sql_vars);
+    }
+
+    /**
      * return array of userIDs
      * @param int $groupID
      *

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -862,7 +862,7 @@ class System
     /**
      * Set primary admin.
      *
-     * @return array array with response array
+     * @return string json is string
      */
     public function setPrimaryAdmin()
     {
@@ -937,6 +937,10 @@ class System
      */
     public function syncSystem(\Group $org_group, \Service $org_service, \OrgChart\Group $nexus_group, \OrgChart\Employee $nexus_employee, \OrgChart\Tag $nexus_tag, \OrgChart\Position $nexus_position): string
     {
+        // this is needed to clean up some databases where a user is currently not
+        // locally managed and they are also not active
+        $org_group->cleanDb();
+
         $nexus_services = array();
         $nexus_chiefs = array();
         $nexus_groups = array();


### PR DESCRIPTION
Here if a portal db has a user that is currently LocallyManaged = 0 and active = 0 performing a sync services will not do anything with that person. With this update the db is getting cleaned by removing all records that are LocallyManaged = 0 and active = 0. Thereby putting them back into the list of active users, so long as they are listed on the Nexus side.