### PR TITLE
LEAF 3350  form entry scroll behavior

### DIFF
--- a/LEAF_Request_Portal/templates/form.tpl
+++ b/LEAF_Request_Portal/templates/form.tpl
@@ -133,6 +133,9 @@ function updateProgress(focusNext=false) {
                 $('#nextQuestion').focus();
             }
         },
+        error: function(err) {
+            console.log('an error occurred during form progress checking', err);
+        },
         cache: false
     });
 }

--- a/LEAF_Request_Portal/templates/form.tpl
+++ b/LEAF_Request_Portal/templates/form.tpl
@@ -114,7 +114,7 @@ function onKeyPressClick(event){
     }
 }
 
-function updateProgress() {
+function updateProgress(focusNext=false) {
     $.ajax({
         type: 'GET',
         url: "./api/form/<!--{$recordID}-->/progress",
@@ -127,6 +127,10 @@ function updateProgress() {
             else {
                 savechange = '<div tabindex="0" class="buttonNorm" onkeypress="if(event.keyCode === 13){ manualSaveChange(); }" onclick="manualSaveChange();"><div id="save_indicator"><img src="../libs/dynicons/?img=media-floppy.svg&amp;w=22" alt="save" style="vertical-align: middle" /> Save Change</div></button>';
                 $('#progressControl').html(savechange);
+            }
+            window.scrollTo(0,0);
+            if(focusNext===true){
+                $('#nextQuestion').focus();
             }
         },
         cache: false
@@ -240,7 +244,7 @@ $(function() {
         form.dialog().indicateBusy();
         form.setPostModifyCallback(function() {
             getNext();
-            updateProgress();
+            updateProgress(true);
         });
         form.dialog().clickSave();
     });
@@ -249,7 +253,7 @@ $(function() {
         form.dialog().indicateBusy();
         form.setPostModifyCallback(function() {
             getPrev();
-            updateProgress();
+            updateProgress(true);
         });
         form.dialog().clickSave();
     });


### PR DESCRIPTION
Adds a call to window.scrollTo after the progress check (form entry page only) to ensure that it is at the top.

Also focuses the top next question button if the form had been progressed through the prev or next buttons (does not affect the form nav menu), so that the tab focus also will be at the beginning of form entry.