### PR TITLE
LEAF-3308 - Missing icon on step when email notification is enabled.

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -1773,7 +1773,8 @@ function loadWorkflow(workflowID) {
                     }
                 }
 
-            	  $('#workflow').append('<div tabindex="0" class="workflowStep" id="step_'+ res[i].stepID +'">'+ res[i].stepTitle +'</div><div class="workflowStepInfo" id="stepInfo_'+ res[i].stepID +'"></div>');
+                $('#workflow').append('<div tabindex="0" class="workflowStep" id="step_'+ res[i].stepID +'">'+ res[i].stepTitle + ' ' + emailNotificationIcon + '</div><div class="workflowStepInfo" id="stepInfo_'+ res[i].stepID +'"></div>');
+                
             	$('#step_' + res[i].stepID).css({
             		'left': parseFloat(res[i].posX) + 'px',
             		'top': posY + 'px',


### PR DESCRIPTION
Hotfix/leaf 3308/email notification icon missing

Missing Icon
![image](https://user-images.githubusercontent.com/94810508/207968938-8302f318-7bb9-4e65-a2c0-744d32057f5b.png)
