### PR TITLE
LEAF-3351 - Development env nginx settings

### DIFF
--- a/docker/nginx/leaf_nginx.conf.template
+++ b/docker/nginx/leaf_nginx.conf.template
@@ -35,25 +35,6 @@ server {
         gzip on;
     }
     
-    # static files browser caching
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
-        #how long a browser should wait on checking for new cache
-        expires 1m;
-        #leave these out of the access log, who cares if someone access the leaf logo at 1245 pm
-        access_log off;
-        add_header Vary Accept-Encoding;
-        #send the whole file
-        #tcp_nodelay off;
-        #If many changes to the file it can cause the file not to load, waiting the 45s between file changes keeps it
-        #from failing. This should not be too much of an issue on live and helps perf
-        #open_file_cache max=3000 inactive=120s;
-        #open_file_cache_valid 45s;
-        #open_file_cache_min_uses 2;
-        #open_file_cache_errors off;
-        #the magic sauce to bust a cache
-        etag on;
-    }
-
     location ~ /api/(.*?)$ {
         fastcgi_pass ${LEAF_POD}:9000;
         fastcgi_buffers 16 16k;
@@ -75,6 +56,25 @@ server {
         add_header x-debug-root-script "$document_root$fastcgi_script_name" always;
         add_header x-debug-path-info "$fastcgi_path_info" always;
         add_header x-debug-args-info "$args" always;
+    }
+
+    # static files browser caching
+    location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+        #how long a browser should wait on checking for new cache
+        expires 1m;
+        #leave these out of the access log, who cares if someone access the leaf logo at 1245 pm
+        access_log off;
+        add_header Vary Accept-Encoding;
+        #send the whole file
+        #tcp_nodelay off;
+        #If many changes to the file it can cause the file not to load, waiting the 45s between file changes keeps it
+        #from failing. This should not be too much of an issue on live and helps perf
+        #open_file_cache max=3000 inactive=120s;
+        #open_file_cache_valid 45s;
+        #open_file_cache_min_uses 2;
+        #open_file_cache_errors off;
+        #the magic sauce to bust a cache
+        etag on;
     }
 
     #location /adminer {

--- a/docker/nginx/leaf_nginx.conf.template
+++ b/docker/nginx/leaf_nginx.conf.template
@@ -15,6 +15,8 @@ server {
     ssl_protocols TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
+    port_in_redirect off;
+
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
 


### PR DESCRIPTION
adjust the nginx settings for dev so api calls work correctly.  

Testing area that showed this issue was deleting files within the file manager, other areas should be tested as well to make sure this change did not interfere.