### PR TITLE
LEAF 3217 checkboxes format for IFTHEN

### DIFF
--- a/LEAF_Request_Portal/admin/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/admin/templates/print_subindicators.tpl
@@ -71,7 +71,7 @@
 
                     &nbsp;<img src="../../libs/dynicons/?img=accessories-text-editor.svg&amp;w=16" tabindex="0" onkeypress="keyPressGetForm(event, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" alt="Edit this field" title="Edit this field" style="cursor: pointer" />
                     &nbsp;<img src="../../libs/dynicons/?img=emblem-readonly.svg&amp;w=16" tabindex="0" onkeypress="keyPressEditIndicatorPrivileges(event, <!--{$indicator.indicatorID}-->)" onclick="editIndicatorPrivileges(<!--{$indicator.indicatorID}-->);" alt="Edit indicator privileges" title="Edit indicator privileges" style="cursor: pointer" />
-                    <!--{if $indicator.format|in_array:['text','dropdown','multiselect','radio']}-->
+                    <!--{if $indicator.format|in_array:['text','dropdown','multiselect','radio', 'checkboxes']}-->
                         &nbsp;<img id="edit_conditions_<!--{$indicator.indicatorID}-->" src="../../libs/dynicons/?img=preferences-system.svg&amp;w=16" tabindex="0" onkeypress="updateVueData(<!--{$indicator.indicatorID}-->)" onclick="updateVueData(<!--{$indicator.indicatorID}-->,<!--{$indicator.required}-->);" alt="Edit Conditions" title="Edit conditions" style="cursor: pointer" />
                     <!--{/if}-->
                     <!--{if $indicator.has_code}-->

--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -102,6 +102,9 @@ input[class*="icheck"][class*="leaf_check"]:checked ~ span.leaf_check::after,
 input[class*="ischecked"][class*="leaf_check"]:checked ~ span.leaf_check::after {
     display: block;
 }
+input:disabled ~ span.leaf_check:hover {
+    cursor: not-allowed;
+}
 
 
 /** modifications to choicesjs styles **/

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1435,7 +1435,7 @@ class Form
             } else {
                 //check if there are conditions that result in required questions being in a hidden state, and adjust percentage
                 $multiChoiceParentFormats = array('multiselect', 'checkboxes');
-                $singleChoiceParentFormats = array('radio, dropdown');
+                $singleChoiceParentFormats = array('radio', 'dropdown');
 
                 foreach ($resRequestRequired as $ind) {
                     //if a required question is not complete, and there are conditions...(conditions could potentially have the string null due to a past import issue)
@@ -1474,7 +1474,7 @@ class Form
                                             }
                                         } else if (in_array($parentFormat, $singleChoiceParentFormats) && $currentParentDataValue[0] === $conditionParentValue[0]) {
                                             $conditionMet = true;
-                                        } 
+                                        }
                                         break;
                                     case '!=':
                                         if ((in_array($parentFormat, $multiChoiceParentFormats) && !array_intersect($currentParentDataValue, $conditionParentValue)) ||
@@ -1495,7 +1495,7 @@ class Form
                         }
                     }
                 }
-                if ($countRequestRequired===0) {
+                if ($countRequestRequired === 0) {
                     $returnValue = 100;
                 } else {
                     $returnValue = round(100 * ($resCountCompletedRequired/$countRequestRequired));

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1398,9 +1398,19 @@ class Form
             $resCountCompletedRequired = 0;
             $resCompletedIndIDs = array();
             foreach($resCompleted as $entry) {
-                $resCompletedIndIDs[(int)$entry['indicatorID']] = $entry['data'];
-                if((int)$entry['required'] === 1) {
-                    $resCountCompletedRequired++;
+                $arrData = @unserialize($entry['data']) === false ? array($entry['data']) : unserialize($entry['data']);
+                //need to filter out checkboxes entries that have all 'no' values
+                $allNo = true;
+                foreach ($arrData as $ele) {
+                    if($ele !== 'no') {
+                        $allNo = false;
+                    };
+                }
+                if ($allNo === false) {
+                    $resCompletedIndIDs[(int) $entry['indicatorID']] = $entry['data'];
+                    if ((int) $entry['required'] === 1) {
+                        $resCountCompletedRequired++;
+                    }
                 }
             }
         
@@ -1423,6 +1433,9 @@ class Form
                 $returnValue = 100;
 
             } else {
+                //check if there are conditions that result in required questions being in a hidden state, and adjust percentage
+                $multiChoiceParentFormats = array('multiselect', 'checkboxes');
+                $singleChoiceParentFormats = array('radio, dropdown');
 
                 foreach ($resRequestRequired as $ind) {
                     //if a required question is not complete, and there are conditions...(conditions could potentially have the string null due to a past import issue)
@@ -1435,40 +1448,37 @@ class Form
                         foreach ($conditions as $c) {
                             //only continue if:
                             if ($c->childFormat === $currFormat //current format and condition format matches
-                                && (strtolower($c->selectedOutcome)==='hide' || strtolower($c->selectedOutcome)==='show') //outcome is hide or show
-                                && in_array((int)$c->parentIndID, array_keys($resCompletedIndIDs))) { //and parent data exists
+                                && (strtolower($c->selectedOutcome) === 'hide' || strtolower($c->selectedOutcome ) === 'show') //outcome is hide or show
+                                && in_array((int)$c->parentIndID, array_keys($resCompletedIndIDs))) { //and parent data exists and is not all 'no' (unchecked checkboxes format)
 
                                 $parentFormat = $c->parentFormat;
-
+                                $conditionParentValue = preg_split('/\R/', $c->selectedParentValue) ?? [];
                                 $currentParentDataValue =  preg_replace('/&apos;/', '&#039;', $resCompletedIndIDs[(int)$c->parentIndID]);
-                                if ($parentFormat==='multiselect') {
+                                if (in_array($parentFormat, $multiChoiceParentFormats)) {
                                     $currentParentDataValue = @unserialize($currentParentDataValue) === false ? array($currentParentDataValue) : unserialize($currentParentDataValue);
                                 } else {
                                     $currentParentDataValue = array($currentParentDataValue);
                                 }
                                 
-                                $conditionParentValue = preg_split('/\R/', $c->selectedParentValue) ?? [];
                                 $operator = $c->selectedOp;
 
                                 switch($operator) {
                                     case '==':
-                                        if ($parentFormat === 'multiselect') { //true if the current data value includes any of the condition values
+                                        if (in_array($parentFormat, $multiChoiceParentFormats)) {
+                                            //true if the current data value includes any of the condition values
                                             foreach ($currentParentDataValue as $v) {
                                                 if (in_array($v, $conditionParentValue)) {
                                                     $conditionMet = true;
                                                     break;
                                                 }
                                             }
-                                        } else if (($parentFormat === 'dropdown' || $parentFormat === 'radio')
-                                            && $currentParentDataValue[0] === $conditionParentValue[0]) {
+                                        } else if (in_array($parentFormat, $singleChoiceParentFormats) && $currentParentDataValue[0] === $conditionParentValue[0]) {
                                             $conditionMet = true;
                                         } 
                                         break;
                                     case '!=':
-                                        if (($parentFormat === 'multiselect' && !array_intersect($currentParentDataValue, $conditionParentValue))
-                                            || 
-                                            (($parentFormat === 'dropdown' || $parentFormat === 'radio')
-                                            && $currentParentDataValue[0] !== $conditionParentValue[0])) {
+                                        if ((in_array($parentFormat, $multiChoiceParentFormats) && !array_intersect($currentParentDataValue, $conditionParentValue)) ||
+                                            (in_array($parentFormat, $singleChoiceParentFormats) && $currentParentDataValue[0] !== $conditionParentValue[0])) {
                                             $conditionMet = true;
                                         } 
                                         break;
@@ -1478,7 +1488,7 @@ class Form
 
                             }
                             //if the question is not being shown due to its conditions, do not count it as a required question
-                            if(($conditionMet===false && strtolower($c->selectedOutcome) === 'show') || ($conditionMet===true && strtolower($c->selectedOutcome) === 'hide')) {
+                            if(($conditionMet === false && strtolower($c->selectedOutcome) === 'show') || ($conditionMet === true && strtolower($c->selectedOutcome) === 'hide')) {
                                 $countRequestRequired--;
                                 break;
                             }

--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -75,7 +75,10 @@ var LeafForm = function(containerID) {
                 linkedChildConditions.push(...getConditionsLinkedToChild(id, parentElID)); //get all other possible parents controlling the above children
             });
 
-            const allConditions = [...linkedParentConditions, ...linkedChildConditions];
+            let allConditions = [...linkedParentConditions, ...linkedChildConditions];
+            let hideShowConditions = allConditions.filter(c => ['show', 'hide'].includes(c.selectedOutcome.toLowerCase()));
+            let prefillConditions = allConditions.filter(c => !['show', 'hide'].includes(c.selectedOutcome.toLowerCase()));
+            allConditions = [...hideShowConditions, ...prefillConditions]; //orders them so that prefills would be last
 
             const conditionsByChild = {}
             allConditions.map(c => {

--- a/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
+++ b/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
@@ -49,7 +49,7 @@ const ConditionsEditor = Vue.createApp({
                 url: '../api/form/indicator/list/unabridged',
                 success: (res)=> {
                     const list = res;
-                    const filteredList = list.filter(ele => parseInt(ele.indicatorID) > 0 && parseInt(ele.isDisabled)===0);
+                    const filteredList = list.filter(ele => parseInt(ele.indicatorID) > 0 && parseInt(ele.isDisabled) === 0);
                     this.indicators = filteredList;
                     
                     /* this.indicators.forEach(i => {
@@ -101,9 +101,9 @@ const ConditionsEditor = Vue.createApp({
             
             const indicator = this.indicators.find(i => indicatorID !== null && parseInt(i.indicatorID) === parseInt(indicatorID));
             //handle scenario if a parent is archived/deleted
-            if(indicator===undefined) {
+            if(indicator === undefined) {
                 this.parentFound = false;
-                this.selectedDisabledParentID = indicatorID===0 ? this.selectedDisabledParentID : parseInt(indicatorID);
+                this.selectedDisabledParentID = indicatorID === 0 ? this.selectedDisabledParentID : parseInt(indicatorID);
                 return;
             } else {
                 this.parentFound = true;
@@ -238,7 +238,7 @@ const ConditionsEditor = Vue.createApp({
                     const form = res;
                     form.forEach((formheader, index) => {
                         this.indicators.forEach(ind => {
-                            if (parseInt(ind.headerIndicatorID)===parseInt(formheader.indicatorID)){
+                            if (parseInt(ind.headerIndicatorID) === parseInt(formheader.indicatorID)){
                                 ind.formPage = index;
                             }
                         })
@@ -256,7 +256,7 @@ const ConditionsEditor = Vue.createApp({
             if (!parent || !parent.parentIndicatorID) {
                 //debug this.indicatorOrg[parentIndicatorID].indicators[initialIndicator.indicatorID] = {...initialIndicator, headerIndicatorID: parentIndicatorID};
                 //add information about the headerIndicatorID to the indicators
-                let indToUpdate = this.indicators.find(i => parseInt(i.indicatorID)===parseInt(initialIndicator.indicatorID));
+                let indToUpdate = this.indicators.find(i => parseInt(i.indicatorID) === parseInt(initialIndicator.indicatorID));
                 indToUpdate.headerIndicatorID = parentIndicatorID;
             } else {
                 this.crawlParents(parent, initialIndicator);
@@ -327,7 +327,7 @@ const ConditionsEditor = Vue.createApp({
                 const { childIndID, parentIndID, selectedOutcome, selectedChildValue } = data.condition;
                 
                 if (childIndID !== undefined) {
-                    const hasActiveParentIndicator = this.indicators.some(ele => parseInt(ele.indicatorID)===parseInt(parentIndID));
+                    const hasActiveParentIndicator = this.indicators.some(ele => parseInt(ele.indicatorID) === parseInt(parentIndID));
                     const conditionsJSON = JSON.stringify(data.condition);
 
                     //get all conditions on this child
@@ -343,7 +343,7 @@ const ConditionsEditor = Vue.createApp({
                     if(hasActiveParentIndicator) {
                         newConditions = currConditions.filter(c => JSON.stringify(c) !== conditionsJSON);
                     } else {
-                        newConditions = currConditions.filter(c => !(c.parentIndID===this.selectedDisabledParentID && c.selectedOutcome===selectedOutcome && c.selectedChildValue===selectedChildValue))
+                        newConditions = currConditions.filter(c => !(c.parentIndID === this.selectedDisabledParentID && c.selectedOutcome === selectedOutcome && c.selectedChildValue === selectedChildValue))
                     }
                     
                     if (newConditions.length === 0) newConditions = null;
@@ -527,7 +527,7 @@ const ConditionsEditor = Vue.createApp({
                 elSelectParent.choicesjs = choices;
             }
 
-            if(outcome==='pre-fill' && this.multiOptionFormats.includes(childFormat) && elSelectChild !== null && elExistingChoicesChild===null) {
+            if(outcome === 'pre-fill' && this.multiOptionFormats.includes(childFormat) && elSelectChild !== null && elExistingChoicesChild === null) {
                 let options = this.selectedChildValueOptions || [];
                 let arrValues = this.conditions?.selectedChildValue.split('\n') || [];
                 arrValues = arrValues.map(v => this.textValueDisplay(v).trim());
@@ -599,7 +599,7 @@ const ConditionsEditor = Vue.createApp({
                     childIndID !== 0 && parentIndID !== 0 && 
                     selectedOp !== '' && selectedParentValue !== '' &&
                     (selectedOutcome && selectedOutcome.toLowerCase() !== "pre-fill" ||
-                    (selectedOutcome.toLowerCase()==="pre-fill" && selectedChildValue !== ''))
+                    (selectedOutcome.toLowerCase() === "pre-fill" && selectedChildValue !== ''))
                 );
         },
         /**


### PR DESCRIPTION
Adds checkboxes as both a parent and child format to the conditions editor.

Also reworked some of the comparison logic that occurs on the form data entry page to make it easier to follow, and added styles for checkboxes and radio buttons that have the disabled attribute.