### PR TITLE
LEAF 3392 ELT access issue

### DIFF
--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -66,7 +66,7 @@ class FormWorkflow
      * @return array database result
      * @return null if no database result
      */
-    public function getCurrentSteps(): ?array
+    public function getCurrentSteps(): array|int|null
     {
         // check privileges
         require_once 'form.php';
@@ -120,7 +120,7 @@ class FormWorkflow
                         ':quadGroupIDs' => $quadGroupIDs
                     );
                     $strSQL = 'SELECT * FROM services
-                        WHERE groupID IN (:quadGroupIDs)
+                        WHERE find_in_set(groupID, :quadGroupIDs)
                         AND serviceID = :serviceID';
                     $res3 = $this->db->prepared_query($strSQL, $vars3);
 

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -193,7 +193,6 @@ switch ($action) {
         $tabText = 'Workflow Editor';
 
         break;
-    /*
     case 'form_vue':
         $t_form = new Smarty;
         $t_form->left_delimiter = '<!--{';
@@ -229,7 +228,6 @@ switch ($action) {
 
         $tabText = 'Form Editor Testing';        
         break;
-    */
     case 'form':
         $t_form = new Smarty;
         $t_form->left_delimiter = '<!--{';


### PR DESCRIPTION
This addresses an issue that can affect the 'hasAccess' value for users who are members of more than one ELT group, and prevent the action buttons from appearing during the request workflow.  This also resolves an error caused by a return value data type 