### PR TITLE
LEAF 3336 escape quotes and apos in indicator names

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -525,7 +525,8 @@ function editIndicatorPrivileges(indicatorID) {
     portalAPI.FormEditor.getIndicator(
         indicatorID,
         function(indicator) {
-            const indicatorName = indicator[indicatorID]?.name || '[blank]';
+            let indicatorName = indicator[indicatorID]?.name || '[blank]';
+            indicatorName = indicatorName.replace(/"/g, '&quot;').replace(/'/g, '\\\'');
             dialog_simple.setTitle('Edit Indicator Read Privileges - ' + indicatorID);
             portalAPI.FormEditor.getIndicatorPrivileges(indicatorID,
                 function (groups) {

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -527,6 +527,7 @@ function editIndicatorPrivileges(indicatorID) {
         function(indicator) {
             let indicatorName = indicator[indicatorID]?.name || '[blank]';
             indicatorName = indicatorName.replace(/"/g, '&quot;').replace(/'/g, '\\\'');
+            indicatorName = indicatorName.replaceAll('\n', '').trim();
             dialog_simple.setTitle('Edit Indicator Read Privileges - ' + indicatorID);
             portalAPI.FormEditor.getIndicatorPrivileges(indicatorID,
                 function (groups) {


### PR DESCRIPTION
This should resolve formatting issues that can occur on the indicator privileges modal if the indicator name contains quotes or apostrophes.