### PR TITLE
Mitigate issue when "filled" status isn't updated

### DIFF
--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -90,7 +90,7 @@ class FormWorkflow
         $numRes = count($res);
         if ($numRes > 0)
         {
-            if ($numRes == 1 && $res[0]['dependencyID'] < 0 && $res[0]['filled'] == 1) {
+            if ($numRes == 1 && $res[0]['filled'] == 1) {
                 $res[0]['filled'] = 0;
             }
 

--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -78,21 +78,27 @@ class FormWorkflow
 
         $steps = array();
         $vars = array(':recordID' => $this->recordID);
-        $strSQL = 'SELECT dependencyID, recordID, stepID, stepTitle, blockingStepID, workflowID, serviceID, stepBgColor, stepFontColor, stepBorder, description, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, jsSrc, userID, requiresDigitalSignature FROM records_workflow_state
+        $strSQL = 'SELECT dependencyID, recordID, stepID, stepTitle, blockingStepID, workflowID, serviceID, filled, stepBgColor, stepFontColor, stepBorder, description, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, jsSrc, userID, requiresDigitalSignature FROM records_workflow_state
             LEFT JOIN records USING (recordID)
             LEFT JOIN workflow_steps USING (stepID)
             LEFT JOIN step_dependencies USING (stepID)
             LEFT JOIN dependencies USING (dependencyID)
             LEFT JOIN records_dependencies USING (recordID, dependencyID)
-            WHERE recordID = :recordID
-            AND (filled = 0 OR filled IS NULL)';
+            WHERE recordID = :recordID';
         $res = $this->db->prepared_query($strSQL, $vars);
 
         $numRes = count($res);
         if ($numRes > 0)
         {
+            if ($numRes == 1 && $res[0]['dependencyID'] < 0 && $res[0]['filled'] == 1) {
+                $res[0]['filled'] = 0;
+            }
+
             for ($i = 0; $i < $numRes; $i++)
             {
+                if ($res[$i]['filled'] == 1) {
+                    continue;
+                }
                 $res[$i]['dependencyActions'] = $this->getDependencyActions($res[$i]['workflowID'], $res[$i]['stepID']);
                 // override access if user is in the admin group
                 $res[$i]['hasAccess'] = $this->login->checkGroup(1); // initialize hasAccess


### PR DESCRIPTION
This mitigates an issue within FormWorkflow.php -> handleAction() where the following conditions exist:

1. The filled status within the records_dependency table is not written correctly due to an aborted request
2. The workflow contains two sequential steps that utilize the same dependencyID

Solving # 1 would also resolve the problem, however it's riskier due to its complexity and therefore not suited within a hotfix.

To reproduce the problem:
1. Create a workflow: Start -> Step A -> Step B -> End
2. Start a request and advance the workflow to Step B
3. Edit the database: records_dependency, and set filled = 1 for the respective request ID. This simulates the server interruption.
4. When viewing the request, note that the workflow does not show any action buttons
