### PR TITLE
LEAF-3420 Add missing groupID

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -630,7 +630,7 @@ class Form
 
 
         $res = $this->db->prepared_query(
-            'SELECT h.recordID, h.indicatorID, h.series, h.data, h.timestamp, h.userID, i.is_sensitive
+            'SELECT h.recordID, h.indicatorID, h.series, h.data, h.timestamp, h.userID, i.is_sensitive, groupID
                 FROM data_history h
                     LEFT JOIN indicator_mask USING (indicatorID)
                     LEFT JOIN indicators i USING (indicatorID)


### PR DESCRIPTION
This missing groupID prevents the following access check from working correctly.

```js
if (isset($line['groupID']))
```
