### PR TITLE
LEAF-3424 - Email Reminders not working on National sites

### DIFF
--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -58,7 +58,7 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
     $getRecordSql = 'SELECT records.recordID, records.title, records.userID, service 
         FROM records_workflow_state
         JOIN records ON records.recordID = records_workflow_state.recordID
-        JOIN services USING(serviceID) 
+        LEFT JOIN services USING(serviceID) 
         WHERE records_workflow_state.stepID = :stepID
         AND lastNotified <= :lastNotified
         AND deleted = 0;';


### PR DESCRIPTION
Nationals do not normally use services. Add in flexibility to allow for services to exist or not.

Local replication, take a request that is currently on the step that an email reminder would go out. In the database remove the service (set it to 0 which is how nationals work). Then run the email reminder script from with in the scripts folder.

I would also suggest we get a demo national and a demo vax portal for us to specifically test.