### PR TITLE
LEAF 2459 add warning to subordinate sites

### DIFF
--- a/LEAF_Request_Portal/admin/css/style.css
+++ b/LEAF_Request_Portal/admin/css/style.css
@@ -736,6 +736,10 @@ div#emailReminder input,  div#emailReminder .chosen-container {
 div#emailReminder .groupSelectorInput {
     margin-bottom: 0px;
 }
+div#subordinate_site_warning {
+    padding: 0.25rem 0.5rem;
+    background-color: #ffffc0;
+}
 
 @media(max-width: 520px) {
     #header:not(.usa-header) {

--- a/LEAF_Request_Portal/admin/templates/form_editor_vue.tpl
+++ b/LEAF_Request_Portal/admin/templates/form_editor_vue.tpl
@@ -1,4 +1,8 @@
 <div id="vue-formeditor-app">
+    <div v-if="siteSettings.siteType === 'national_subordinate'" id="subordinate_site_warning">
+        <h3>This is a Nationally Standardized Subordinate Site</h3>
+        <span>Do not make modifications! &nbsp;Synchronization problems will occur. &nbsp;Please contact your process POC if modifications need to be made.</span>
+    </div>
     <mod-form-menu></mod-form-menu>
     <div style="display:flex; max-width: 2000px; margin: auto;">
         <!-- CATEGORY BROWSER / RESTORE FIELDS -->

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -2002,7 +2002,7 @@ function viewHistory(categoryId){
 /**
  * Purpose: Check for Secure Form Certifcation
  * @param searchResolved
- * @returns {*|jQuery}
+ * @returns { *|jQuery}
  */
 function fetchLEAFSRequests(searchResolved) {
     let deferred = $.Deferred();
@@ -2027,7 +2027,7 @@ function fetchLEAFSRequests(searchResolved) {
 
 /**
  * Purpose: Get all Indicators on Form
- * @returns {*|jQuery}
+ * @returns { *|jQuery}
  */
 function fetchIndicators() {
     let deferred = $.Deferred();
@@ -2052,6 +2052,13 @@ function fetchFormSecureInfo() {
         cache: false
     })
     .then(function(res) {
+        const siteType = res?.siteType || '';
+        if (siteType.toLowerCase() === 'national_subordinate') {
+            let warnContent = `<div id="subordinate_site_warning"><h3>This is a Nationally Standardized Subordinate Site</h3>`;
+            warnContent += `<span>Do not make modifications! &nbsp;Synchronization problems will occur. &nbsp;`;
+            warnContent += `Please contact your process POC if modifications need to be made.</span></div>`;
+            $('#bodyarea').prepend(warnContent);
+        }
         renderSecureFormsInfo(res)
     });
 }

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2103,6 +2103,22 @@ $(function() {
     jsPlumb.Defaults.Endpoint = "Blank";
 
     loadWorkflowList();
+
+    $.ajax({
+        type: 'GET',
+        url: '../api/system/settings',
+        success: res => {
+            const siteType = res?.siteType || '';
+            if (siteType.toLowerCase() === 'national_subordinate') {
+                let warnContent = `<div id="subordinate_site_warning"><h3>This is a Nationally Standardized Subordinate Site</h3>`;
+                warnContent += `<span>Do not make modifications! &nbsp;Synchronization problems will occur. &nbsp;`;
+                warnContent += `Please contact your process POC if modifications need to be made.</span></div>`;
+                $('#bodyarea').prepend(warnContent);
+            }
+        },
+        error: err => console.log(err),
+        cache: false
+    })
 });
 
 </script>


### PR DESCRIPTION
Adds a banner warning users against making modifications, to the top of the Form Editor, Form Editor Refresh, and Workflow Editor views if these areas are accessed on a subordinate site.