### PR TITLE
Leaf 3431 - New query parameter: Actionable

### DIFF
--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -801,10 +801,15 @@ class FormWorkflow
       */
     public function getEmpUIDByUserName(string $userName): string
     {
+        if(isset($this->cache['getEmpUIDByUserName'.$userName])) {
+            return $this->cache['getEmpUIDByUserName'.$userName];
+        }
+
         $nexusDB = $this->login->getNexusDB();
         $vars = array(':userName' => $userName);
         $strSQL = 'SELECT * FROM employee WHERE userName = :userName';
-        return $nexusDB->prepared_query($strSQL, $vars)[0]["empUID"];
+        $this->cache['getEmpUIDByUserName'.$userName] = $nexusDB->prepared_query($strSQL, $vars)[0]["empUID"];
+        return $this->cache['getEmpUIDByUserName'.$userName];
     }
 
     /**

--- a/LEAF_Request_Portal/FormWorkflow.php
+++ b/LEAF_Request_Portal/FormWorkflow.php
@@ -63,7 +63,7 @@ class FormWorkflow
         return isset($res[0]);
     }
 
-    private function getDependency(int $depID) {
+    private function getDependency(int $depID): array {
         if(!isset($this->cache["dependencyID{$depID}"])) {
             $vars = array(':dependencyID' => $depID);
             $strSQL = 'SELECT * FROM dependency_privs WHERE dependencyID = :dependencyID';
@@ -73,7 +73,7 @@ class FormWorkflow
         return $this->cache["dependencyID{$depID}"];
     }
 
-    private function getServiceQuadrads(int $serviceID) {
+    private function getServiceQuadrads(int $serviceID): array {
         if(!isset($this->cache["serviceQuadrads{$serviceID}"])) {
             $quadGroupIDs = $this->login->getQuadradGroupID(); // get csv of ints
             $vars3 = array(

--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -2672,6 +2672,7 @@ class Form
 
         $joinSearchAllData = false;
         $joinSearchOrgchartEmployeeData = false;
+        $filterActionable = false;
         $vars = array();
         $conditions = '';
         $joins = '';
@@ -2874,6 +2875,12 @@ class Form
                                 $joins .= 'LEFT JOIN records_workflow_state USING (recordID) ';
 
                                 break;
+                            case 'actionable':
+                                $conditions .= "{$gate}(records_workflow_state.stepID IS NOT NULL AND submitted > 0 AND deleted = 0)";
+                                $joins .= 'LEFT JOIN records_workflow_state USING (recordID) ';
+                                $filterActionable = true;
+
+                                break;
                             default:
                                 if (is_numeric($vars[':stepID' . $count]))
                                 {
@@ -2918,6 +2925,11 @@ class Form
 
                                 break;
                             case 'notResolved': // backwards compat
+                                $conditions .= "{$gate}(records_workflow_state.stepID IS NULL AND submitted > 0 AND deleted = 0)";
+                                $joins .= 'LEFT JOIN records_workflow_state USING (recordID) ';
+
+                                break;
+                            case 'actionable':
                                 $conditions .= "{$gate}(records_workflow_state.stepID IS NULL AND submitted > 0 AND deleted = 0)";
                                 $joins .= 'LEFT JOIN records_workflow_state USING (recordID) ';
 
@@ -3409,6 +3421,32 @@ class Form
         if ($this->isNeedToKnow())
         {
             $data = $this->checkReadAccess($data);
+        }
+
+        // check actionable
+        if ($filterActionable)
+        {
+            include_once 'FormWorkflow.php';
+            $FormWorkflow = new FormWorkflow($this->db, $this->login, 0);
+
+            $actionable = $FormWorkflow->getActionable($this, $data);
+
+            $actionLookup = [];
+            foreach($actionable as $t) {
+                if(!isset($actionLookup[$t['recordID']])) {
+                    $actionLookup[$t['recordID']] = $t['isActionable'];
+                }
+            }
+            $countPurged = 0;
+            foreach($data as $i => $v) {
+                if($actionLookup[$v['recordID']] != true) {
+                    unset($data[$i]);
+                    $countPurged++;
+                }
+            }
+            if($countPurged > 0) {
+                header('LEAF-Query: continue');
+            }
         }
 
         // check if data is being requested as part of the query

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -585,6 +585,7 @@ var LeafFormSearch = function(containerID) {
 						categories += '<option value="submitted">Submitted</option>';
 						categories += '<option value="deleted">Cancelled</option>';
 						categories += '<option value="resolved">Resolved</option>';
+                        categories += '<option value="actionable">Actionable by me</option>';
 						for(var i in res) {
 							categories += '<option value="'+ res[i].stepID +'">'+ res[i].description + ': ' + res[i].stepTitle +'</option>';
 						}


### PR DESCRIPTION
The new "actionable" query parameter identifies records that the current user has pending workflow actions. This inherits features from api/form/query and will be used as part of a performant Inbox.

Testing:
- Workflow access types: admin/non-admin/groups/designated person/designated group/requestor followup
- The workflow action box should have the same behavior as before
- Report Builder: setting "Current Status IS Actionable by me" should only show records that the current user has pending actions for
- Report Builder: setting "Current Status IS NOT Actionable by me" should only show resolved requests