### PR TITLE
Leaf 3437 - Replace arbitrary pop()

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1393,8 +1393,18 @@ $(function() {
                 }
             }
             leafSearch.getLeafFormQuery().setQuery(inQuery);
+
+            // We usually don't want to see deleted requests, but this parameter still needs to be
+            // passed into the API. To simplify the user interface, the parameter is removed before
+            // rendering the view. Explicit searches for deleted requests are not affected.
             if(!isSearchingDeleted(leafSearch)) {
-                inQuery.terms.pop();
+                for(let i in inQuery.terms) {
+                    if(inQuery.terms[i].id == 'deleted'
+                        && inQuery.terms[i].operator == '='
+                        && parseInt(inQuery.terms[i].match) == 0) {
+                        inQuery.terms.splice(i, 1);
+                    }
+                }
             }
             leafSearch.renderPreviousAdvancedSearch(inQuery.terms);
             headers = headers.concat(inIndicators);


### PR DESCRIPTION
This resolves an issue when custom queries are imported into the Report Builder.

To replicate this:

Add the following script as a new page in LEAF Programmer.
```js
<script>
    let today = new Date();
    today.setDate(today.getDate() - 30);

    let query = new LeafFormQuery();
    query.addTerm('deleted', '=', 0);
    query.setLimit(10);
    query.addTerm('dateSubmitted', '>=', `${today.getMonth() + 1}/${today.getDate()}/${today.getFullYear()}`);

    let indicators = [
        {indicatorID: 1, name: 'Col 1'},
        {indicatorID: 2, name: 'Col 2'},
    ];

    let exportQuery = LZString.compressToBase64(JSON.stringify(query.getQuery()));
    let exportIndicators = LZString.compressToBase64(JSON.stringify(indicators));

    window.location.href = `index.php?a=reports&v=3&query=${exportQuery}&indicators=${exportIndicators}`;
</script>
```

Prior to this patch, this script would cause the Report Builder to incorrectly show all records.

After this patch, the Report Builder correctly shows records submitted within the past 30 days.

