### PR TITLE
LEAF 3346 - automated emails iteration after the first email

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -252,7 +252,8 @@ function addEmailReminderDialog(stepID){
     dialog.setContent(output);
     
     dialog.setValidator('reminder_days', function() {
-        if ($('#edit_email_check').prop('checked') == true && (parseInt($('#reminder_days').val()) === NaN || parseInt($('#reminder_days').val()) < 1)) {
+        reminder_days = $('#reminder_days').val();
+        if ($('#edit_email_check').prop('checked') == true && (parseInt(reminder_days) === NaN || parseInt(reminder_days) < 1) || reminder_days == '') {
             return false;
         } else {
             return true;
@@ -262,12 +263,28 @@ function addEmailReminderDialog(stepID){
     dialog.setSubmitValid('reminder_days', function() {
         alert('Number of days to remind user must be greater than 0!');
     });
+
+    dialog.setValidator('reminder_days_additional', function() {
+    
+        reminder_days_additional = $('#reminder_days_additional').val();
+        if ($('#edit_email_check').prop('checked') == true && (parseInt(reminder_days_additional) === NaN || parseInt(reminder_days_additional) < 1) || reminder_days_additional == '') {
+            return false;
+        } else {
+            return true;
+        }
+    });
+
+    dialog.setSubmitValid('reminder_days_additional', function() {
+        alert('Additional Number of days to remind user must be greater than 0!');
+    });
+
     dialog.setSaveHandler(function() {
 
         let seriesData = {
             AutomatedEmailReminders : {
                 'Automate Email Group': $('#edit_email_check').prop('checked'),
                 'Days Selected': $('#reminder_days').val(),
+                'Additional Days Selected': $('#reminder_days_additional').val(),
             }
         }
 
@@ -297,11 +314,13 @@ function addEmailReminderDialog(stepID){
         let stepParse = JSON.parse(workflowStep.stepData);
         let automateEmailGroup = stepParse.AutomatedEmailReminders?.AutomateEmailGroup;
         let daysSelected = stepParse.AutomatedEmailReminders?.DaysSelected;
+        let additionalDaysSelected = stepParse.AutomatedEmailReminders?.AdditionalDaysSelected;
 
         if (automateEmailGroup?.toLowerCase() == "true") {
             $('#edit_email_check').prop('checked', true);
             editEmailChecked();
             $("#reminder_days").val(daysSelected);
+            $("#reminder_days_additional").val(additionalDaysSelected);
         } else {
             $('#edit_email_check').prop('checked', false);
         }
@@ -314,7 +333,7 @@ function editEmailChecked() {
     let editSelectdatesString = "";
     if (emailChecked.checked) {
         editSelectdatesString += '<br>Send a reminder after <input aria-label="number of days" type="number" min="1" id="reminder_days"> days of inactivity. <br>';
-      
+        editSelectdatesString += '<br>After the initial notification send another reminder every <input aria-label="number of days additional" type="number" min="1" id="reminder_days_additional"> days of inactivity. <br>';
         createElement("div", "edit_date_select", "edit_email_container");
         document.getElementById("edit_date_select").innerHTML = editSelectdatesString;
     } else {

--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -66,23 +66,25 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
 
     $getRecordResInitial = $db->prepared_query($getRecordSql, $getRecordVar);
 
-    // PUT THE daysagotimestamp for the second query here, we will need to figure that one out!
+    // make sure additional days selected is set, this will be a required field moving forward however there is a chance this could not be set.
+    if(!empty($eventDataArray['AutomatedEmailReminders']['AdditionalDaysSelected'])) {
+        
+        $addldaysago = $eventDataArray['AutomatedEmailReminders']['AdditionalDaysSelected'];
 
-    // DateSelected * DaysSelected * what is a day anyway= how many days to bug this person.
-    $daysago = $eventDataArray['AutomatedEmailReminders']['DaysSelected'];
+        // pass ?current=asdasd to get the present time for testing purposes
+        if (!empty($_GET['current'])) {
+            $intialdaysagotimestamp = time();
+            echo "Present day, Present time \r\n";
+        } else{
+            $additionaldaysagotimestamp = time() - ($addldaysago * 60 * 60 * 24);
 
-    // pass ?current=asdasd to get the present time for testing purposes
-    if (!empty($_GET['current'])) {
-        $intialdaysagotimestamp = time();
-        echo "Present day, Present time \r\n";
-    } else{
-        $intialdaysagotimestamp = time() - ($daysago * 60 * 60 * 24);
+            echo "Working on step: {$workflowStep['stepID']}, time calculation: ".time()." - $addldaysago = $additionaldaysagotimestamp / ".date('Y-m-d H:i:s',$additionaldaysagotimestamp)."\r\n";
+        }
 
-        echo "Working on step: {$workflowStep['stepID']}, time calculation: ".time()." - $daysago = $intialdaysagotimestamp / ".date('Y-m-d H:i:s',$intialdaysagotimestamp)."\r\n";
+        // get the other entries
+        $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$additionaldaysagotimestamp)];
+
     }
-
-    // get the other entries
-    $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$intialdaysagotimestamp)];
 
     // get the records that have not been responded to, had actions taken on, in x amount of time and never been responded to
     $getRecordSql = 'SELECT records.recordID, records.title, records.userID, service 

--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -42,17 +42,17 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
 
     // pass ?current=asdasd to get the present time for testing purposes
     if (!empty($_GET['current'])) {
-        $daysagotimestamp = time();
+        $intialdaysagotimestamp = time();
         echo "Present day, Present time \r\n";
     } else{
-        $daysagotimestamp = time() - ($daysago * 60 * 60 * 24);
+        $intialdaysagotimestamp = time() - ($daysago * 60 * 60 * 24);
 
-        echo "Working on step: {$workflowStep['stepID']}, time calculation: ".time()." - $daysago = $daysagotimestamp / ".date('Y-m-d H:i:s',$daysagotimestamp)."\r\n";
+        echo "Working on step: {$workflowStep['stepID']}, time calculation: ".time()." - $daysago = $intialdaysagotimestamp / ".date('Y-m-d H:i:s',$intialdaysagotimestamp)."\r\n";
     }
 
 
     // step id, I think workflow id is also needed here
-    $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$daysagotimestamp)];
+    $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$intialdaysagotimestamp)];
 
     // get the records that have not been responded to, had actions taken on, in x amount of time and never been responded to
     $getRecordSql = 'SELECT records.recordID, records.title, records.userID, service 
@@ -68,8 +68,21 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
 
     // PUT THE daysagotimestamp for the second query here, we will need to figure that one out!
 
+    // DateSelected * DaysSelected * what is a day anyway= how many days to bug this person.
+    $daysago = $eventDataArray['AutomatedEmailReminders']['DaysSelected'];
+
+    // pass ?current=asdasd to get the present time for testing purposes
+    if (!empty($_GET['current'])) {
+        $intialdaysagotimestamp = time();
+        echo "Present day, Present time \r\n";
+    } else{
+        $intialdaysagotimestamp = time() - ($daysago * 60 * 60 * 24);
+
+        echo "Working on step: {$workflowStep['stepID']}, time calculation: ".time()." - $daysago = $intialdaysagotimestamp / ".date('Y-m-d H:i:s',$intialdaysagotimestamp)."\r\n";
+    }
+
     // get the other entries
-    $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$daysagotimestamp)];
+    $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$intialdaysagotimestamp)];
 
     // get the records that have not been responded to, had actions taken on, in x amount of time and never been responded to
     $getRecordSql = 'SELECT records.recordID, records.title, records.userID, service 

--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -17,7 +17,7 @@ $protocol = 'https';
 $siteRoot = "{$protocol}://" . HTTP_HOST . dirname($_SERVER['REQUEST_URI']) . '/';
 
 // allow us to control if this is in days or minutes
-if (!empty($_GET['current'])) {
+if (!empty($_GET['minutes'])) {
     $timeAdjustment = 60;
 } else {
     $timeAdjustment = 60 * 60 * 24;

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -465,7 +465,9 @@ class Workflow
                 'NotifyGroup' => $data['Notify Group'],
                 'AutomateEmailGroup' => $data['Automate Email Group'],
                 'DateSelected' => $data['Date Selected'],
-                'DaysSelected' => $data['Days Selected'])));
+                'DaysSelected' => $data['Days Selected'],
+                'AdditionalDaysSelected' => $data['Additional Days Selected']
+            )));
 
         $strSQL = 'UPDATE events SET eventID=:newEventID, eventDescription=:eventDescription, eventType=:eventType, eventData=:eventData WHERE eventID=:eventID';
 
@@ -628,7 +630,8 @@ class Workflow
                 ':stepID' => $stepID,
                 ':stepData' => json_encode(['AutomatedEmailReminders' => [
                         'AutomateEmailGroup' => $data['AutomatedEmailReminders']['Automate Email Group'],
-                        'DaysSelected' => $data['AutomatedEmailReminders']['Days Selected']
+                        'DaysSelected' => $data['AutomatedEmailReminders']['Days Selected'],
+                        'AdditionalDaysSelected' => $data['AutomatedEmailReminders']['Additional Days Selected']
                     ]
                 ])
             ];

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023012400-2023012600.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023012400-2023012600.sql
@@ -1,0 +1,19 @@
+START TRANSACTION;
+
+ALTER TABLE `records_workflow_state` ADD COLUMN `initialNotificationSent` TINYINT(1) NULL DEFAULT '0' AFTER `lastNotified`;
+
+CREATE INDEX idx_lastNotified ON records_workflow_state (lastNotified);
+
+COMMIT;
+
+/**** Revert DB ****
+
+START TRANSACTION;
+
+ALTER TABLE `records_workflow_state` DROP COLUMN `initialNotificationSent`;
+
+DROP INDEX idx_lastNotified ON records_workflow_state;
+
+COMMIT;
+
+*/


### PR DESCRIPTION

I have adjusted the previous testing methodologies from just sending  the current information to augmenting the number of days to number of minutes. So for example initial email can go out in 1 day and every other notification will be 2 days. These numbers will then become 1 minute and 2 minutes when using the url below. 
https://localhost/LEAF_Request_Portal/scripts/automated_email.php?minutes=minutes

Some talking points for this would be the wording on the popup when choosing the additional notifications.