### PR TITLE
Prevent duplicate DOM IDs from being generated

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -21,6 +21,7 @@ var LeafFormGrid = function(containerID, options) {
     var rootURL = '';
     var isRenderingVirtualHeader = true;
     var isRenderingBody = false;
+    let renderHistory = {}; // index of rendered recordIDs
 
     $('#' + containerID).html('<div id="'+prefixID+'grid"></div><div id="'+prefixID+'form" style="display: none"></div>');
 
@@ -498,6 +499,12 @@ var LeafFormGrid = function(containerID, options) {
                 break;
             }
 
+            // Prevent duplicate DOM IDs from being generated
+            if(renderHistory[currentData[i].recordID] != undefined) {
+                continue;
+            }
+
+            renderHistory[currentData[i].recordID] = 1;
             buffer += '<tr id="'+prefixID + 'tbody_tr'+currentData[i].recordID+'">';
             if(showIndex) {
                 buffer += '<td><a href="index.php?a=printview&recordID='+currentData[i].recordID+'">'+currentData[i].recordID+'</a></td>';


### PR DESCRIPTION
This fixes an issue where duplicate DOM IDs are generated in certain conditions*.


*a few hundred records (or requires scrolling) and/or the parent DOM ID has an initial display:none CSS state.

I can reproduce the issue with https://github.com/department-of-veterans-affairs/LEAF/blob/combined_inbox_v3/LEAF_Request_Portal/templates/reports/LEAF_inbox_combined_sort_type.tpl + ~600 records in a single table