### PR TITLE
Leaf 3480 - Improve compatibility for multi-site interactivity

### DIFF
--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -12,6 +12,7 @@ var LeafForm = function(containerID) {
     var dialog;
     var recordID = 0;
     var postModifyCallback;
+    let rootURL = '';
 
     $('#' + containerID).html('<div id="'+prefixID+'xhrDialog" style="display: none; background-color: white; border-style: none solid solid; border-width: 0 1px 1px; border-color: #e0e0e0; padding: 4px">\
             <form id="'+prefixID+'record" enctype="multipart/form-data" action="javascript:void(0);">\
@@ -499,7 +500,7 @@ var LeafForm = function(containerID) {
 
         $.ajax({
             type: 'POST',
-            url: 'ajaxIndex.php?a=domodify',
+            url: rootURL + 'ajaxIndex.php?a=domodify',
             data: data,
             dataType: 'text',
             success: function(res) {
@@ -528,7 +529,7 @@ var LeafForm = function(containerID) {
         formConditions = new Object();
         $.ajax({
             type: 'GET',
-            url: "ajaxIndex.php?a=getindicator&recordID=" + recordID + "&indicatorID=" + indicatorID + "&series=" + series,
+            url: rootURL + "ajaxIndex.php?a=getindicator&recordID=" + recordID + "&indicatorID=" + indicatorID + "&series=" + series,
             dataType: 'text',
             success: function(response) {
                 dialog.setTitle('Editing #' + recordID);
@@ -576,12 +577,13 @@ var LeafForm = function(containerID) {
         dialog: function() { return dialog; },
         getHtmlFormID: function() { return htmlFormID; },
         serializeData: function() { return $('#' + htmlFormID).serialize(); },
+		setRootURL: function(url) { rootURL = url; },
 
         setRecordID: setRecordID,
         setPostModifyCallback: setPostModifyCallback,
         doModify: doModify,
         getForm: getForm,
         initCustom: initCustom,
-        setHtmlFormID: setHtmlFormID
+        setHtmlFormID: setHtmlFormID,
     }
 };

--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -223,7 +223,7 @@ var LeafWorkflow = function(containerID, CSRFToken) {
                 url: rootURL + 'ajaxScript.php?a=workflowStepModules&s=LEAF_digital_signature&stepID=' + step.stepID,
                 dataType: 'script',
                 success: function() {
-                    workflowStepModule[step.stepID].LEAF_digital_signature.init(step);
+                    workflowStepModule[step.stepID].LEAF_digital_signature.init(step, rootURL);
                 },
                 fail: function(err) {
                     console.log("Error: " + err);
@@ -245,7 +245,7 @@ var LeafWorkflow = function(containerID, CSRFToken) {
                         url: rootURL + 'ajaxScript.php?a=workflowStepModules&s='+ step.stepModules[x].moduleName +'&stepID=' + step.stepID,
                         dataType: 'script',
                         success: function() {
-                            workflowStepModule[step.stepID][step.stepModules[x].moduleName].init(step);
+                            workflowStepModule[step.stepID][step.stepModules[x].moduleName].init(step, rootURL);
                             $(`#form_dep_container${step.dependencyID} .button`).attr('disabled', false);
                         },
                         fail: function(err) {
@@ -263,7 +263,7 @@ var LeafWorkflow = function(containerID, CSRFToken) {
                 url: rootURL + step.jsSrcList[u],
                 dataType: 'script',
                 success: function() {
-                    workflowModule[step.dependencyID].init(currRecordID);
+                    workflowModule[step.dependencyID].init(currRecordID, rootURL);
                 },
                 fail: function(err) {
                     console.log("Error: " + err);

--- a/LEAF_Request_Portal/scripts/workflowStepModules/LEAF_workflow_indicator.tpl
+++ b/LEAF_Request_Portal/scripts/workflowStepModules/LEAF_workflow_indicator.tpl
@@ -6,7 +6,7 @@ workflowStepModule[{{$stepID}}]['LEAF_workflow_indicator'] = (function() {
 	var series = 1;
 	var form;
 
-	function init(step) {
+	function init(step, rootURL) {
 		recordID = step.recordID;
 		depID = step.dependencyID;
 		indicatorID = config.indicatorID;
@@ -18,6 +18,7 @@ workflowStepModule[{{$stepID}}]['LEAF_workflow_indicator'] = (function() {
 				</div>');
 
 		form = new LeafForm(prefixID + 'anchor');
+        form.setRootURL(rootURL);
 		form.initCustom(prefixID + 'anchor', prefixID + 'container', prefixID + 'anchor', prefixID + 'anchor', prefixID + 'anchor');
 		form.setHtmlFormID('form_dep'+ depID);
 		form.setRecordID(recordID);

--- a/LEAF_Request_Portal/scripts/workflowStepModules/TEMPLATE_workflowStepModule.tpl
+++ b/LEAF_Request_Portal/scripts/workflowStepModules/TEMPLATE_workflowStepModule.tpl
@@ -1,7 +1,7 @@
 workflowStepModule[{{$stepID}}] = workflowStepModule[{{$stepID}}] || {};
 workflowStepModule[{{$stepID}}]['UNIQUE_NAME_OF_MODULE'] = (function() {
 
-	function init(recordID) {
+	function init(recordID, rootURL) {
 
 	}
 


### PR DESCRIPTION
This enables pages such as the Combined Inbox to work correctly.

Preconditions:
- Two LEAF sites A and B
- [Combined Inbox](https://github.com/department-of-veterans-affairs/LEAF/blob/combined_inbox_v3/LEAF_Request_Portal/templates/reports/LEAF_inbox_combined_sort_type.tpl) saved on site A, and configured to import data from B
- Site B has a workflow containing a Step with a Form Field configured
- A request on Site B is on the Step with a Form Field

Before this patch: The form field does not load correctly in the Combined Inbox
After: It works

