### PR TITLE
LEAF-3516 - Report builder sort persistence

### DIFF
--- a/LEAF_Request_Portal/admin/templates/view_admin_menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_admin_menu.tpl
@@ -54,18 +54,6 @@
             <span class="leaf-admin-btndesc">Edit site name, time zone, and other labels</span>
         </a>
 
-        <a href="../?a=reports&v=3" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-            <i class="leaf-admin-btnicon fas fa-file-invoice text-blue-cool-50 leaf-icn-narrow4" alt="Report Builder" title="Report Builder"></i>
-            <span class="leaf-admin-btntitle">Report Builder</span>
-            <span class="leaf-admin-btndesc">Create custom reports</span>
-        </a>
-
-        <a href="../report.php?a=LEAF_Timeline_Explorer" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-            <i class="leaf-admin-btnicon fas fa-clock text-blue-cool-50 leaf-icn-narrow2" alt="Timeline Explorer" title="Timeline Explorer"></i>
-            <span class="leaf-admin-btntitle">Timeline Explorer</span>
-            <span class="leaf-admin-btndesc">Analyze timeline data</span>
-        </a>
-
         <!--{if $siteType == 'national_primary'}-->
         <a href="../report.php?a=LEAF_National_Distribution" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
             <i class="leaf-admin-btnicon fas fa-sitemap text-blue-cool-50" alt="Site Distribution" title="Site Distribution"></i>
@@ -73,6 +61,25 @@
             <span class="leaf-admin-btndesc">Deploy changes to subordinate sites</span>
         </a>
         <!--{/if}-->
+
+    <h3 role="heading" aria-level="1" tabindex="0">Admin Oversight Tools</h3>
+        <a href="../?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJHSAHASQBEQAaEAez2gEMwKpsBCAXjJBjoGMALbKCHAoAbAG4Qs5AOZ0I2AIIA5EgF9S6LIhAYIwiJEmVqUOg2xtynMLyQAGabIXKQKgLrkAVhTQA7BChxoUTQuOXIuWSkGAE9FGhgwnDA6AFcEchouMDQKHwB9HjRcGPZcCDwAMRThADM0YWEEnzAAeR9haJB3HAYwJGA1EGE0GDQ%2BxABGW2nyYdHWmpq4fTsVIA%3D%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAsgCeABwrVaDfGGZt0HPDz6RYCFBhwKWyFAFcWzOY0XVlq9fy1DdosInhFUUAPoALCAYzizegsldi5eO0EdEQUYRHEWDxZoeDIPEkQDDxc3KED5JitQtW4AXSA&sort=N4Ig1gpgniBcIBMCGUDOBlAlgOwMYQBklUAXAQVxMwHtsQAaEagJwQmbkQlVxAF8gA%3D%3D&title=VW5yZXNvbHZlZCByZXF1ZXN0cw%3D%3D" role="button" class="leaf-admin-button bg-violet-10 lf-trans-blue">
+            <i class="leaf-admin-btnicon fas fa-search text-violet-50 leaf-icn-narrow2" alt="Timeline Explorer" title="Timeline Explorer"></i>
+            <span class="leaf-admin-btntitle">Unresolved Requests</span>
+            <span class="leaf-admin-btndesc">Examine potential delays</span>
+        </a>
+
+        <a href="../report.php?a=LEAF_Timeline_Explorer" role="button" class="leaf-admin-button bg-violet-10 lf-trans-blue">
+            <i class="leaf-admin-btnicon fas fa-clock text-violet-50 leaf-icn-narrow2" alt="Timeline Explorer" title="Timeline Explorer"></i>
+            <span class="leaf-admin-btntitle">Timeline Explorer</span>
+            <span class="leaf-admin-btndesc">Analyze timeline data</span>
+        </a>
+
+        <a href="../?a=reports&v=3" role="button" class="leaf-admin-button bg-violet-10 lf-trans-blue">
+            <i class="leaf-admin-btnicon fas fa-file-invoice text-violet-50 leaf-icn-narrow4" alt="Report Builder" title="Report Builder"></i>
+            <span class="leaf-admin-btntitle">Report Builder</span>
+            <span class="leaf-admin-btndesc">Create custom reports</span>
+        </a>
 
     <h3 role="heading" aria-level="1" tabindex="0">LEAF Developer Console</h3>
 

--- a/LEAF_Request_Portal/admin/templates/view_admin_menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_admin_menu.tpl
@@ -22,7 +22,7 @@
         </a>
         <!--{/if}-->
 
-    <h3 role="heading" aria-level="1" tabindex="0">Request Portal Admin</h3>
+    <h3 role="heading" aria-level="1" tabindex="0">Site Configuration</h3>
         
         <!--{if $siteType != 'national_subordinate'}-->
         <a href="?a=workflow" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -402,7 +402,7 @@ var LeafFormGrid = function(containerID, options) {
                 if(b[key] == undefined) {
                     b[key] = '';
                 }
-                return -collator.compare(a[key], b[key]);
+                return collator.compare(b[key], a[key]);
             });
         }
         if(order == 'asc') {

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -730,7 +730,7 @@ var LeafFormGrid = function(containerID, options) {
             var i = 0;
             var thisSite = document.createElement('a');
             var numColumns = headers.length - 1;
-            $('#' + prefixID + 'tbody>tr>td').each(function(idx, val) {
+            document.querySelectorAll('#' + prefixID + 'tbody>tr>td').forEach(function(val) {
                 var foundScripts = val.querySelectorAll('script');
 
                 for(var tIdx = 0; tIdx < foundScripts.length; tIdx++) {
@@ -755,10 +755,10 @@ var LeafFormGrid = function(containerID, options) {
             });
 
             rows = '';
-            $(output).each(function(idx, thisRow)
+            output.forEach(function(thisRow)
             {
                 //escape double quotes
-                $(thisRow).each(function(idx, col) {
+                thisRow.forEach(function(col, idx) {
                     thisRow[idx] = col.replace(/\"/g, "\"\"");
                 });
                 //add to csv string

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -681,10 +681,16 @@ function editLabels() {
 
     for(let i in resSelectList) {
         if(resIndicatorList[resSelectList[i]] != undefined) {
-            buffer += '<tr id="sortID_'+ resSelectList[i] +'"><td><input type="text" style="min-width: 400px" id="id_'+ resSelectList[i] +'" value="'+ resIndicatorList[resSelectList[i]] +'"></input></td>';
-            buffer += '<td><button class="buttonNorm" onclick="editLabels_down('+ resSelectList[i] +');"><img src="../libs/dynicons/?img=go-down_red.svg&w=16" /></button> ';
-            buffer += '<button class="buttonNorm" onclick="editLabels_up('+ resSelectList[i] +');"><img src="../libs/dynicons/?img=go-up.svg&w=16" /></button>';
-            buffer += '<input type="color" id="colorPicker' + resSelectList[i] + '" value="#d1dfff" style="height: 26px;" /></td></tr>';
+            buffer += `<tr id="sortID_${resSelectList[i]}">
+                <td>
+                    <input type="color" id="colorPicker${resSelectList[i]}" value="#d1dfff" style="height: 26px;" />
+                    <input type="text" style="min-width: 400px" id="id_${resSelectList[i]}" value="${resIndicatorList[resSelectList[i]]}"></input>
+                </td>
+                <td>
+                    <button class="buttonNorm" onclick="editLabels_down(${resSelectList[i]});"><img src="../libs/dynicons/?img=go-down_red.svg&w=16" /></button>
+                    <button class="buttonNorm" onclick="editLabels_up(${resSelectList[i]});"><img src="../libs/dynicons/?img=go-up.svg&w=16" /></button>
+                </td>
+                </tr>`;
         }
     }
     buffer += '</table>';
@@ -763,9 +769,8 @@ function sortHeaders(a, b) {
 }
 
 function openShareDialog() {
-    var pwd = document.URL.substr(0,document.URL.lastIndexOf('/') + 1);
-    var reportLink = document.URL.substr(document.URL.lastIndexOf('/') + 1);
-
+    var pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
+    var reportLink = document.URL.substr(document.URL.lastIndexOf('?') - 1);
 
     dialog_message.setTitle('Share Report');
     dialog_message.setContent('<p>This link can be shared to provide a live view into this report.</p>'
@@ -793,7 +798,7 @@ function openShareDialog() {
 }
 
 function showJSONendpoint() {
-    var pwd = document.URL.substr(0,document.URL.lastIndexOf('/') + 1);
+    var pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
     leafSearch.getLeafFormQuery().setLimit(0, 10000);
     var queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
     var jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString;
@@ -977,6 +982,7 @@ var indicatorSort = {}; // object = indicatorID : sortID
 var grid;
 let gridColorData = {}; //object updated with id: color
 let tempColorData = {}; //object updated with id: color
+let sortPreference = {}; // store current sorting preference
 let isOneFormType = false;
 
 /**
@@ -1020,11 +1026,26 @@ var version = 3;
     * v3 - uses getData() from formQuery.js
 */
 
-function buildURLComponents(baseURL){
+/**
+ * Generates a url based on the current report preferences
+ * @param baseURL URL of this script, without parameters
+ * @param update (optional) bool - update an existing URL
+ */
+function buildURLComponents(baseURL, update){
     url = baseURL + '&v='+ version + '&query=' + encodeURIComponent(urlQuery) + '&indicators=' + encodeURIComponent(urlIndicators);
+
+    if(update != undefined) {
+        let urlParams = new URLSearchParams(window.location.search);
+        url = baseURL + '&v='+ version + '&query=' + urlParams.get('query') + '&indicators=' + urlParams.get('indicators');
+    }
+
     if (Object.keys(gridColorData).length !== 0){
         urlColorData = LZString.compressToBase64(JSON.stringify(gridColorData));
         url += '&colors=' + encodeURIComponent(urlColorData);
+    }
+    if(Object.keys(sortPreference).length != 0) {
+        let urlSortPreference = LZString.compressToBase64(JSON.stringify(sortPreference));
+        url += '&sort=' + encodeURIComponent(urlSortPreference);
     }
     if($('#reportTitle').val() != '') {
         url += '&title=' + encodeURIComponent(btoa($('#reportTitle').val()));
@@ -1103,6 +1124,11 @@ $(function() {
     var selectedIndicators = [];
     grid = new LeafFormGrid('results');
     grid.enableToolbar();
+    grid.setPostSortRequestFunc((key, order) => {
+        sortPreference = {key: key, order: order};
+        let baseURL = window.location.href.substr(0, window.location.href.indexOf('&'));
+        buildURLComponents(baseURL, true);
+    });
     var extendedToolbar = false;
     $('#generateReport').off();
     $('#generateReport').on('click', function() {
@@ -1198,7 +1224,13 @@ $(function() {
 
             if(<!--{$version}--> >= 3) {
                 grid.setData(tGridData);
-                grid.sort('recordID', 'desc');
+                let sortKey = 'recordID';
+                let sortDirection = 'desc';
+                if(sortPreference.key != undefined && sortPreference.order != undefined) {
+                    sortKey = sortPreference.key;
+                    sortDirection = sortPreference.order;
+                }
+                grid.sort(sortKey, sortDirection);
                 grid.renderBody();
             }
             else {
@@ -1315,7 +1347,7 @@ $(function() {
             buildURLComponents(baseURL);
 
             $('#reportTitle').on('keyup', function() {
-                buildURLComponents(baseURL);
+                buildURLComponents(baseURL, true);
             });
         }
         else {
@@ -1364,10 +1396,17 @@ $(function() {
                 checkIfOneTypeSearchedAndUpdate(inQuery.terms);
 
                 t_inIndicators = JSON.parse(LZString.decompressFromBase64(indicators));
+                selectedIndicators = t_inIndicators;
                 let queryColors = JSON.parse(LZString.decompressFromBase64(colors));
                 if (queryColors !== null) {
                     gridColorData = queryColors;
                     updateHeaderColors(gridColorData);
+                }
+
+                let urlParams = new URLSearchParams(window.location.search);
+                urlSortParam = urlParams.get('sort');
+                if(urlSortParam != null) {
+                    sortPreference = JSON.parse(LZString.decompressFromBase64(urlSortParam));
                 }
             }
             else {

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1396,7 +1396,6 @@ $(function() {
                 checkIfOneTypeSearchedAndUpdate(inQuery.terms);
 
                 t_inIndicators = JSON.parse(LZString.decompressFromBase64(indicators));
-                selectedIndicators = t_inIndicators;
                 let queryColors = JSON.parse(LZString.decompressFromBase64(colors));
                 if (queryColors !== null) {
                     gridColorData = queryColors;


### PR DESCRIPTION
This primarily adds a feature to save sort preferences in the report builder.

Other fixes and changes:
- Resolve shortlink issue if the base64 encoded URL included a slash (/)
- Fix reversed sort indicator issue
- Use Intl.Collator for most sort operations
- Add sort callback to formGrid.js
- Adjust label editor UX
- Optimization: Replace $.each with forEach in hotspots

Testing checklist:
- [x] After sorting a column in the Report builder, the sort is retained after refreshing the page
- [x] Report Builder can export to Excel
- [x] Sorting works for text and numeric data
- [x] Report Builder -> Share Report link works
- [x] New Admin Panel option "Unresolved Requests" shows unresolved requests, sorted by days since last action in descending order
