### PR TITLE
LEAF-3517 - Avoid redundant queries

### DIFF
--- a/LEAF_Request_Portal/form.php
+++ b/LEAF_Request_Portal/form.php
@@ -1795,9 +1795,16 @@ class Form
                 }
 
                 //check if the requester has any backups
-                $nexusDB = $this->login->getNexusDB();
-                $vars4 = array(':empId' => $empUID);
-                $backupIds = $nexusDB->prepared_query('SELECT * FROM relation_employee_backup WHERE empUID =:empId', $vars4);
+                $backupIds = [];
+                if(isset($this->cache['checkReadAccess_relation_employee_backup_' . $empUID])) {
+                    $backupIds = $this->cache['checkReadAccess_relation_employee_backup_' . $empUID];
+                }
+                else {
+                    $nexusDB = $this->login->getNexusDB();
+                    $vars4 = array(':empId' => $empUID);
+                    $backupIds = $nexusDB->prepared_query('SELECT * FROM relation_employee_backup WHERE empUID =:empId', $vars4);
+                    $this->cache['checkReadAccess_relation_employee_backup_' . $empUID] = $backupIds;
+                }
 
                 if ($empUID == $this->login->getEmpUID())
                 {


### PR DESCRIPTION
This optimizes a hot spot that was flagged in monitoring.

Testing preconditions:
- A request is on a step that's configured with "person designated by requestor"
- The current user is not the person designated
- The current user is a backup of the person designated
- The current user is not an admin

Testing checklist:

- [x] The current user can take workflow actions in the request
- [x] When the current user is removed as a backup, they cannot take actions

