### PR TITLE
LEAF-3519 - Workaround race condition

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -268,7 +268,7 @@ var LeafFormSearch = function(containerID) {
 			if(txt != "" && txt != q) {
 				q = txt;
 
-				if(currRequest != null) {
+				if(currRequest != null && currRequest.abort != undefined && typeof currRequest.abort == 'function') {
 					currRequest.abort();
 				}
 


### PR DESCRIPTION
There's a potential race condition that triggers an error: "currRequest.abort is not a function", which prevents people from searching on the homepage.

This might be happening because the underlying $.ajax() call is resolving before this timer loop expects it.

This workaround checks to see if currRequest.abort is a valid function before trying to execute it.