### PR TITLE
LEAF 3398 file del endpoint update

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
@@ -69,7 +69,10 @@ function deleteFile(file) {
             success: function() {
                 showFiles();
                 dialog_confirm.hide();
-            }
+            },
+            error: function(err) {
+                console.log('an error occurred during file deletion', err)
+            },
         });
     });
     dialog_confirm.show();

--- a/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
@@ -64,8 +64,8 @@ function deleteFile(file) {
     dialog_confirm.setSaveHandler(function() {
         $.ajax({
             type: 'DELETE',
-            url: '../api/system/files/_'+ file + '?' +
-                $.param({'CSRFToken': CSRFToken}),
+            url: '../api/system/files/delete?' +
+                $.param({'CSRFToken': CSRFToken, 'file': file}),
             success: function() {
                 showFiles();
                 dialog_confirm.hide();

--- a/LEAF_Request_Portal/api/controllers/SystemController.php
+++ b/LEAF_Request_Portal/api/controllers/SystemController.php
@@ -152,8 +152,8 @@ class SystemController extends RESTfulResponse
         $this->index['DELETE']->register('system', function ($args) {
         });
 
-        $this->index['DELETE']->register('system/files/[text]', function ($args) use ($db, $login, $system) {
-            return $system->removeFile($args[0]);
+        $this->index['DELETE']->register('system/files/delete', function ($args) use ($db, $login, $system) {
+            return $system->removeFile($_GET['file']);
         });
 
         return $this->index['DELETE']->runControl($act['key'], $act['args']);


### PR DESCRIPTION
Updates the registered deletion endpoint used in the file manager to take the file name as a parameter rather than through the url, which had caused some file names (eg test#file) to be undeletable through the UI.