### PR TITLE
LEAF- 3534 - Align with HTTP specification for etags

### DIFF
--- a/LEAF_Nexus/api/RESTfulResponse.php
+++ b/LEAF_Nexus/api/RESTfulResponse.php
@@ -93,7 +93,7 @@ abstract class RESTfulResponse
 
                 if ($_SERVER['REQUEST_METHOD'] === 'GET')
                 {
-                    $etag = md5($jsonOut);
+                    $etag = '"' . md5($jsonOut) . '"';
                     header_remove('Pragma');
                     header_remove('Cache-Control');
                     header_remove('Expires');

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -95,7 +95,7 @@ abstract class RESTfulResponse
 
                 if ($_SERVER['REQUEST_METHOD'] === 'GET')
                 {
-                    $etag = md5($jsonOut);
+                    $etag = '"' . md5($jsonOut) . '"';
                     header_remove('Pragma');
                     header_remove('Cache-Control');
                     header_remove('Expires');


### PR DESCRIPTION
This adds missing double quotes defined in RFC9110 and summarized in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag