### PR TITLE
Clear render history when tbody is emptied

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -481,6 +481,7 @@ var LeafFormGrid = function(containerID, options) {
             || startIdx == 0) {
             startIdx = 0;
             $('#' + prefixID + 'tbody').empty();
+            renderHistory = {};
             fullRender = true;
         }
 


### PR DESCRIPTION
Fix issue when the table on the main page is cleared after attempting to sort one of the columns.