### PR TITLE
LEAF-3547 Fix Report Builder: Date Cancelled

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -161,7 +161,7 @@ function addHeader(column) {
                 name: 'Cancelled By', indicatorID: 'cancelledBy', editable: false, callback: function(data, blob) {
                 if(blob[data.recordID].action_history != undefined) {
                     var cancelData = blob[data.recordID].action_history.pop();
-                    if(cancelData.actionType === 'deleted') {
+                    if(cancelData != undefined && cancelData.actionType === 'deleted') {
                         $('#'+data.cellContainerID).html(cancelData.approverName);
                     }
                 }
@@ -1087,7 +1087,7 @@ $(function() {
         }
 
         if(showOptionCancelled) {
-            $('#option_dateCancelled').css('display', 'inline');
+            $('#option_dateCancelled').css('display', 'block');
         }
         else {
             $('#option_dateCancelled').css('display', 'none');


### PR DESCRIPTION
Resolves an issue where Report Builder output gets mangled in these conditions:

- Report Builder must have a "Current Status IS Cancelled" term
- "Date Request Cancelled" is selected in Step 2
- Attempt to sort on any column