### PR TITLE
Fix Dynicon caching on prod

### DIFF
--- a/LEAF_Request_Portal/qrcode/index.php
+++ b/LEAF_Request_Portal/qrcode/index.php
@@ -51,6 +51,11 @@ else {
     QRcode::png($encode, $cacheFile, 'L', 4, 2);
 }
 
+header_remove('Pragma');
+header_remove('Cache-Control');
+header_remove('Expires');
+header('Cache-Control: private, max-age=604800');
+
 $time = filemtime($cacheFile);
 if(isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $_SERVER['HTTP_IF_MODIFIED_SINCE'] == date(DATE_RFC822, $time)) {
     header('Last-Modified: ' . date(DATE_RFC822, $time), true, 304);

--- a/libs/php-commons/Dynicon.php
+++ b/libs/php-commons/Dynicon.php
@@ -72,6 +72,10 @@ class Dynicon
     private function output()
     {
         $time = filemtime($this->cachedFile);
+        header_remove('Pragma');
+        header_remove('Cache-Control');
+        header_remove('Expires');
+        header('Cache-Control: private, max-age=604800');
         if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $_SERVER['HTTP_IF_MODIFIED_SINCE'] == gmdate('D, d M Y H:i:s T', $time))
         {
             header('Last-Modified: ' . gmdate('D, d M Y H:i:s T', $time), true, 304);


### PR DESCRIPTION
Dynicons on prod don't seem to be cached anymore, causing ~20x bandwidth consumption on the main page.

This could potentially be used as a workaround.

Testing:
- [ ] Dynicons are cached by the browser