### PR TITLE
LEAF-3568 - Copy request_service does not show on non admin

### DIFF
--- a/LEAF_Request_Portal/api/controllers/ServiceController.php
+++ b/LEAF_Request_Portal/api/controllers/ServiceController.php
@@ -57,18 +57,21 @@ class ServiceController extends RESTfulResponse
         $login = $this->login;
         $service = $this->service;
 
-        $this->verifyAdminReferrer();
+        if ($login->checkGroup(1)) {
+            
+            $this->verifyAdminReferrer();
 
-        $this->index['POST'] = new ControllerMap();
-        $this->index['POST']->register('service', function ($args) use ($db, $login, $service) {
-            return $service->addService(\Leaf\XSSHelpers::sanitizeHTML($_POST['service']), $_POST['groupID']);
-        });
+            $this->index['POST'] = new ControllerMap();
+            $this->index['POST']->register('service', function ($args) use ($db, $login, $service) {
+                return $service->addService(\Leaf\XSSHelpers::sanitizeHTML($_POST['service']), $_POST['groupID']);
+            });
 
-        $this->index['POST']->register('service/[digit]/members', function ($args) use ($db, $login, $service) {
-            return $service->addMember($args[0], $_POST['userID']);
-        });
+            $this->index['POST']->register('service/[digit]/members', function ($args) use ($db, $login, $service) {
+                return $service->addMember($args[0], $_POST['userID']);
+            });
 
-        return $this->index['POST']->runControl($act['key'], $act['args']);
+            return $this->index['POST']->runControl($act['key'], $act['args']);
+        }
     }
 
     public function delete($act)
@@ -77,20 +80,24 @@ class ServiceController extends RESTfulResponse
         $login = $this->login;
         $service = $this->service;
 
-        $this->verifyAdminReferrer();
+        if ($login->checkGroup(1)) {
 
-        $this->index['DELETE'] = new ControllerMap();
-        $this->index['DELETE']->register('service', function ($args) {
-        });
+            $this->verifyAdminReferrer();
 
-        $this->index['DELETE']->register('service/[digit]', function ($args) use ($db, $login, $service) {
-            return $service->removeService($args[0]);
-        });
+            $this->index['DELETE'] = new ControllerMap();
+            $this->index['DELETE']->register('service', function ($args) {
+            });
 
-        $this->index['DELETE']->register('service/[digit]/members/[text]', function ($args) use ($db, $login, $service) {
-            return $service->removeMember($args[0], $args[1]);
-        });
+            $this->index['DELETE']->register('service/[digit]', function ($args) use ($db, $login, $service) {
+                return $service->removeService($args[0]);
+            });
 
-        return $this->index['DELETE']->runControl($act['key'], $act['args']);
+            $this->index['DELETE']->register('service/[digit]/members/[text]', function ($args) use ($db, $login, $service) {
+                return $service->removeMember($args[0], $args[1]);
+            });
+
+            return $this->index['DELETE']->runControl($act['key'], $act['args']);
+
+        }
     }
 }

--- a/LEAF_Request_Portal/api/index.php
+++ b/LEAF_Request_Portal/api/index.php
@@ -51,6 +51,11 @@ $controllerMap->register('classicphonebook', function () use ($p_db, $login, $ac
     $controller->handler($action);
 });
 
+$controllerMap->register('service', function () use ($p_db, $login, $action) {
+    $serviceController = new Portal\ServiceController($p_db, $login);
+    $serviceController->handler($action);
+});
+
 // admin only
 if ($login->checkGroup(1))
 {
@@ -62,11 +67,6 @@ if ($login->checkGroup(1))
     $controllerMap->register('formEditor', function () use ($p_db, $login, $action) {
         $formEditorController = new Portal\FormEditorController($p_db, $login);
         $formEditorController->handler($action);
-    });
-
-    $controllerMap->register('service', function () use ($p_db, $login, $action) {
-        $serviceController = new Portal\ServiceController($p_db, $login);
-        $serviceController->handler($action);
     });
 
     $controllerMap->register('group', function () use ($p_db, $login, $action) {


### PR DESCRIPTION
When copying a request, services were not showing when a user was not an admin, this was due to the services call being an admin only call. I did not see any reason for this since none of the other sections working with services in this way needed to be admin only.