### PR TITLE
LEAF 3411 add decode for excel 'from web' import

### DIFF
--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -91,22 +91,8 @@ abstract class RESTfulResponse
         $format = isset($_GET['format']) ? $_GET['format'] : '';
         switch ($format) {
             case 'json':
-            case 'jsoncompatmode':
             default:
                 header('Content-type: application/json');
-                //this is used specifically for excel imports 'from web' via Report Builder toolbar -> JSON -> compat mode
-                if($format === 'jsoncompatmode') {
-                    foreach ($out as $recordID => $record) {
-                        $out[$recordID]['title'] = html_entity_decode($record['title'], ENT_QUOTES);
-                        if (isset($record['s1'])) {
-                            foreach ($record['s1'] as $key => $entry) {
-                                if (preg_match('/^id\d+$/', $key) && is_string($entry)) {
-                                    $out[$recordID]['s1'][$key] = html_entity_decode($entry, ENT_QUOTES);
-                                }
-                            }
-                        }
-                    }
-                }
                 $jsonOut = json_encode($out);
 
                 if ($_SERVER['REQUEST_METHOD'] === 'GET')
@@ -170,7 +156,7 @@ abstract class RESTfulResponse
                 break;
             case 'xml':
                 header('Content-type: text/xml');
-                $xml = new SimpleXMLElement('<?xml version="1.0"?><output></output>');
+                $xml = new \SimpleXMLElement('<?xml version="1.0"?><output></output>');
                 $this->buildXML($out, $xml);
                 echo $xml->asXML();
 

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -91,8 +91,22 @@ abstract class RESTfulResponse
         $format = isset($_GET['format']) ? $_GET['format'] : '';
         switch ($format) {
             case 'json':
+            case 'jsoncompatmode':
             default:
                 header('Content-type: application/json');
+                //this is used specifically for excel imports 'from web' via Report Builder toolbar -> JSON -> compat mode
+                if($format === 'jsoncompatmode') {
+                    foreach ($out as $recordID => $record) {
+                        $out[$recordID]['title'] = html_entity_decode($record['title'], ENT_QUOTES);
+                        if (isset($record['s1'])) {
+                            foreach ($record['s1'] as $key => $entry) {
+                                if (preg_match('/^id\d+$/', $key) && is_string($entry)) {
+                                    $out[$recordID]['s1'][$key] = html_entity_decode($entry, ENT_QUOTES);
+                                }
+                            }
+                        }
+                    }
+                }
                 $jsonOut = json_encode($out);
 
                 if ($_SERVER['REQUEST_METHOD'] === 'GET')

--- a/LEAF_Request_Portal/sources/Shortener.php
+++ b/LEAF_Request_Portal/sources/Shortener.php
@@ -54,7 +54,7 @@ class Shortener
         return $res - $this->offset;
     }
 
-    public function decodeEntitiesForExcel($formQuery) {
+    public function decodeEntitiesForImport(array $formQuery): array {
         foreach ($formQuery as $recordID => $record) {
             $formQuery[$recordID]['title'] = html_entity_decode($record['title'], ENT_QUOTES);
             if (isset($record['s1'])) {
@@ -89,7 +89,7 @@ class Shortener
 
         $form = new Form($this->db, $this->login);
         $formQuery = $form->query($resReport[0]['data']);
-        return $this->decodeEntitiesForExcel($formQuery);
+        return $this->decodeEntitiesForImport($formQuery);
     }
 
     public function shortenFormQuery($data) {

--- a/LEAF_Request_Portal/sources/Shortener.php
+++ b/LEAF_Request_Portal/sources/Shortener.php
@@ -54,6 +54,20 @@ class Shortener
         return $res - $this->offset;
     }
 
+    public function decodeEntitiesForExcel($formQuery) {
+        foreach ($formQuery as $recordID => $record) {
+            $formQuery[$recordID]['title'] = html_entity_decode($record['title'], ENT_QUOTES);
+            if (isset($record['s1'])) {
+                foreach ($record['s1'] as $key => $entry) {
+                    if (preg_match('/^id\d+$/', $key) && is_string($entry)) {
+                        $formQuery[$recordID]['s1'][$key] = html_entity_decode($entry, ENT_QUOTES);
+                    }
+                }
+            }
+        }
+        return $formQuery;
+    }
+
     public function getFormQuery($shortUID) {
         $shortID = $this->decodeShortUID($shortUID);
         $vars = array(':shortID' => $shortID);
@@ -74,7 +88,8 @@ class Shortener
         }
 
         $form = new Form($this->db, $this->login);
-        return $form->query($resReport[0]['data']);
+        $formQuery = $form->query($resReport[0]['data']);
+        return $this->decodeEntitiesForExcel($formQuery);
     }
 
     public function shortenFormQuery($data) {

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -842,7 +842,12 @@ function showJSONendpoint() {
 
         switch($('#format').val()) {
             case 'json':
-                $('#exportFormat').html('');
+                const isCompatMode = $('#msCompatMode').is(':checked');
+                if (isCompatMode) {
+                    $('#exportFormat').append('format=jsoncompatmode');
+                } else {
+                    $('#exportFormat').html('');
+                }
                 break;
             default:
                 $('#exportFormat').append('format=' + $('#format').val());

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -842,12 +842,7 @@ function showJSONendpoint() {
 
         switch($('#format').val()) {
             case 'json':
-                const isCompatMode = $('#msCompatMode').is(':checked');
-                if (isCompatMode) {
-                    $('#exportFormat').append('format=jsoncompatmode');
-                } else {
-                    $('#exportFormat').html('');
-                }
+                $('#exportFormat').html('');
                 break;
             default:
                 $('#exportFormat').append('format=' + $('#format').val());


### PR DESCRIPTION
Adds decode for the Report Builder -> JSON (toolbar option) -> JSON option, use compat mode checked, endpoint to avoid encoded characters in excel 'from web' imports.