### PR TITLE
LEAF-3615 - refresh orgchart employees script

### DIFF
--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -197,7 +197,9 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
         return FALSE;
     }
     foreach ($orgEmployeeRes as $orgEmployee) {
-        
+
+        $nationalEmpUIDs[] = (int) $orgEmployee['empUID'];
+
         $localEmployeeArray[] = [
             'empUID' => (empty($localEmpArray[$orgEmployee['userName']]) ? null : $localEmpArray[$orgEmployee['userName']]),
             'userName' => $orgEmployee['userName'],


### PR DESCRIPTION
missing the org employee empuid line, adding this back in restores the import functionality.