### PR TITLE
LEAF 3617 - Update jsonExport_PDL.php - Fortify

### DIFF
--- a/LEAF_Nexus/utils/jsonExport_PDL.php
+++ b/LEAF_Nexus/utils/jsonExport_PDL.php
@@ -208,6 +208,7 @@ foreach($jsonOut as $key => $item) {
 }
 
 $result = json_encode($jsonOut);
+$result = htmlspecialchars($result, ENT_QUOTES, 'UTF-8');
 
 // cache the result
 $vars = array(':cacheID' => 'jsonExport_PDL.php',


### PR DESCRIPTION
the htmlspecialchars function is used to escape any special characters that might be included in the JSON output. The ENT_QUOTES flag is used to escape both single and double quotes, and the UTF-8 charset is used to encode the output. Finally, the JSON is outputted using the echo statement. This was requested by the fortify team.