### PR TITLE
LEAF-3606 - automated email days ticket has been open

### DIFF
--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -114,6 +114,7 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
         $email->setSiteRoot($siteRoot);
         // ive seen examples using the attachApproversAndEmail method and some had smarty vars and some did not.
         $title = strlen($record['title']) > 45 ? substr($record['title'], 0, 42) . '...' : $record['title'];
+        var_dump(date('Y-m-d H:i:s',$additionalDaysAgoTimestamp));
 var_dump($record);exit();
         // add in variables for the smarty template
         $email->addSmartyVariables(array(

--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -54,7 +54,7 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
     $getRecordVar = [':stepID' => $workflowStep['stepID'], ':lastNotified' => date('Y-m-d H:i:s',$intialDaysAgoTimestamp)];
 
     // get the records that have not been responded to, had actions taken on, in x amount of time and never been responded to
-    $getRecordSql = 'SELECT records.recordID, records.title, records.userID, service 
+    $getRecordSql = 'SELECT records.recordID, records.title, records.userID, `service`, records.`submitted`
         FROM records_workflow_state
         JOIN records ON records.recordID = records_workflow_state.recordID
         LEFT JOIN services USING(serviceID) 
@@ -84,7 +84,7 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
     }
 
     // get the records that have not been responded to, had actions taken on, in x amount of time and never been responded to
-    $getRecordSql = 'SELECT records.recordID, records.title, records.userID, service 
+    $getRecordSql = 'SELECT records.recordID, records.title, records.userID, `service`, records.`submitted`
         FROM records_workflow_state
         JOIN records ON records.recordID = records_workflow_state.recordID
         LEFT JOIN services USING(serviceID) 
@@ -109,16 +109,36 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
 
     // go through each and send an email
     foreach ($getRecordRes as $record) {
-        // send the email
+
+        // get the last action
+        $getLastActionVar = [':recordID' => $record['recordID']];
+        $getLastActionSql = "SELECT `time` FROM action_history WHERE recordID = :recordID ORDER BY `time` DESC LIMIT 1;";
+        $getLastActionRes = $db->prepared_query($getLastActionSql, $getLastActionVar);
+
+        if(!empty($getLastActionRes[0])){
+            // if this is not empty use the time of the action
+            $lastActionTime = $getLastActionRes[0]['time'];
+        } else {
+            // else this is where some test would show the action history may not be up to date for testing data, use the submitted time
+            $lastActionTime = $record['submitted'];
+        }
+
+        // calculate the days
+        $date1 = new DateTime(date('Y-m-d'));
+        $date2 = new DateTime(date('Y-m-d',$lastActionTime));
+        $interval = $date1->diff($date2);
+        $lastActionDays = $interval->format('%a');
+
+        // initialize the email
         $email = new Portal\Email();
         $email->setSiteRoot($siteRoot);
         // ive seen examples using the attachApproversAndEmail method and some had smarty vars and some did not.
         $title = strlen($record['title']) > 45 ? substr($record['title'], 0, 42) . '...' : $record['title'];
-        var_dump(date('Y-m-d H:i:s',$additionalDaysAgoTimestamp));
-var_dump($record);exit();
+
         // add in variables for the smarty template
         $email->addSmartyVariables(array(
             "daysSince" => $record['daysSince'],
+            "actualDaysAgo" => $lastActionDays,
             "truncatedTitle" => $title,
             "fullTitle" => $record['title'],
             "recordID" => $record['recordID'],

--- a/LEAF_Request_Portal/scripts/automated_email.php
+++ b/LEAF_Request_Portal/scripts/automated_email.php
@@ -114,7 +114,7 @@ foreach ($getWorkflowStepsRes as $workflowStep) {
         $email->setSiteRoot($siteRoot);
         // ive seen examples using the attachApproversAndEmail method and some had smarty vars and some did not.
         $title = strlen($record['title']) > 45 ? substr($record['title'], 0, 42) . '...' : $record['title'];
-
+var_dump($record);exit();
         // add in variables for the smarty template
         $email->addSmartyVariables(array(
             "daysSince" => $record['daysSince'],

--- a/LEAF_Request_Portal/templates/email/LEAF_automated_reminder_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_automated_reminder_body.tpl
@@ -1,4 +1,3 @@
-The last action on Request #{{$recordID}} is older than {{$daysSince}} days.
 Please review this request at your earliest convenience.<br /><br />
 
 Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
@@ -6,4 +5,5 @@ Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target
 Request status: {{$lastStatus}}<br /><br />
 Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
     {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
+    Number of days outstanding: <b>{{$actualDaysAgo}} </b> (Threshold: {{$daysSince}} days)
 <br />

--- a/LEAF_Request_Portal/templates/email/LEAF_automated_reminder_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_automated_reminder_body.tpl
@@ -5,5 +5,5 @@ Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target
 Request status: {{$lastStatus}}<br /><br />
 Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
     {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
-    Number of days outstanding: <b>{{$actualDaysAgo}} </b> (Threshold: {{$daysSince}} days)
+    Number of days outstanding: <b>{{$actualDaysAgo}} days</b> (Threshold: {{$daysSince}} days)
 <br />


### PR DESCRIPTION
This is the change that was brought up in the CoP where end users wanted to see the actual number of days since the last activity in the email. For testing  this is standard automated email sending it will now just have the extra text for number of days since last action.