### PR TITLE
LEAF-3607: Removed IE Workaround

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -443,12 +443,6 @@ var LeafFormGrid = function (containerID, options) {
         ).html();
         currentData[i][key] =
           currentData[i][key] == undefined ? "" : currentData[i][key];
-
-        // IE workaround... it adds zero-width "left-to-right mark" spaces for some reason, and we need to take it out
-        currentData[i][key] = currentData[i][key].replace(
-          /[\u200B-\u200E]/g,
-          ""
-        );
       }
       if (currentData[i].s1 == undefined) {
         currentData[i].s1 = {};


### PR DESCRIPTION
Workaround code for IE was making certain reports not work because of certain edge cases reported in helpdesk ticket.