### PR TITLE
LEAF-3629: intervalQueue setQueue() should create a copy of the array

### DIFF
--- a/libs/js/LEAF/intervalQueue.js
+++ b/libs/js/LEAF/intervalQueue.js
@@ -35,7 +35,7 @@ var intervalQueue = function() {
     }
 
     function setQueue(myArray) {
-        queue = myArray;
+        queue = Array.from(myArray);
     }
 
     function start() {


### PR DESCRIPTION
This resolves an issue where intervalQueue incorrectly clears out arrays provided through setQueue().

To reproduce the issue, copy and run this in LEAF Programmer:
```js
<script src="../libs/js/LEAF/intervalQueue.js"></script>
<script>
    let list = [1,2,3,4,5];
    
    let queue = new intervalQueue();
    queue.setQueue(list);
    queue.setWorker(item => {
    	return new Promise(resolve => resolve());
    });
    
    queue.start().then(() => {
    	console.log(list);
    });
</script>
```

Prior to this patch, the output in the console would be an empty array.

After this patch, it correctly shows: Array(5) [ 1, 2, 3, 4, 5 ]
