### PR TITLE
LEAF-3630: Simplify instructions

### DIFF
--- a/docs/InstallationConfiguration.md
+++ b/docs/InstallationConfiguration.md
@@ -15,35 +15,9 @@ Clone this project into a directory on your computer (example: C:\Desktop\Projec
 
 Several files need to be created/updated for LEAF to operate in your environment.
 
-In the sections below `$dbUser` and `$dbPass` are the same values used in the mysql Dockerfile and setup script.
-
 ## LEAF_Nexus
 
-Copy `globals.php` from the configuration files provided they will look like:
-Note there is a line here that can help you emulate a national db if you are pulling in data from a national however this file IS part of the repo now.
-
-```php
-<?php
-if (!defined('PRODUCT_NAME')) define('PRODUCT_NAME', getenv('PRODUCT_NAME'));
-if (!defined('VERSION_NUMBER')) define('VERSION_NUMBER', getenv('NEXUS_VERSION_NUMBER'));
-
-if (!defined('DATABASE_DB_ADMIN')) define('DATABASE_DB_ADMIN', getenv('DATABASE_DB_ADMIN'));
-
-if (!defined('DIRECTORY_HOST')) define('DIRECTORY_HOST', getenv('DATABASE_HOST'));
-// if you need to emulate a national you can create drop in a table name here instead of the getenv.
-if (!defined('DIRECTORY_DB')) define('DIRECTORY_DB', getenv('DATABASE_DB_DIRECTORY'));
-if (!defined('DIRECTORY_USER')) define('DIRECTORY_USER', getenv('DATABASE_USERNAME'));
-if (!defined('DIRECTORY_PASS')) define('DIRECTORY_PASS', getenv('DATABASE_PASSWORD'));
-
-if (!defined('HTTP_HOST')) define('HTTP_HOST', getenv('APP_HTTP_HOST'));
-if (!defined('AUTH_URL')) define('AUTH_URL', getenv('APP_URL_AUTH'));
-if (!defined('AUTH_TYPE')) define('AUTH_TYPE', getenv('APP_AUTH_TYPE'));
-if (!defined('CIPHER_KEY')) define('CIPHER_KEY', getenv('APP_CIPHER_KEY'));
-if (!defined('LIB_PATH')) define('LIB_PATH', getenv('APP_LIB_PATH'));
-
-```
-
-Copy `sources/Config.php` from the configuration files provided they will look like:
+Create `LEAF_Nexus/sources/Config.php`, and add the following code to the file:
 
 ```php
 <?php
@@ -77,46 +51,9 @@ class Config
 
 ## LEAF_Request_Portal
 
-Copy `globals.php` from the configuration files provided they will look like:
+Create `LEAF_Request_Portal/sources/Config.php` and add the following code into the file:
 
 ```php
-<?php
-if (!defined('PRODUCT_NAME')) define('PRODUCT_NAME', getenv('PRODUCT_NAME'));
-if (!defined('VERSION_NUMBER')) define('VERSION_NUMBER', getenv('PORTAL_VERSION_NUMBER'));
-
-if (!defined('DATABASE_DB_ADMIN')) define('DATABASE_DB_ADMIN', getenv('DATABASE_DB_ADMIN'));
-
-if (!defined('DIRECTORY_HOST')) define('DIRECTORY_HOST', getenv('DATABASE_HOST'));
-if (!defined('DIRECTORY_DB')) define('DIRECTORY_DB', getenv('DATABASE_DB_DIRECTORY'));
-if (!defined('DIRECTORY_USER')) define('DIRECTORY_USER', getenv('DATABASE_USERNAME'));
-if (!defined('DIRECTORY_PASS')) define('DIRECTORY_PASS', getenv('DATABASE_PASSWORD'));
-
-if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS'));
-if (!defined('HTTP_HOST')) define('HTTP_HOST', getenv('APP_HTTP_HOST'));
-if (!defined('AUTH_URL')) define('AUTH_URL', getenv('APP_URL_AUTH'));
-if (!defined('AUTH_TYPE')) define('AUTH_TYPE', getenv('APP_AUTH_TYPE'));
-if (!defined('CIPHER_KEY')) define('CIPHER_KEY', getenv('APP_CIPHER_KEY'));
-if (!defined('LIB_PATH')) define('LIB_PATH', getenv('APP_LIB_PATH'));
-
-```
-
-Create the following files `sources/DbConfig.php` and `sources/Config.php` and place the following code into them
-
-```php
-// This is the DbConfig.php in the sources folder
-<?php
-
-namespace Portal;
-
-class DB_Config
-{
-    public $dbHost = DIRECTORY_HOST;
-    public $dbName = 'leaf_portal';
-    public $dbUser = DIRECTORY_USER;
-    public $dbPass = DIRECTORY_PASS;
-}
-
-// This is the Config.php in the sources folder
 <?php
 
 namespace Portal;
@@ -162,7 +99,7 @@ Navigate to https://localhost/LEAF_Nexus or https://localhost/LEAF_Request_Porta
 
 ### Docker
 
-In `docker/docker-compose.yml`, comment out the line `- 443:443`. Next, in `docker/php/Dockerfile`, comment out the line `EXPOSE 443`. Finally, rebuild the images with `docker compose build --no-cache` and navigate to http://localhost/LEAF_Nexus or http://localhost/LEAF_Request_Portal.
+In `docker/docker-compose.yml`, comment out the line `- 443:443`. Finally, rebuild the images with `docker compose build --no-cache` and navigate to http://localhost/LEAF_Nexus or http://localhost/LEAF_Request_Portal.
 
 ## Checking Email
 


### PR DESCRIPTION
This aims to simplify installation for developers.

1. Are the lines removed necessary? It seems to work without them.
2. Is deployment impacted if the Config.php files are stored in the repository? It would be easier if people didn't need to manually create this.
