### PR TITLE
LEAF-3596 file upload copy error

### DIFF
--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -770,17 +770,16 @@ function copyRequest(){
                         if (pickAndChooseValues.includes(resultValue[series].indicatorID)) {
 
                             // uploaded files will need to have a special case done to them to copy them over to the new record
-                            if(resultValue[series].format == 'fileupload' || resultValue[series].format == 'image'){
-                                if(resultValue[series].value.length > 0){
-                                    resultValue[series].value.forEach(function(currentFile){
-                                        let fileDat = {
-                                            fileName: currentFile,
-                                            series: series,
-                                            indicatorID: resultValue[series].indicatorID
-                                        }
-                                        fileData.push(fileDat);
-                                    });
-                                }
+                            if((resultValue[series].format == 'fileupload' || resultValue[series].format == 'image')
+                                && Array.isArray(resultValue[series].value)) {
+                                resultValue[series].value.forEach(function(currentFile){
+                                    let fileDat = {
+                                        fileName: currentFile,
+                                        series: series,
+                                        indicatorID: resultValue[series].indicatorID
+                                    }
+                                    fileData.push(fileDat);
+                                });
                                 // also need to pull this out of an array since it would then move this to an object which breaks everything.
                                 updateData[resultValue[series].indicatorID] = resultValue[series].value.join('\r\n');
                             }


### PR DESCRIPTION
Reworks the logic for copying file upload formats to confirm that the value is an array prior to proceeding with array methods.
Value is an empty string on an original (non-copied) form if no files have ever been attached because there is no data table entry. 
Associated with yourIT INC26366962