### PR TITLE
LEAF 3501 duplicate text issue and 'no format' text formatting

### DIFF
--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -38,8 +38,8 @@
                 <br /><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
             </label>
             <!--{else}-->
-            <span <!--{if $indicator.format == null || $indicator.format == 'fileupload' || $indicator.format == 'image' }-->tabindex="0"<!--{/if}--> id="format_label_<!--{$indicator.indicatorID|strip_tags}-->">
-                    <!--{if $indicator.format == null}-->
+            <span id="format_label_<!--{$indicator.indicatorID|strip_tags}-->" <!--{if $indicator.format|in_array:['','fileupload','image'] }-->tabindex="0"<!--{/if}-->>
+                    <!--{if $indicator.format === ''}-->
                         <br /><b><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--></b><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
                     <!--{else}-->
                         <br /><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
@@ -60,7 +60,7 @@
             <div class="tableinput">
             <table class="table" id="grid_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->_input"
                 style="word-wrap:break-word; table-layout: fixed; height: 100%; display: table"
-                aria-label="<!--{$indicator.name|sanitizeRichtext}-->">
+                aria-describedby="format_label_<!--{$indicator.indicatorID|strip_tags}-->">
                 <thead>
                 </thead>
                 <tbody>


### PR DESCRIPTION
Adjusts the aria attribute on grid format questions so that it refers back to the element containing the question's name, rather than directly to the name value, where the value was being interpreted as html in some circumstances. 

Also corrects the format value for no-format questions to an empty string. 
edit:  format is empty string, but this did not cause further formatting issues, so this update will only correct the duplication issue in grid questions