### PR TITLE
LEAF 3635 grid format - load options from file celltype

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -1009,7 +1009,28 @@ function updateNames(){
         gridJSON[i].id = gridJSON[i].id === undefined ? makeColumnID() : gridJSON[i].id;
     });
 }
-
+/**
+ * Purpose: Add basic HTML input areas to the grid cell
+ */
+function gridCellBasicInputs(name = '', columnNumber = '', id = makeColumnID(), isNewRow = false) {
+    return `<div tabindex="0" id="${id}" class="cell">
+      <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer;" />
+      <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer; display: ${isNewRow ? 'none;' : 'inline;'}" />
+      </br>
+      <span class="columnNumber">Column #${columnNumber}: </span>
+      <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />
+      </br>&nbsp;
+      <input type="text" value="${name}" onchange="updateNames();" />
+      </br>&nbsp;</br>
+      <label for="grid_cell_type_${columnNumber}" style="display: block; text-align: left;">Type: </label>
+      <select id="grid_cell_type_${columnNumber}" style="width: 185px;" onchange="toggleDropDown(this.value, this, ${columnNumber});">
+        <option value="text">Single line input</option>
+        <option value="date">Date</option>
+        <option value="dropdown">Drop Down</option>
+        <option value="dropdown_file">Dropdown From File</option>
+        <option value="textarea">Multi-line text</option>
+      </select>`;
+}
 /**
  * Purpose: Make Grid for Input Option
  * @param columns
@@ -1026,25 +1047,7 @@ function makeGrid(columns) {
         }
         let name = gridJSON[i].name === undefined ? 'No title' : gridJSON[i].name;
         let id = gridJSON[i].id === undefined ? makeColumnID() : gridJSON[i].id;
-        $(gridBodyElement).append(
-            `<div tabindex="0" id="${id}" class="cell">
-                <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer" />
-                <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer" />
-                </br>
-                <span class="columnNumber">Column #${(i + 1)}: </span>
-                <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />
-                </br>&nbsp;
-                <input type="text" value="${name}" onchange="updateNames();" />
-                </br>&nbsp;</br>
-                <label for="grid_cell_type_${i + 1}" style="display: block; text-align: left;">Type: </label>
-                <select id="grid_cell_type_${i + 1}" style="width: 185px;" onchange="toggleDropDown(this.value, this, ${i + 1});">
-                    <option value="text">Single line input</option>
-                    <option value="date">Date</option>
-                    <option value="dropdown">Drop Down</option>
-                    <option value="dropdown_file">Dropdown From File</option>
-                    <option value="textarea">Multi-line text</option>
-                </select>`
-        );
+        $(gridBodyElement).append(gridCellBasicInputs(name, i + 1, id, false));
         if(columns === 1){
             rightArrows($(gridBodyElement + ' > div:last'), false);
             leftArrows($(gridBodyElement + ' > div:last'), false);
@@ -1195,25 +1198,7 @@ function rightArrows(cell, toggle){
 function addCells(){
     columns = columns + 1;
     rightArrows($(gridBodyElement + ' > div:last'), true);
-    $(gridBodyElement).append(
-        `<div tabindex="0" id="${makeColumnID()}" class="cell">
-            <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer; display: inline" />
-            <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer; display: none" />
-            </br>
-            <span class="columnNumber"></span>
-            <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />
-            </br>&nbsp;
-            <input type="text" value="No title" onchange="updateNames();" />
-            </br>&nbsp;</br>
-            <label for="grid_cell_type_${columns}" style="display: block; text-align: left;">Type: </label>
-            <select id="grid_cell_type_${columns}" style="width: 185px;" onchange="toggleDropDown(this.value, this, columns);">
-                <option value="text">Single line input</option>
-                <option value="date">Date</option>
-                <option value="dropdown">Drop Down</option>
-                <option value="dropdown_file">Dropdown From File</option>
-                <option value="textarea">Multi-line text</option>
-            </select>`
-    );
+    $(gridBodyElement).append(gridCellBasicInputs('No Title', columns, makeColumnID(), true));
     $('#tableStatus').attr('aria-label', 'Column added, ' + $(gridBodyElement).children().length + ' total.');
     $(gridBodyElement + ' > div:last').focus();
     updateColumnNumbers();

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -911,6 +911,7 @@ function setFormatElementValue() {
                     }
                     if(properties.type === 'dropdown_file'){
                         properties.file = $(this).find('select[id^="dropdown_file_select"]').val();
+                        properties.hasHeader = Boolean(+$(this).find('select[id^="dropdown_file_header_select"]').val());
                     }
                 } else {
                     properties.type = 'textarea';
@@ -1075,6 +1076,7 @@ function makeGrid(columns) {
             if(gridJSON[i].type.toString() === 'dropdown_file') {
                 if($(gridBodyElement + ' > div:eq(' + i + ') > div.dropdown_file').length === 0) {
                     const gridFile = gridJSON[i]?.file;
+                    const hasHeader = gridJSON[i]?.hasHeader;
                     let options = '<option value="">Select a File</option>';
                     for (let f = 0; f < fileManagerTextFiles.length; f++) {
                         const filename = XSSHelpers.stripAllTags(fileManagerTextFiles[f]);
@@ -1084,7 +1086,12 @@ function makeGrid(columns) {
                     $(gridBodyElement + ' > div:eq(' + i + ')').append(`
                         <div class="dropdown_file" style="margin-top: 0.5rem;">
                             <label for="dropdown_file_select_${i}" style="display: block; text-align: left;">File:</label>
-                            <select id="dropdown_file_select_${i}" style="width: 185px;">${options}</select>
+                            <select id="dropdown_file_select_${i}" style="width: 185px; margin-bottom:0.25rem;">${options}</select>
+                            <label for="dropdown_file_header_select_${i}" style="display: block; text-align: left;">Does file contain headers</label>
+                            <select id="dropdown_file_header_select_${i}" style="width: 185px;">
+                                <option value="0" ${hasHeader === false ? 'selected': ''}>No</option>
+                                <option value="1" ${hasHeader === true ? 'selected': ''}>Yes</option>
+                            </select>
                         </div>`
                     );
                 }
@@ -1131,7 +1138,12 @@ function toggleDropDown(type, cell, columnNumber) {
             $(cell).parent().append(`
                 <div class="dropdown_file" style="margin-top: 0.5rem;">
                     <label for="dropdown_file_select_${columnNumber}" style="display: block; text-align: left;">File:</label>
-                    <select id="dropdown_file_select_${columnNumber}" style="width: 185px;">${options}</select>
+                    <select id="dropdown_file_select_${columnNumber}" style="width: 185px; margin-bottom:0.25rem;">${options}</select>
+                    <label for="dropdown_file_header_select_${columnNumber}" style="display: block; text-align: left;">Does file contain headers</label>
+                    <select id="dropdown_file_header_select_${columnNumber}" style="width: 185px;">
+                        <option value="0">No</option>
+                        <option value="1">Yes</option>
+                    </select>
                 </div>`
             );
             ariaStatus += 'Source file select added.';

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -908,10 +908,9 @@ function setFormatElementValue() {
                 if(properties.type !== undefined){
                     if(properties.type === 'dropdown'){
                         properties.options = gridDropdown($(this).find('textarea').val().replace(/,/g, ""));
-                    } else if(properties.type === 'dropdown_file'){
+                    }
+                    if(properties.type === 'dropdown_file'){
                         properties.file = $(this).find('select[id^="dropdown_file_select"]').val();
-                    } else {
-                        console.log(properties.type);
                     }
                 } else {
                     properties.type = 'textarea';

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -1088,7 +1088,7 @@ function makeGrid(columns) {
                     }
                     $(gridBodyElement + ' > div:eq(' + i + ')').append(`
                         <div class="dropdown_file" style="margin-top: 0.5rem;">
-                            <label for="dropdown_file_select_${i}" style="display: block; text-align: left;">File:</label>
+                            <label for="dropdown_file_select_${i}" style="display: block; text-align: left;">File (csv or txt format):</label>
                             <select id="dropdown_file_select_${i}" style="width: 185px; margin-bottom:0.25rem;">${options}</select>
                             <label for="dropdown_file_header_select_${i}" style="display: block; text-align: left;">Does file contain headers</label>
                             <select id="dropdown_file_header_select_${i}" style="width: 185px;">
@@ -1140,7 +1140,7 @@ function toggleDropDown(type, cell, columnNumber) {
             }
             $(cell).parent().append(`
                 <div class="dropdown_file" style="margin-top: 0.5rem;">
-                    <label for="dropdown_file_select_${columnNumber}" style="display: block; text-align: left;">File:</label>
+                    <label for="dropdown_file_select_${columnNumber}" style="display: block; text-align: left;">File (csv or txt format):</label>
                     <select id="dropdown_file_select_${columnNumber}" style="width: 185px; margin-bottom:0.25rem;">${options}</select>
                     <label for="dropdown_file_header_select_${columnNumber}" style="display: block; text-align: left;">Does file contain headers</label>
                     <select id="dropdown_file_header_select_${columnNumber}" style="width: 185px;">

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -904,10 +904,14 @@ function setFormatElementValue() {
                     properties.name = $(this).children('input:eq(0)').val();
                 }
                 properties.id = $(this).attr('id');
-                properties.type = $(this).find('select').val();
+                properties.type = $(this).find('select[id^="grid_cell_type"]').val();
                 if(properties.type !== undefined){
                     if(properties.type === 'dropdown'){
                         properties.options = gridDropdown($(this).find('textarea').val().replace(/,/g, ""));
+                    } else if(properties.type === 'dropdown_file'){
+                        properties.file = $(this).find('select[id^="dropdown_file_select"]').val();
+                    } else {
+                        console.log(properties.type);
                     }
                 } else {
                     properties.type = 'textarea';
@@ -1023,11 +1027,23 @@ function makeGrid(columns) {
         let name = gridJSON[i].name === undefined ? 'No title' : gridJSON[i].name;
         let id = gridJSON[i].id === undefined ? makeColumnID() : gridJSON[i].id;
         $(gridBodyElement).append(
-            '<div tabindex="0" id="' + id + '" class="cell"><img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer" />' +
-            '<img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer" /></br>' +
-            '<span class="columnNumber">Column #' + (i + 1) + ': </span><img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />' +
-            '</br>&nbsp;<input type="text" value="' + name + '" onchange="updateNames();"></input></br>&nbsp;</br>Type:<select onchange="toggleDropDown(this.value, this);">' +
-            '<option value="text">Single line input</option><option value="date">Date</option><option value="dropdown">Drop Down</option><option value="textarea">Multi-line text</option></select>'
+            `<div tabindex="0" id="${id}" class="cell">
+                <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer" />
+                <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer" />
+                </br>
+                <span class="columnNumber">Column #${(i + 1)}: </span>
+                <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />
+                </br>&nbsp;
+                <input type="text" value="${name}" onchange="updateNames();" />
+                </br>&nbsp;</br>
+                <label for="grid_cell_type_${i + 1}" style="display: block; text-align: left;">Type: </label>
+                <select id="grid_cell_type_${i + 1}" style="width: 185px;" onchange="toggleDropDown(this.value, this, ${i + 1});">
+                    <option value="text">Single line input</option>
+                    <option value="date">Date</option>
+                    <option value="dropdown">Drop Down</option>
+                    <option value="dropdown_file">Dropdown From File</option>
+                    <option value="textarea">Multi-line text</option>
+                </select>`
         );
         if(columns === 1){
             rightArrows($(gridBodyElement + ' > div:last'), false);
@@ -1057,23 +1073,83 @@ function makeGrid(columns) {
                     $(gridBodyElement + ' > div:eq(' + i + ')').append('<span class="dropdown"><div>One option per line</div><textarea aria-label="Dropdown options, one option per line" style="width: 153px; resize: none;"value="">' + options + '</textarea></span>');
                 }
             }
+            if(gridJSON[i].type.toString() === 'dropdown_file') {
+                if($(gridBodyElement + ' > div:eq(' + i + ') > div.dropdown_file').length === 0) {
+                    const gridFile = gridJSON[i]?.file;
+                    let options = '<option value="">Select a File</option>';
+                    for (let f = 0; f < fileManagerTextFiles.length; f++) {
+                        const filename = XSSHelpers.stripAllTags(fileManagerTextFiles[f]);
+                        const attrSelected = gridFile === filename ? 'selected' : '';
+                        options += `<option value=${filename} ${attrSelected}>${filename}</option>`
+                    }
+                    $(gridBodyElement + ' > div:eq(' + i + ')').append(`
+                        <div class="dropdown_file" style="margin-top: 0.5rem;">
+                            <label for="dropdown_file_select_${i}" style="display: block; text-align: left;">File:</label>
+                            <select id="dropdown_file_select_${i}" style="width: 185px;">${options}</select>
+                        </div>`
+                    );
+                }
+            }
         }
     }
 }
 
 /**
- * Purpose: Dropdown for Grid Options
+ * Purpose: handle Dropdowns for normal and file Grid options, update aria status
  * @param type
  * @param cell
+ * @param columnNumber
  */
-function toggleDropDown(type, cell){
-    if(type === 'dropdown'){
-        $(cell).parent().append('<span class="dropdown"><div>One option per line</div><textarea aria-label="Dropdown options, one option per line" value="" style="width: 153px; resize:none"></textarea></span>');
-        $('#tableStatus').attr('aria-label', 'Make drop options in the space below, one option per line.');
-    } else {
-        $(cell).parent().find('span.dropdown').remove();
-        $('#tableStatus').attr('aria-label', 'Dropdown options box removed');
-    }
+function toggleDropDown(type, cell, columnNumber) {
+    elJQDropDown = $(cell).parent().find('span.dropdown');
+    elJQDropDownFile = $(cell).parent().find('div.dropdown_file');
+    let ariaStatus = '';
+
+    switch(type) {
+        case 'dropdown':
+            if(elJQDropDownFile.length === 1) {
+                elJQDropDownFile.remove();
+                ariaStatus += `Source file select removed.  `;
+            }
+            ariaStatus += `Dropdown options box added.  Make drop options in the space below, one option per line.`;
+            $(cell).parent().append(
+                `<span class="dropdown">
+                    <div>One option per line</div>
+                    <textarea aria-label="Dropdown options, one option per line" value="" style="width: 153px; resize:none"></textarea>
+                </span>`
+            );
+            $('#tableStatus').attr('aria-label', ariaStatus);
+            break;
+        case 'dropdown_file':
+            if(elJQDropDown.length === 1) {
+                elJQDropDown.remove();
+                ariaStatus += 'Dropdown options box removed. ';
+            }
+            let options = '<option value="">Select File</option>';
+            for (let i = 0; i < fileManagerTextFiles.length; i++) {
+                options += `<option value=${XSSHelpers.stripAllTags(fileManagerTextFiles[i])}>${fileManagerTextFiles[i]}</option>`
+            }
+            $(cell).parent().append(`
+                <div class="dropdown_file" style="margin-top: 0.5rem;">
+                    <label for="dropdown_file_select_${columnNumber}" style="display: block; text-align: left;">File:</label>
+                    <select id="dropdown_file_select_${columnNumber}" style="width: 185px;">${options}</select>
+                </div>`
+            );
+            ariaStatus += 'Source file select added.';
+            $('#tableStatus').attr('aria-label', ariaStatus);
+            break;
+        default:
+            if(elJQDropDown.length === 1) {
+                elJQDropDown.remove();
+                ariaStatus += 'Dropdown options box removed.';
+            }
+            if(elJQDropDownFile.length === 1) {
+                elJQDropDownFile.remove();
+                ariaStatus += 'Source file select removed.';
+            }
+            $('#tableStatus').attr('aria-label', ariaStatus);
+            break;
+	}
 }
 
 /**
@@ -1109,11 +1185,23 @@ function addCells(){
     columns = columns + 1;
     rightArrows($(gridBodyElement + ' > div:last'), true);
     $(gridBodyElement).append(
-        '<div tabindex="0" id="' + makeColumnID() + '" class="cell"><img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer; display: inline" />' +
-        '<img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer; display: none" /></br>' +
-        '<span class="columnNumber"></span><img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />' +
-        '</br>&nbsp;<input type="text" value="No title" onchange="updateNames();"></input></br>&nbsp;</br>Type:<select onchange="toggleDropDown(this.value, this);">' +
-        '<option value="text">Single line input</option><option value="date">Date</option><option value="dropdown">Drop Down</option><option value="textarea">Multi-line text</option></select>'
+        `<div tabindex="0" id="${makeColumnID()}" class="cell">
+            <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveLeft(event)" src="../dynicons/?img=go-previous.svg&w=16" title="Move column left" alt="Move column left" style="cursor: pointer; display: inline" />
+            <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="moveRight(event)" src="../dynicons/?img=go-next.svg&w=16" title="Move column right" alt="Move column right" style="cursor: pointer; display: none" />
+            </br>
+            <span class="columnNumber"></span>
+            <img role="button" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="deleteColumn(event)" src="../dynicons/?img=process-stop.svg&w=16" title="Delete column" alt="Delete column" style="cursor: pointer; vertical-align: middle;" />
+            </br>&nbsp;
+            <input type="text" value="No title" onchange="updateNames();" />
+            </br>&nbsp;</br>
+            <label for="grid_cell_type_${columns}" style="display: block; text-align: left;">Type: </label>
+            <select id="grid_cell_type_${columns}" style="width: 185px;" onchange="toggleDropDown(this.value, this, columns);">
+                <option value="text">Single line input</option>
+                <option value="date">Date</option>
+                <option value="dropdown">Drop Down</option>
+                <option value="dropdown_file">Dropdown From File</option>
+                <option value="textarea">Multi-line text</option>
+            </select>`
     );
     $('#tableStatus').attr('aria-label', 'Column added, ' + $(gridBodyElement).children().length + ' total.');
     $(gridBodyElement + ' > div:last').focus();
@@ -2146,6 +2234,24 @@ function fetchFormSecureInfo() {
         renderSecureFormsInfo(res)
     });
 }
+/**
+ * Purpose: Get text files from file mngr for use with grid questions
+*/
+let fileManagerTextFiles = [];
+function fetchDropdownFiles() {
+    $.ajax({
+        type: 'GET',
+        url: '../api/system/files',
+        success: (res) => {
+            const files = res || [];
+            fileManagerTextFiles = files.filter(filename => filename.indexOf('.txt') > -1 || filename.indexOf('.csv') > -1);
+        },
+        error: (err) => {
+            console.log(err);
+        },
+        cache: false
+    });
+}
 
 /**
  * Purpose: Create New form
@@ -2235,6 +2341,7 @@ $(function() {
 
     showFormBrowser();
     fetchFormSecureInfo();
+    fetchDropdownFiles();
 
     <!--{if $form != ''}-->
     postRenderFormBrowser = function() { selectForm('<!--{$form}-->') };

--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -99,7 +99,7 @@ var LeafForm = function (containerID) {
       });
     }
 
-    function loadCrosswalkFile(fileName, iID) {
+    function loadFilemanagerFile(fileName, iID) {
       return new Promise((resolve, reject)=> {
         const xhttpInds = new XMLHttpRequest();
         xhttpInds.onreadystatechange = () => {
@@ -122,7 +122,7 @@ var LeafForm = function (containerID) {
         xhttpInds.open("GET", `files/${fileName}`, true);
         xhttpInds.send();
       });
-    }  
+    }
 
     function removeSelectOptions(iID) {
       let selectbox = document.getElementById(iID);
@@ -262,7 +262,7 @@ var LeafForm = function (containerID) {
           level2indID: cond.level2IndID
         }
 
-        loadCrosswalkFile(dropdownInfo[indID].fileName, indID).then(fileContents => {
+        loadFilemanagerFile(dropdownInfo[indID].fileName, indID).then(fileContents => {
           dropdownInfo[indID].fileContents = fileContents;  //save for crosswalk listeners
           const optionsAreRemoved = removeSelectOptions(indID);
           if (optionsAreRemoved === true) {

--- a/LEAF_Request_Portal/js/gridInput.js
+++ b/LEAF_Request_Portal/js/gridInput.js
@@ -1,4 +1,5 @@
 var gridInput = function (gridParameters, indicatorID, series, recordID) {
+  let fileOptions = {};
   function decodeCellHTMLEntities(values, showScriptTags = false) {
     let gridInfo = { ...values };
     if (gridInfo?.cells) {
@@ -25,18 +26,11 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
   }
   function makeDropdown(options, selected, headerName = "") {
     let dropdownElement = `<select aria-label="${headerName}" role="dropdown" style="width:100%; -moz-box-sizing:border-box; -webkit-box-sizing:border-box; box-sizing:border-box; width: -webkit-fill-available; width: -moz-available; width: fill-available;">`;
+    dropdownElement += `<option value="">Select an option</option>`;
     for (let i = 0; i < options.length; i++) {
-      if (selected === options[i]) {
-        dropdownElement +=
-          '<option value="' +
-          options[i] +
-          '" selected="selected">' +
-          options[i] +
-          "</option>";
-      } else {
-        dropdownElement +=
-          '<option value="' + options[i] + '">' + options[i] + "</option>";
-      }
+      const optVal = options[i].replaceAll('\"', '&quot;');
+      const attrSelected = selected === options[i] ? 'selected' : '';
+      dropdownElement += `<option value="${optVal}" ${attrSelected}>${options[i]}</option>`;
     }
     dropdownElement += "</select>";
     return dropdownElement;
@@ -94,18 +88,28 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
     );
 
     //populates table
-    for (var i = 0; i < rows; i++) {
+    for (let i = 0; i < rows; i++) {
+      const selectedRowValues = values?.cells[i] || [];
       $(gridBodyElement).append("<tr></tr>");
-
       //generates row layout
-      for (var j = 0; j < columns; j++) {
+      for (let j = 0; j < columns; j++) {
         switch (gridParameters[j].type) {
           case "dropdown":
             element = makeDropdown(
               gridParameters[j].options,
-              null,
+              selectedRowValues[j] || null,
               gridParameters[j].name
             );
+            break;
+          case "dropdown_file":
+            const filename = gridParameters[j].file;
+            if (fileOptions[filename] !== undefined) {
+              element = makeDropdown(
+                fileOptions[filename],
+                selectedRowValues[j] || null,
+                gridParameters[j].name
+              );
+            }
             break;
           case "textarea":
             element = `<textarea style="overflow-y:auto; overflow-x:hidden; resize: none; width:100%; height: 50px; -moz-box-sizing:border-box; -webkit-box-sizing:border-box; box-sizing:border-box; width: -webkit-fill-available; width: -moz-available; width: fill-available;" aria-label="${gridParameters[j].name}"></textarea>`;
@@ -120,7 +124,7 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
             break;
         }
         $(gridBodyElement + " > tr:eq(" + i + ")").append(
-          '<td aria-label="' + gridParameters[j].name + '">' + element + "</td>"
+          `<td aria-label="${gridParameters[j].name}">${element}</td>`
         );
         $('input[data-type="grid-date"]').datepicker();
       }
@@ -285,6 +289,62 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
       }
     }
   }
+  function loadFilemanagerFile(fileName, iID) {
+    return new Promise((resolve, reject)=> {
+      const xhttpInds = new XMLHttpRequest();
+      xhttpInds.onreadystatechange = () => {
+        if (xhttpInds.readyState === 4) {
+          switch(xhttpInds.status) {
+            case 200:
+              resolve(xhttpInds.responseText);
+              break;
+            case 404:
+              let content = `The file for indicator ${iID} was not found at files/${fileName}.`
+              content += `\nCheck the entered file name in setup and in the LEAF file manager.`
+              reject(new Error(content));
+              break;
+            default:
+              reject(new Error(xhttpInds.status));
+              break;
+          }
+        }
+      };
+      xhttpInds.open("GET", `files/${fileName}`, true);
+      xhttpInds.send();
+    });
+  }
+  /**
+   * If grid does not have a 'dropdown_file' cell type, or if the filename already exists as a property of
+   * the instance-scoped variable 'fileOptions', loading is skipped and promise is immediately resolved.
+   * Options are otherwise added to 'fileOptions' under their filename as they are loaded.
+   * @returns {Promise}
+   */
+  function checkForFileOptions() {
+    return new Promise((resolve, reject) => {
+      const loadedDropdowns = gridParameters.filter(p => p.type === 'dropdown_file');
+      const uniqueFiles = Array.from(new Set(loadedDropdowns.map(d => d.file)));
+      if (uniqueFiles.length === 0) {
+        resolve();
+      } else {
+        let count = 0;
+        uniqueFiles.forEach(filename => {
+          if (fileOptions[filename] === undefined) {
+            loadFilemanagerFile(filename, indicatorID)
+            .then(fileContent => {
+              let list = fileContent.split(/\n/).map(line => line.split(",")[0]) || [];
+              list = list.map(o => XSSHelpers.stripAllTags(o.trim()));
+              list = Array.from(new Set(list)).sort();
+              fileOptions[filename] = list;
+              count += 1;
+              if (count === uniqueFiles.length) {
+                resolve();
+              }
+            }).catch(err => reject(err))
+          }
+        })
+      }
+    });
+  }
   function addRow() {
     var gridBodyElement =
       "#grid_" + indicatorID + "_" + series + "_input > tbody";
@@ -293,7 +353,7 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
       .find('[title="Move line down"]')
       .css("display", "inline");
     $(gridBodyElement).append("<tr></tr>");
-    for (var i = 0; i < gridParameters.length; i++) {
+    for (let i = 0; i < gridParameters.length; i++) {
       switch (gridParameters[i].type) {
         case "dropdown":
           $(gridBodyElement + " > tr:last").append(
@@ -306,6 +366,20 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
                 gridParameters[i].name
               ) +
               "</td>"
+          );
+          break;
+        case "dropdown_file":
+          const filename = gridParameters[i].file;
+          $(gridBodyElement + " > tr:last").append(
+            '<td aria-label="' +
+            gridParameters[i].name +
+            '">' +
+            makeDropdown(
+              fileOptions[filename] || [],
+              null,
+              gridParameters[i].name
+            ) +
+            "</td>"
           );
           break;
         case "textarea":
@@ -581,9 +655,9 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
     }
   }
   function printTablePreview() {
-    var previewElement = "#grid" + indicatorID + "_" + series;
+    let previewElement = "#grid" + indicatorID + "_" + series;
 
-    for (var i = 0; i < gridParameters.length; i++) {
+    for (let i = 0; i < gridParameters.length; i++) {
       $(previewElement).append(
         '<div style="padding: 10px; vertical-align: top; display: inline-block; flex: 1; order: ' +
           (i + 1) +
@@ -602,6 +676,11 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
             "</li></br>"
         );
       }
+      if (gridParameters[i].type === "dropdown_file" && gridParameters[i].file !== "") {
+        $(previewElement + "> div:eq(" + i + ")").append(
+          `Options loaded from:</br><b>${gridParameters[i].file}</b></br>`
+        );
+      }
     }
   }
   return {
@@ -613,5 +692,6 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
     moveUp: moveUp,
     moveDown: moveDown,
     triggerClick: triggerClick,
+    checkForFileOptions: checkForFileOptions
   };
 };

--- a/LEAF_Request_Portal/js/gridInput.js
+++ b/LEAF_Request_Portal/js/gridInput.js
@@ -102,18 +102,16 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
             break;
           case "dropdown_file":
             const filename = gridParameters[j].file;
-            if (fileOptions[filename] !== undefined) {
-              const hasHeader = gridParameters[j].hasHeader;
-              const loadedOptions = fileOptions[filename]?.options || [];
-              const firstRow =  fileOptions[filename]?.firstRow || '';
-              const options = hasHeader ?
-                loadedOptions.filter(o => o !== firstRow && o !== '') : loadedOptions.filter(o => o !== '');
-              element = makeDropdown(
-                options,
-                selectedRowValues[j] || null,
-                gridParameters[j].name
-              );
-            }
+            const hasHeader = gridParameters[j].hasHeader;
+            const loadedOptions = fileOptions[filename]?.options || [];
+            const firstRow =  fileOptions[filename]?.firstRow || '';
+            const options = hasHeader ?
+              loadedOptions.filter(o => o !== firstRow && o !== '') : loadedOptions.filter(o => o !== '');
+            element = makeDropdown(
+              options,
+              selectedRowValues[j] || null,
+              gridParameters[j].name
+            );
             break;
           case "textarea":
             element = `<textarea style="overflow-y:auto; overflow-x:hidden; resize: none; width:100%; height: 50px; -moz-box-sizing:border-box; -webkit-box-sizing:border-box; box-sizing:border-box; width: -webkit-fill-available; width: -moz-available; width: fill-available;" aria-label="${gridParameters[j].name}"></textarea>`;
@@ -303,8 +301,8 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
               resolve(xhttpInds.responseText);
               break;
             case 404:
-              let content = `The file for indicator ${iID} was not found at files/${fileName}.`
-              content += `\nCheck the entered file name in setup and in the LEAF file manager.`
+              let content = `The file '${fileName}' for indicator ${iID} was not found.`
+              content += `\nCheck the file in the LEAF file manager or notify an admin.`
               reject(new Error(content));
               break;
             default:
@@ -337,7 +335,7 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
             .then(fileContent => {
               let list = fileContent.split(/\n/).map(line => line.split(",")[0]) || [];
               list = list.map(o => XSSHelpers.stripAllTags(o.trim()));
-              const firstRow = list[0];
+              const firstRow = list[0] || '';
               list = Array.from(new Set(list)).sort();
               fileOptions[filename] = {
                 firstRow,
@@ -369,7 +367,7 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
               gridParameters[i].name +
               '">' +
               makeDropdown(
-                gridParameters[i].options,
+                gridParameters[i].options || [],
                 null,
                 gridParameters[i].name
               ) +

--- a/LEAF_Request_Portal/js/gridInput.js
+++ b/LEAF_Request_Portal/js/gridInput.js
@@ -26,6 +26,7 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
   }
   function makeDropdown(options, selected, headerName = "") {
     let dropdownElement = `<select aria-label="${headerName}" role="dropdown" style="width:100%; -moz-box-sizing:border-box; -webkit-box-sizing:border-box; box-sizing:border-box; width: -webkit-fill-available; width: -moz-available; width: fill-available;">`;
+    dropdownElement += `<option value="">Select an option</option>`;
     for (let i = 0; i < options.length; i++) {
       const optVal = options[i].replaceAll('\"', '&quot;');
       const attrSelected = selected === options[i] ? 'selected' : '';

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -72,12 +72,14 @@
                 var gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}--> = new gridInput(<!--{$indicator.options[0]}-->, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->);
                 $(function() {
                     gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.checkForFileOptions()
-                    .then(() => {
+                    .finally(() => {
                         gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.input(<!--{$indicator.value|json_encode}-->);
                         if (typeof (<!--{$indicator.value|json_encode}-->.cells) === "undefined") {
                             gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.addRow();
                         }
-                    }).catch(err => console.log(err));
+                    }).catch(err => {
+                        alert(err);
+                    });
                 });
 
                 <!--{if $indicator.required == 1}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -71,10 +71,13 @@
             <script>
                 var gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}--> = new gridInput(<!--{$indicator.options[0]}-->, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->);
                 $(function() {
-                    gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.input(<!--{$indicator.value|json_encode}-->);
-                    if (typeof (<!--{$indicator.value|json_encode}-->.cells) === "undefined") {
-                        gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.addRow();
-                    }
+                    gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.checkForFileOptions()
+                    .then(() => {
+                        gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.input(<!--{$indicator.value|json_encode}-->);
+                        if (typeof (<!--{$indicator.value|json_encode}-->.cells) === "undefined") {
+                            gridInput_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->.addRow();
+                        }
+                    }).catch(err => console.log(err));
                 });
 
                 <!--{if $indicator.required == 1}-->


### PR DESCRIPTION
Adds the cell type 'dropdown from file' for grid format questions..  This allows options for the dropdown to be loaded from a file manager text file.

Other: Fixes an issue that caused quotes to break dropdown options for grid format questions, and adds 'Select an Option' as an initial dropdown text prompt.