### PR TITLE
Hotfix Leaf 3757 email tracker not in comments

### DIFF
--- a/LEAF_Request_Portal/scripts/events/TEMPLATE_CustomEvent_YOUR_ID.php
+++ b/LEAF_Request_Portal/scripts/events/TEMPLATE_CustomEvent_YOUR_ID.php
@@ -74,6 +74,6 @@ class CustomEvent_[YOUR EVENT ID]
         $tmp = $this->dir->lookupLogin($record[0]['userID']);
         $this->email->addRecipient($tmp[0]['Email']);
 
-        $this->email->sendMail();
+        $this->email->sendMail($this->eventInfo['recordID']);
     }
 }

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2478,10 +2478,6 @@ class Form
                     FROM notes
                     WHERE recordID = :recordID
                     AND deleted IS NULL
-                    UNION
-                    SELECT "Email Sent", concat(`recipients`, `subject`), `timestamp`, ""
-                    FROM `email_tracker`
-                    WHERE recordID = :recordID
                     ORDER BY time DESC';
 
             $res = $this->db->prepared_query($sql, $vars);
@@ -3361,10 +3357,6 @@ class Form
                         WHERE recordID IN (' . $recordIDs . ')
                         AND deleted IS NULL
                         UNION
-                        SELECT `recordID`, 0, "", `timestamp`, "N/A",
-                            "Email Sent", "LEAF_email", concat(`recipients`, `subject`)
-                        FROM `email_tracker`
-                        WHERE recordID IN (' . $recordIDs . ')
                         ORDER BY time';
 
                 $res2 = $this->db->prepared_query($actionHistorySQL, array());

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3356,7 +3356,6 @@ class Form
                         FROM notes
                         WHERE recordID IN (' . $recordIDs . ')
                         AND deleted IS NULL
-                        UNION
                         ORDER BY time';
 
                 $res2 = $this->db->prepared_query($actionHistorySQL, array());


### PR DESCRIPTION
This removes the email sent from the comments section on the request page, and also removes them from the comments section in report builder. All per Michael Gao.