### PR TITLE
LEAF 3775 fix path to datepicker plugin

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -662,7 +662,7 @@ var LeafFormSearch = function (containerID) {
             '" style="width: 200px" />'
         );
         if (!jQuery.ui) {
-          $.getScript("js/jquery/jquery-ui.custom.min.js", function () {
+          $.getScript("../libs/js/jquery/jquery-ui.custom.min.js", function () {
             $("#" + prefixID + "widgetMat_" + widgetID).datepicker();
           });
         } else {


### PR DESCRIPTION
Changes the path to the jQuery plugin referenced in portal/formSearch.js back to what it was prior to autoloader.

Another longer term solution might be needed, but this will fix the current error that is making the search on the homepage unusable for the 'date submitted' type selection.