### PR TITLE
LEAF 3732 Add File Manager Form Info

### DIFF
--- a/LEAF_Request_Portal/admin/css/style.css
+++ b/LEAF_Request_Portal/admin/css/style.css
@@ -170,7 +170,7 @@ table.table {
 .table td {
   padding: 6px;
   border: 1px solid black;
-  font-size: 11px;
+  font-size: 14px;
 }
 
 .table_important {

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -440,7 +440,7 @@ switch ($action) {
             $t_form = new Smarty;
             $t_form->left_delimiter = '<!--{';
             $t_form->right_delimiter = '}-->';
-
+            $main->assign('javascripts', array('../../libs/js/LEAF/XSSHelpers.js'));
             $main->assign('useUI', true);
             //   		$t_form->assign('orgchartPath', $site_paths['orgchart_path']);
             $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);

--- a/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
@@ -18,7 +18,7 @@
 
         <p>Note: File uploads are intended to be used for custom branding assets. Uploaded files have no access restrictions, and are public.</p>
         
-        <div id="fileList" style="background-color: white; margin-left: 160px"></div>
+        <div id="fileList"></div>
 
         <div class="leaf-row-space"></div>
 
@@ -43,12 +43,26 @@ function showFiles() {
         type: 'GET',
         url: '../api/system/files',
         success: function(res) {
-        	var output = '<table class="table">';
-            for(var i in res) {
-            	output += '<tr><td><a href="../files/'+ res[i] +'">../files/'+ res[i] +'</a></td><td><a href="#" onclick="deleteFile(\''+ res[i] +'\')">Delete</a></td></tr>';
+            const files = [...res];
+        	let output = '<table class="table">';
+            output += `<tr style="background-color:#252f3e; color: white;">
+                <th style="width:250px">File Name</th>
+                <th style="width:100px">Action</th>
+                <th style="width:200px">Context</th>
+            </tr>`;
+            for(let i in res) {
+            	output += `<tr>
+                    <td><a href="../files/${res[i]}">../files/${res[i]}</a></td>
+                    <td><a href="#" onclick="deleteFile('${res[i]}')">Delete</a></td>
+                    <td id="${res[i]}_context"></td>
+                </tr>`;
             }
             output += '</table>';
             $('#fileList').html(output);
+            getIndicatorContext();
+        },
+        error: function(err) {
+            console.error(err?.responseText);
         },
         cache: false
     });
@@ -78,6 +92,36 @@ function deleteFile(file) {
     dialog_confirm.show();
 }
 
+function isJSON(input = '') {
+    try {
+        JSON.parse(input);
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
+function getIndicatorContext() {
+    $.ajax({
+        type: "GET",
+        url: "../api/form/indicator/list/unabridged",
+        success: (res) => {
+            let fileContext = {};
+            res.forEach(i => {
+                const baseFormat = i.format.split('\n')[0].trim();
+                if(isJSON(i.conditions)) {
+                    const conditions = JSON.parse(i.conditions) || [];
+                    console.log(i.indicatorID, baseFormat, conditions);
+                } else {
+                    console.log(i.indicatorID)
+                }
+            });
+        },
+        error: function(err) {
+            console.error(err?.responseText);
+        },
+    });
+}
 
 var dialog, dialog_confirm;
 $(function() {

--- a/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
@@ -16,10 +16,12 @@
     
         <h2>File Manager</h2>
 
-        <p>Note: File uploads are intended to be used for custom branding assets. Uploaded files have no access restrictions, and are public.</p>
+        <p style="line-height:1.4;">Note: File uploads are intended to be used for custom branding assets. Uploaded files have no access restrictions, and are public.</p>
         
         <div id="fileList"></div>
-        <div id="fileFormContext" style="margin-top: 1rem; display:none;"></div>
+        <div id="fileFormContext" style="margin-top: 1rem;">
+            Loading Form Information... <img src="../images/largespinner.gif" alt="loading..." />
+        </div>
 
         <div class="leaf-row-space"></div>
 
@@ -148,9 +150,16 @@ function addIndicatorContext() {
             });
             if (Object.keys(fileContext).length > 0) {
                 document.getElementById('fileFormContext').style.display = 'block';
-                let output = `<h3 style="margin: 1.5rem 0 2px 0;">Files used in forms are noted below</h3>`;
-                output += `<table style="margin: 0" class="table">`;
-                output += `<th style="border-right: 1px solid black;">File Name</th><th>Form Info</th>`;
+                let output = `<p style="margin-top: 2rem; max-width:650px; line-height:1.4;">
+                    The table below lists files used for loading form options.&nbsp; This includes those
+                    added in the Form Editor with 'ifthen', or Dropdown From File grid format cell types.&nbsp; 
+                    It does not include custom code.</p>`;
+
+                output += `<table style="margin: 0" class="table">
+                    <tr style="background-color:#252f3e;color:white;">
+                        <th>File Name</th>
+                        <th>Form Info</th>
+                    </tr>`;
                 for(let file in fileContext) {
                     output += `<tr><td>${file}</td><td>`
                     for(let form in fileContext[file]) {
@@ -163,6 +172,8 @@ function addIndicatorContext() {
                 }
                 output += '</table>';
                 $('#fileFormContext').html(output);
+            } else {
+                $('#fileFormContext').html('');
             }
         },
         error: function(err) {


### PR DESCRIPTION
Adds a table in the file manager to display information about files used to load active indicator options.  This includes which forms and indicators they are used for.