### PR TITLE
LEAF-3790: Email Class not Working on New Portals

### DIFF
--- a/libs/loaders/Leaf_autoloader.php
+++ b/libs/loaders/Leaf_autoloader.php
@@ -58,8 +58,10 @@ $oc_db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, $site_paths
 $setting_up = new Leaf\Setting($db);
 $settings = $setting_up->getSettings();
 
-if (class_exists('Portal\DbConfig')) {
-    $db_config = new Portal\DbConfig();
+if (class_exists('Portal\Config')) {
+    if (class_exists('Portal\DbConfig')) {
+        $db_config = new Portal\DbConfig();
+    }
     $config = new Portal\Config($site_paths, $settings);
     if (!defined('PORTAL_CONFIG')) define('PORTAL_CONFIG', $config);
 }


### PR DESCRIPTION
Description

Email class is calling on DbConfig class to instantiate and send emails.
DbConfig no longer exists
Email class is failing when calling DbConfig class
Currently old portals still have the DbConfig class so the Email class works properly
New portals as of 6/8 do not have the DbConfig class so it's possible their Email class does not work


