### PR TITLE
LEAF 3804 - allow custom hashes as recordID

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -436,7 +436,6 @@ var LeafFormGrid = function (containerID, options) {
     var idKey = "id" + key;
     var tDate;
     for (let i in currentData) {
-      currentData[i].recordID = parseInt(currentData[i].recordID);
       if (currentData[i][key] == undefined) {
         currentData[i][key] = $(
           "#" + prefixID + currentData[i].recordID + "_" + key


### PR DESCRIPTION
This allows custom implementations to use a hash in place of a recordID.

Currently used in a Nationally Standardized Report Builder prototype.

Testing:
- LEAF Tables (Report Builder, Main Page, etc) should function the same as before