### PR TITLE
LEAF-3827: Check array length before accessing

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -289,7 +289,7 @@ function addHeader(column) {
                 callback: function(data, blob) {
                     let daysSinceAction;
                     let recordBlob = blob[data.recordID];
-                    if(recordBlob.action_history != undefined) {
+                    if(recordBlob.action_history != undefined && recordBlob.action_history.length > 0) {
                         // Get Last Action no matter what (could change for non-comment)
                         let lastActionRecord = recordBlob.action_history.length - 1;
                         let lastAction = recordBlob.action_history[lastActionRecord];


### PR DESCRIPTION
Prevent an error by checking to make sure the array has a > 0 length before accessing it in the following assignment on line 295:
```js
let lastAction = recordBlob.action_history[lastActionRecord];
```
If recordBlob.action_history was empty, lastActionRecord would be an invalid reference.