### PR TITLE
LEAF 3803 fix group search non-unique results

### DIFF
--- a/LEAF_Nexus/sources/Group.php
+++ b/LEAF_Nexus/sources/Group.php
@@ -704,7 +704,13 @@ class Group extends Data
             $vars = array(':grpAbbr' => $input);
             $vars = array_merge($vars, $vars_tag);
             $tempResult = $this->db->prepared_query($sql, $vars);
-            $result = array_merge($result, $tempResult);
+            $currGroups = array_column($result, 'groupID');
+            foreach ($tempResult as $tmp) {
+                $tmpGroupID = $tmp["groupID"];
+                if(!in_array($tmpGroupID, $currGroups)) {
+                    $result[] = $tmp;
+                }
+            }
         }
 
         // search by ID number


### PR DESCRIPTION
It was found that queries for orgchart groups can return non-unique results in some circumstances (<=10 records retrieved and value of the group abbreviation field).  This update replaces an array merge with a loop so that the groupIDs of the additional records can be confirmed to be new before adding them to the results list.