### PR TITLE
LEAF-3837: Add "get help" button and remove unnecessary alt tags

### DIFF
--- a/LEAF_Request_Portal/admin/templates/menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/menu.tpl
@@ -21,6 +21,7 @@
         <ul>
 
             <li><a href="./">Admin Home<i class="leaf-nav-icon-space"></i></a></li>
+            <li><a href="https://leaf.va.gov/platform/service_requests_launchpad/" target="_blank">Get Help<i class="leaf-nav-icon-space"></i></a></li>
 
             <li class="lev3">
                 <a href="javascript:void(0);">User Access</a>

--- a/LEAF_Request_Portal/admin/templates/view_admin_menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_admin_menu.tpl
@@ -1,35 +1,42 @@
 <div class="leaf-admin-content">
 
+    <h3 role="heading" aria-level="1" tabindex="0">Get Help</h3>
+
+    <a href="https://leaf.va.gov/platform/service_requests_launchpad/" target="_blank" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
+        <i class="leaf-admin-btnicon fas fa-info-circle text-blue-cool-50" title="LEAF Support"></i>
+        <span class="leaf-admin-btntitle">LEAF Support</span>
+        <span class="leaf-admin-btndesc">Access VA LEAF Support Services</span>
+    </a>
+    <br /><br />
+
     <h3 role="heading" aria-level="1" tabindex="0">User Access</h3>
 
     <a href="?a=mod_groups" role="button" class="leaf-admin-button bg-yellow-5 lf-trans-yellow">
-        <i class="leaf-admin-btnicon fas fa-users text-yellow-40" alt="Modify users and groups"
-            title="Modify users and groups"></i>
+        <i class="leaf-admin-btnicon fas fa-users text-yellow-40" title="Modify users and groups"></i>
         <span class="leaf-admin-btntitle">User Access Groups</span>
         <span class="leaf-admin-btndesc">Modify users and groups</span>
     </a>
 
     <a href="?a=mod_svcChief" role="button" class="leaf-admin-button bg-yellow-5 lf-trans-yellow">
-        <i class="leaf-admin-btnicon fas fa-user-friends text-yellow-40" alt="Modify service chief listing"
-            title="Modify service chief listing"></i>
+        <i class="leaf-admin-btnicon fas fa-user-friends text-yellow-40" title="Modify service chief listing"></i>
         <span class="leaf-admin-btntitle">Service Chiefs</span>
         <span class="leaf-admin-btndesc">Review service chiefs and set backups</span>
     </a>
 
     <!--{if $siteType == 'national_subordinate'}-->
         <a href="?a=access_matrix" role="button" class="leaf-admin-button bg-yellow-5 lf-trans-yellow">
-            <i class="leaf-admin-btnicon fas fa-th text-yellow-40" title="Modify users and groups"></i>
+            <i class="leaf-admin-btnicon fas fa-th text-yellow-40" title="Access Matrix"></i>
             <span class="leaf-admin-btntitle">Access Matrix</span>
             <span class="leaf-admin-btndesc">Configure group access to tasks</span>
         </a>
     <!--{/if}-->
+    <br /><br />
 
     <h3 role="heading" aria-level="1" tabindex="0">Site Configuration</h3>
 
     <!--{if $siteType != 'national_subordinate'}-->
         <a href="?a=workflow" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-            <i class="leaf-admin-btnicon fas fa-cogs text-blue-cool-50" alt="Workflow Visualizer"
-                title="Workflow Visualizer"></i>
+            <i class="leaf-admin-btnicon fas fa-cogs text-blue-cool-50" title="Workflow Editor"></i>
             <span class="leaf-admin-btntitle">Workflow Editor</span>
             <span class="leaf-admin-btndesc">Edit flowcharts for workflows</span>
         </a>
@@ -37,8 +44,7 @@
 
     <!--{if $siteType != 'national_subordinate'}-->
         <a href="?a=form" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-            <i class="leaf-admin-btnicon fas fa-file-alt text-blue-cool-50 leaf-icn-narrow4" alt="Form Editor"
-                title="Form Editor"></i>
+            <i class="leaf-admin-btnicon fas fa-file-alt text-blue-cool-50 leaf-icn-narrow4" title="Form Editor"></i>
             <span class="leaf-admin-btntitle">Form Editor</span>
             <span class="leaf-admin-btndesc">Create and Modify Forms</span>
         </a>
@@ -46,15 +52,14 @@
 
     <!--{if $siteType != 'national_subordinate'}-->
         <a href="?a=formLibrary" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-            <i class="leaf-admin-btnicon fas fa-book text-blue-cool-50 leaf-icn-narrow2" alt="LEAF Library"
-                title="LEAF Library"></i>
+            <i class="leaf-admin-btnicon fas fa-book text-blue-cool-50 leaf-icn-narrow2" title="LEAF Library"></i>
             <span class="leaf-admin-btntitle">LEAF Library</span>
             <span class="leaf-admin-btndesc">Use a form made by the LEAF community</span>
         </a>
     <!--{/if}-->
 
     <a href="?a=mod_system" role="button" class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-        <i class="leaf-admin-btnicon fas fa-keyboard text-blue-cool-50" alt="Bookmarks" title="Bookmarks"></i>
+        <i class="leaf-admin-btnicon fas fa-keyboard text-blue-cool-50" title="Bookmarks"></i>
         <span class="leaf-admin-btntitle">Site Settings</span>
         <span class="leaf-admin-btndesc">Edit site name, time zone, and other labels</span>
     </a>
@@ -62,126 +67,115 @@
     <!--{if $siteType == 'national_primary'}-->
         <a href="../report.php?a=LEAF_National_Distribution" role="button"
             class="leaf-admin-button bg-blue-cool-10 lf-trans-blue">
-            <i class="leaf-admin-btnicon fas fa-sitemap text-blue-cool-50" alt="Site Distribution"
-                title="Site Distribution"></i>
+            <i class="leaf-admin-btnicon fas fa-sitemap text-blue-cool-50" title="Site Distribution"></i>
             <span class="leaf-admin-btntitle">Site Distribution</span>
             <span class="leaf-admin-btndesc">Deploy changes to subordinate sites</span>
         </a>
     <!--{/if}-->
+    <br /><br />
 
     <h3 role="heading" aria-level="1" tabindex="0">Admin Oversight Tools</h3>
     <a href="../?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJHSAHASQBEQAaEAez2gEMwKpsBCAXjJBjoGMALbKCHAoAbAG4Qs5AOZ0I2AIIA5EgF9S6LIhAYIwiJEmVqUOg2xtynMLyQAGabIXKQKgLrkAVhTQA7BChxoUTQuOXIuWSkGAE9FGhgwnDA6AFcEchouMDQKHwB9HjRcGPZcCDwAMRThADM0YWEEnzAAeR9haJB3HAYwJGA1EGE0GDQ%2BxABGW2nyYdHWmpq4fTsVIA%3D%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAsgCeABwrVaDfGGZt0HPDz6RYCFBhwKWyFAFcWzOY0XVlq9fy1DdosInhFUUAPoALCAYzizegsldi5eO0EdEQUYRHEWDxZoeDIPEkQDDxc3KED5JitQtW4AXSA&sort=N4Ig1gpgniBcIBMCGUDOBlAlgOwMYQBklUAXAQVxMwHtsQAaEagJwQmbkQlVxAF8gA%3D%3D&title=VW5yZXNvbHZlZCByZXF1ZXN0cw%3D%3D"
         role="button" class="leaf-admin-button bg-violet-10 lf-trans-blue">
-        <i class="leaf-admin-btnicon fas fa-search text-violet-50 leaf-icn-narrow2" alt="Timeline Explorer"
-            title="Timeline Explorer"></i>
+        <i class="leaf-admin-btnicon fas fa-search text-violet-50 leaf-icn-narrow2" title="Timeline Explorer"></i>
         <span class="leaf-admin-btntitle">Unresolved Requests</span>
         <span class="leaf-admin-btndesc">Examine potential delays</span>
     </a>
 
     <a href="../report.php?a=LEAF_Timeline_Explorer" role="button" class="leaf-admin-button bg-violet-10 lf-trans-blue">
-        <i class="leaf-admin-btnicon fas fa-clock text-violet-50 leaf-icn-narrow2" alt="Timeline Explorer"
-            title="Timeline Explorer"></i>
+        <i class="leaf-admin-btnicon fas fa-clock text-violet-50 leaf-icn-narrow2" title="Timeline Explorer"></i>
         <span class="leaf-admin-btntitle">Timeline Explorer</span>
         <span class="leaf-admin-btndesc">Analyze timeline data</span>
     </a>
 
     <a href="../?a=reports&v=3" role="button" class="leaf-admin-button bg-violet-10 lf-trans-blue">
-        <i class="leaf-admin-btnicon fas fa-file-invoice text-violet-50 leaf-icn-narrow4" alt="Report Builder"
-            title="Report Builder"></i>
+        <i class="leaf-admin-btnicon fas fa-file-invoice text-violet-50 leaf-icn-narrow4" title="Report Builder"></i>
         <span class="leaf-admin-btntitle">Report Builder</span>
         <span class="leaf-admin-btndesc">Create custom reports</span>
     </a>
+    <br /><br />
 
     <h3 role="heading" aria-level="1" tabindex="0">LEAF Developer Console</h3>
 
     <a href="?a=mod_templates" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-edit text-green-cool-50 leaf-icn-narrow2" alt="Template Editor"
-            title="Template Editor"></i>
+        <i class="leaf-admin-btnicon fas fa-edit text-green-cool-50 leaf-icn-narrow2" title="Template Editor"></i>
         <span class="leaf-admin-btntitle">Template Editor</span>
         <span class="leaf-admin-btndesc">Edit HTML Templates</span>
     </a>
 
     <a href="?a=mod_templates_email" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-mail-bulk text-green-cool-50 leaf-icn-narrow2" alt="Email Template Editor"
-            title="Email Template Editor"></i>
+        <i class="leaf-admin-btnicon fas fa-mail-bulk text-green-cool-50 leaf-icn-narrow2" title="Email Template Editor"></i>
         <span class="leaf-admin-btntitle">Email Template Editor</span>
         <span class="leaf-admin-btndesc">Add and Edit Email Templates</span>
     </a>
 
     <a href="?a=mod_templates_reports" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-terminal text-green-cool-50" alt="LEAF Programmer"
-            title="LEAF Programmer"></i>
+        <i class="leaf-admin-btnicon fas fa-terminal text-green-cool-50" title="LEAF Programmer"></i>
         <span class="leaf-admin-btntitle">LEAF Programmer</span>
         <span class="leaf-admin-btndesc">Advanced Reports and Custom Pages</span>
     </a>
 
     <a href="?a=mod_file_manager" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-tasks text-green-cool-50" alt="File Manager" title="File Manager"></i>
+        <i class="leaf-admin-btnicon fas fa-tasks text-green-cool-50" title="File Manager"></i>
         <span class="leaf-admin-btntitle">File Manager</span>
         <span class="leaf-admin-btndesc">Upload custom images and documents</span>
     </a>
 
     <a href="../?a=search" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-search text-green-cool-50 leaf-icn-narrow2" alt="Search Database"
-            title="Search Database"></i>
+        <i class="leaf-admin-btnicon fas fa-search text-green-cool-50 leaf-icn-narrow2" title="Search Database"></i>
         <span class="leaf-admin-btntitle">Search Database</span>
         <span class="leaf-admin-btndesc">Perform custom queries</span>
     </a>
 
     <a href="?a=admin_sync_services" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-sync-alt text-green-cool-50" alt="Sync Services" title="Sync Services"></i>
+        <i class="leaf-admin-btnicon fas fa-sync-alt text-green-cool-50" title="Sync Services"></i>
         <span class="leaf-admin-btntitle">Sync Services</span>
         <span class="leaf-admin-btndesc">Update Service listing from Org Chart</span>
     </a>
 
     <a href="?a=admin_update_database" role="button" class="leaf-admin-button bg-green-cool-10 lf-trans-green">
-        <i class="leaf-admin-btnicon fas fa-database text-green-cool-50 leaf-icn-narrow2" alt="Update Database"
-            title="Update Database"></i>
+        <i class="leaf-admin-btnicon fas fa-database text-green-cool-50 leaf-icn-narrow2" title="Update Database"></i>
         <span class="leaf-admin-btntitle">Update Database</span>
         <span class="leaf-admin-btndesc">Updates the system database, if available</span>
     </a>
+    <br /><br />
 
     <h3 role="heading" aria-level="1" tabindex="0" class="leaf-clear-both">Toolbox</h3>
 
     <a href="../report.php?a=LEAF_import_data" role="button" class="leaf-admin-button bg-orange-10 lf-trans-orange">
-        <i class="leaf-admin-btnicon fas fa-file-import text-orange-50" alt="Import Spreadsheet"
-            title="Import Spreadsheet"></i>
+        <i class="leaf-admin-btnicon fas fa-file-import text-orange-50" title="Import Spreadsheet"></i>
         <span class="leaf-admin-btntitle">Import Spreadsheet</span>
         <span class="leaf-admin-btndesc">Rows to requests, columns as fields</span>
     </a>
 
     <a href="../report.php?a=LEAF_mass_action" role="button" class="leaf-admin-button bg-orange-10 lf-trans-orange">
-        <i class="leaf-admin-btnicon fas fa-list text-orange-50" alt="Mass Actions" title="Mass Actions"></i>
+        <i class="leaf-admin-btnicon fas fa-list text-orange-50" title="Mass Actions"></i>
         <span class="leaf-admin-btntitle">Mass Actions</span>
         <span class="leaf-admin-btndesc">Apply bulk actions to requests</span>
     </a>
 
     <a href="./?a=mod_account_updater" role="button" class="leaf-admin-button bg-orange-10 lf-trans-orange">
-        <i class="leaf-admin-btnicon fas fa-play text-orange-50 leaf-icn-narrow2" alt="Initiator New Account"
-            title="Initiator New Account"></i>
+        <i class="leaf-admin-btnicon fas fa-play text-orange-50 leaf-icn-narrow2" title="Initiator New Account"></i>
         <span class="leaf-admin-btntitle">New Account Updater</span>
         <span class="leaf-admin-btndesc">Update records with new account</span>
     </a>
 
     <a href="../report.php?a=LEAF_sitemaps_template" role="button"
         class="leaf-admin-button bg-orange-10 lf-trans-orange">
-        <i class="leaf-admin-btnicon fas fa-map-signs text-orange-50 leaf-icn-narrow2" alt="Sitemap Editor"
-            title="Sitemap Editor"></i>
+        <i class="leaf-admin-btnicon fas fa-map-signs text-orange-50 leaf-icn-narrow2" title="Sitemap Editor"></i>
         <span class="leaf-admin-btntitle">Sitemap Editor</span>
         <span class="leaf-admin-btndesc">Edit portal Sitemap links</span>
     </a>
 
     <a href="?a=mod_combined_inbox" role="button" class="leaf-admin-button bg-orange-10 lf-trans-orange">
-        <i class="leaf-admin-btnicon fas fa-solid fa-inbox text-orange-50 leaf-icn-narrow2" alt="Combined Inbox Editor"
-            title="Combined Inbox Editor"></i>
+        <i class="leaf-admin-btnicon fas fa-solid fa-inbox text-orange-50 leaf-icn-narrow2" title="Combined Inbox Editor"></i>
         <span class="leaf-admin-btntitle">Combined Inbox Editor</span>
         <span class="leaf-admin-btndesc">Edit combined inbox</span>
     </a>
 
     <a href="../report.php?a=LEAF_table_input_report" role="button"
         class="leaf-admin-button bg-orange-10 lf-trans-orange">
-        <i class="leaf-admin-btnicon fas fa-file-export text-orange-50 leaf-icn-narrow2" alt="Sitemap Editor"
-            title="Sitemap Editor"></i>
+        <i class="leaf-admin-btnicon fas fa-file-export text-orange-50 leaf-icn-narrow2" title="Sitemap Editor"></i>
         <span class="leaf-admin-btntitle">Grid Splitter</span>
         <span class="leaf-admin-btndesc">Export grid form data to Excel spreadsheet</span>
     </a>


### PR DESCRIPTION
- Added "Get Help" in the Admin Panel and Admin Header Menu
- Removed alt tags for decorative icons

Testing:
- The "Get Help" button links to a site in the prod environment, and opens it in a new window