### PR TITLE
LEAF 3830 - backup submit errors and behavior

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1612,8 +1612,9 @@ class Form
         }
 
         // give the requestor access if the record explictly gives them write access
-        if ($resRecords[0]['isWritableUser'] == 1
-            && $this->login->getUserID() == $resRecords[0]['userID'])
+        if ($resRecords[0]['isWritableUser'] == 1 &&
+            ($this->login->getUserID() == $resRecords[0]['userID'] || $this->checkIfBackup($this->getEmpUID($resRecords[0]['userID'])))
+        )
         {
             $this->cache["hasWriteAccess_{$recordID}_{$categoryID}"] = 1;
             $this->log["write"]["{$recordID}_{$categoryID}_writable"] = "You are a writable user or initiator of record {$recordID}, {$categoryID}.";

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1205,7 +1205,7 @@ class Form
      *
      * Created at: 10/3/2022, 7:40:04 AM (America/New_York)
      */
-    public function doSubmit(int $recordID): int|array
+    public function doSubmit(int $recordID): array
     {
         $recordID = (int)$recordID;
 
@@ -1214,14 +1214,14 @@ class Form
                                         WHERE recordID=:recordID', $vars);
 
         if ($_POST['CSRFToken'] != $_SESSION['CSRFToken']) {
-            $return_value = 0;
+            $return_value = array('status' => 0, 'errors' => array('Invalid Token'));
         } else if (!is_numeric($recordID)) {
-            $return_value = 0;
+            $return_value = array('status' => 0, 'errors' => array('Invalid Record'));
         } else if (!$this->hasWriteAccess($recordID)) {
-            $return_value = 0;
+            $return_value = array('status' => 0, 'errors' => array('No Write Access'));
         } else if ($res[0]['submitted'] > 0) {
             // make sure request isn't already submitted
-            $return_value = $recordID;
+            $return_value = array('status' => 0, 'errors' => array('Already Submitted'));
         } else {
             $this->db->beginTransaction();
 

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -154,7 +154,7 @@ function doSubmit(recordID) {
         url: "./api/form/" + recordID + "/submit",
         data: {CSRFToken: '<!--{$CSRFToken}-->'},
         success: function(response) {
-            if(response?.errors?.length == 0) {
+            if(response?.errors?.length === 0) {
                 $('#submitStatus').text('Request submmited');
                 $('#submitControl').empty().html('Submitted');
                 $('#submitContent').hide('blind', 500);
@@ -163,13 +163,10 @@ function doSubmit(recordID) {
                 workflow.getWorkflow(recordID);
             } else {
                 let errors = '';
-                if (Array.isArray(response?.errors)) {
-                    for(let i in response.errors) {
-                        errors += response.errors[i] + '<br />';
-                    }
-                } else {
-                    errors = 'invalid request'
+                for(let i in response.errors) {
+                    errors += response.errors[i] + '<br />';
                 }
+
                 $('#submitControl').empty().html('Error: ' + errors);
                 $('#submitStatus').text('Request can not be submmited');
             }

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -148,26 +148,28 @@ var serviceID = <!--{$serviceID|strip_tags}-->;
 let CSRFToken = '<!--{$CSRFToken}-->';
 let formPrintConditions = {};
 function doSubmit(recordID) {
-	$('#submitControl').empty().html('<img alt="Submitting..." src="./images/indicator.gif" />Submitting...');
-	$.ajax({
-		type: 'POST',
-		url: "./api/form/" + recordID + "/submit",
-		data: {CSRFToken: '<!--{$CSRFToken}-->'},
-		success: function(response) {
-            if(response.errors.length == 0) {
+    $('#submitControl').empty().html('<img alt="Submitting..." src="./images/indicator.gif" />Submitting...');
+    $.ajax({
+        type: 'POST',
+        url: "./api/form/" + recordID + "/submit",
+        data: {CSRFToken: '<!--{$CSRFToken}-->'},
+        success: function(response) {
+            if(response?.errors?.length == 0) {
                 $('#submitStatus').text('Request submmited');
                 $('#submitControl').empty().html('Submitted');
                 $('#submitContent').hide('blind', 500);
                 $('#comments').css({'display': "block"});
                 $('#notes').css({'display': "block"});
                 workflow.getWorkflow(recordID);
-            }
-            else {
+            } else {
                 let errors = '';
-            	for(let i in response.errors) {
-            		errors += response.errors[i] + '<br />';
-            	}
-
+                if (Array.isArray(response?.errors)) {
+                    for(let i in response.errors) {
+                        errors += response.errors[i] + '<br />';
+                    }
+                } else {
+                    errors = 'invalid request'
+                }
                 $('#submitControl').empty().html('Error: ' + errors);
                 $('#submitStatus').text('Request can not be submmited');
             }


### PR DESCRIPTION
Adds the ability for backups to submit requests (for example if they have been returned to requestor).

This also fixes an error that occurred if a (non-admin) backup tried to re-submit a request and normalizes the Form.php  doSubmit method return values.  Custom code can use this endpoint, so I otherwise retained the return value array format used for this method.
