### PR TITLE
Leaf 3887 - fix incorrect indicator

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -278,6 +278,7 @@ function addHeader(column) {
             filterData['action_history.stepID'] = 1;
             filterData['action_history.actionType'] = 1;
             filterData['stepFulfillmentOnly'] = 1;
+            filterData['submitted'] = 1;
             leafSearch.getLeafFormQuery().join('action_history');
             leafSearch.getLeafFormQuery().join('stepFulfillmentOnly');
 
@@ -312,8 +313,8 @@ function addHeader(column) {
                             }
                         }
                         daysSinceAction = Math.round((today.getTime() - date.getTime()) / 86400000);
-                        if(recordBlob.submitted == 0 || !daysSinceAction) {
-                            // if there are no actions then it was never submitted
+                        if(recordBlob.submitted == 0) {
+                            // if there's no submit timestamp, then it's not submitted
                             daysSinceAction = "Not Submitted";
                         }
                     }


### PR DESCRIPTION
Steps to reproduce issue:
1. Start a new request and submit it
2. Report Builder: set filter to "Current Status IS NOT Resolved", Click next
3. Select "Days since last action"
5. Note the request from step 1 shows up as "Not Submitted" in the "Days since last action" column
