### PR TITLE
Add missing parentID

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -128,6 +128,7 @@ class Form
             {
                 $this->flattenFullFormData($item['child'], $output, $item['indicatorID']);
                 unset($item['child']);
+                $item['parentID'] = $parentID;
                 $output[$item['indicatorID']][$item['series']] = $item;
             }
         }


### PR DESCRIPTION
Resolves API consistency error where the parentID of a field was missing if the field has child fields.