### PR TITLE
Temporarily disable deep search

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1249,7 +1249,8 @@ class Employee extends Data
     }
 
     private function searchDeeper($input) {
-        return $this->lookupByIndicatorID(23, $this->parseWildcard($input)); // search AD title
+        //return $this->lookupByIndicatorID(23, $this->parseWildcard($input)); // search AD title
+        return []; // temporarily disable deep searches
     }
 
     public function search($input, $indicatorID = '')


### PR DESCRIPTION
There's a missing index in Nexus :: employee, where indicatorID + data. However implementing this would benefit from further discussion/analysis.

This temporarily disables the "deep" employee search feature to mitigate the performance impact.