### PR TITLE
LEAF-3937: Attempt to clear cookies and fix sessions

### DIFF
--- a/LEAF_Nexus/sources/Login.php
+++ b/LEAF_Nexus/sources/Login.php
@@ -237,6 +237,7 @@ class Login
 //        $https = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? true : false;
         $https = true;
         setcookie('PHPSESSID', '', time() - 3600, $cookie['path'], $cookie['domain'], $https, true);
+        setcookie('REMOTE_USER', '', time() - 3600, $cookie['path'], $cookie['domain'], $https, true);
     }
 
     public function isLogin()

--- a/LEAF_Request_Portal/sources/Login.php
+++ b/LEAF_Request_Portal/sources/Login.php
@@ -173,6 +173,7 @@ class Login
 //        $https = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? true : false;
         $https = true;
         setcookie('PHPSESSID', '', time() - 3600, $cookie['path'], $cookie['domain'], $https, true);
+        setcookie('REMOTE_USER', '', time() - 3600, $cookie['path'], $cookie['domain'], $https, true);
     }
 
     public function isLogin()


### PR DESCRIPTION
This is intended to resolve an issue where signing out does not clear out all cookies.

Testing procedure, might need to be done on pre-prod instead of dev:
1. Open the LEAF homepage
2. Open the browser's devtools, navigate to Application -> Cookies
3. Note that PHPSESSID and REMOTE_USER cookies exist
4. Click "Sign out" on the LEAF homepage
5. Confirm that the PHPSESSID and REMOTE_USER cookies have been deleted
6. Close the browser
7. Go back to the LEAF homepage, it should load normally
