### PR TITLE
Leaf 3902 - Update groups, service and user

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -709,7 +709,7 @@ class Employee extends Data
         $cacheHash = "lookupLogin{$userName}";
         unset($this->cache[$cacheHash]);
 
-        $db_nat = new \Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
+        $db_nat = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
         $login_nat = new Login($db_nat, $db_nat);
 
         $natEmployee = new NationalEmployee($db_nat, $login_nat);

--- a/LEAF_Nexus/sources/Tag.php
+++ b/LEAF_Nexus/sources/Tag.php
@@ -111,4 +111,26 @@ class Tag extends Data
 
         return $res;
     }
+
+    /**
+     * @param int $id
+     * @param string $tag
+     *
+     * @return array
+     *
+     * Created at: 8/16/2023, 8:57:05 AM (America/New_York)
+     */
+    public function groupIsTagged(int $id, string $tag): array
+    {
+        $vars = array(':groupID' => $id,
+                    ':tag' => $tag);
+        $sql = 'SELECT `groupID`, `tag`
+                FROM `group_tags`
+                WHERE `groupID` = :groupID
+                AND `tag` = :tag';
+
+        $return_value = $this->db->pdo_select_query($sql, $vars);
+
+        return $return_value;
+    }
 }

--- a/LEAF_Request_Portal/admin/ajaxIndex.php
+++ b/LEAF_Request_Portal/admin/ajaxIndex.php
@@ -53,6 +53,7 @@ switch ($action) {
 
         break;
     case 'remove_user_old':
+        // this should be deprecated as of 8/18/2023
         checkToken();
 
         $deleteList = Leaf\XSSHelpers::scrubObjectOrArray(json_decode($_POST['json'], true));
@@ -72,6 +73,7 @@ switch ($action) {
 
            break;
     case 'remove_user':
+        // this should be deprecated as of 8/18/2023
            checkToken();
 
            $group = new Portal\Group($db, $login);

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -395,16 +395,20 @@ function toTitleCase(str) {
 }
 
 function addAdmin(userID) {
-    $.ajax({
-        type: 'POST',
-        url: "../api/group/" + 1 + "/members",
-        data: {'userID': userID,
-               'CSRFToken': '<!--{$CSRFToken}-->'},
-        success: function(response) {
-        	getMembers(1);
-        },
-        cache: false
-    });
+    if (userID === '') {
+        return;
+    } else {
+        $.ajax({
+            type: 'POST',
+            url: "../api/group/" + 1 + "/members",
+            data: {'userID': userID,
+                'CSRFToken': '<!--{$CSRFToken}-->'},
+            success: function(response) {
+                getMembers(1);
+            },
+            cache: false
+        });
+    }
 }
 
 function removeAdmin(userID) {

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -353,6 +353,18 @@ function pruneMember(groupID, userID) {
     });
 }
 
+function reactivateMember(groupID, userID) {
+    $.ajax({
+        type: 'POST',
+        url: "../api/group/" + groupID + "/members/_" + userID + "/reactivate",
+        data: {'CSRFToken': '<!--{$CSRFToken}-->'},
+        fail: function(err) {
+            console.log(err);
+        },
+        cache: false
+    });
+}
+
 function addNexusMember(groupID, empUID) {
     $.ajax({
         type: 'POST',
@@ -385,9 +397,8 @@ function toTitleCase(str) {
 function addAdmin(userID) {
     $.ajax({
         type: 'POST',
-        url: "ajaxIndex.php?a=add_user",
+        url: "../api/group/" + 1 + "/members",
         data: {'userID': userID,
-               'groupID': 1,
                'CSRFToken': '<!--{$CSRFToken}-->'},
         success: function(response) {
         	getMembers(1);
@@ -515,7 +526,12 @@ function getGroupList() {
                                                 actions += '</td>';
                                                 employee_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${isRegional}${actions}</tr>`;
                                             } else {
-                                                let pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="pruneMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Prune this user from this group">Prune</button>`;
+                                                let pruneMemberButton = '';
+                                                if (res[i].regionallyManaged === false) {
+                                                    pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="pruneMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Prune this user from this group">Prune</button>`;
+                                                } else {
+                                                    pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="reActivateMember_${counter}" class="usa-button usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Reactivate this user for this group">Reactivate</button>`;
+                                                }
                                                 let actions = `${pruneMemberButton}`;
                                                 actions += '</td>';
                                                 inactive_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${isRegional}${actions}</tr>`;
@@ -565,6 +581,16 @@ function getGroupList() {
                                                     dialog_confirm.setContent('Are you sure you want to prune this member?');
                                                     dialog_confirm.setSaveHandler(function () {
                                                         pruneMember(groupID, res[i].userName);
+                                                        dialog_confirm.hide();
+                                                        dialog.hide();
+                                                    });
+                                                    dialog_confirm.show();
+                                                });
+
+                                                $('#reActivateMember_' + counter).on('click', function () {
+                                                    dialog_confirm.setContent('Are you sure you want to Reactivate this member?');
+                                                    dialog_confirm.setSaveHandler(function () {
+                                                        reactivateMember(groupID, res[i].userName);
                                                         dialog_confirm.hide();
                                                         dialog.hide();
                                                     });

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -413,11 +413,9 @@ function addAdmin(userID) {
 
 function removeAdmin(userID) {
     $.ajax({
-    	type: 'POST',
-        url: "ajaxIndex.php?a=remove_user",
-        data: {'userID': userID,
-        	   'groupID': 1,
-        	   'CSRFToken': '<!--{$CSRFToken}-->'},
+    	type: 'DELETE',
+        url: "../api/group/1/members/" + userID,
+        data: {'CSRFToken': '<!--{$CSRFToken}-->'},
         success: function(response) {
         	getMembers(1);
         },

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -124,7 +124,7 @@ function getMembers(groupID = -1) {
     $.ajax({
         type: 'GET',
         url: '../api/system/updateService/' + groupID,
-        success: function() {
+        success: function(res) {
             $.ajax({
                 url: "../api/service/" + groupID + "/members",
                 dataType: "json",
@@ -155,13 +155,13 @@ function populateMembers(groupID = -1, members = []) {
     $('#members' + groupID).html('');
     let memberCt = -1;
     for (let i in members) {
-        if (members[i].active == 1 && members[i].backupID == null) {
+        if (members[i].active == 1 && members[i].backupID == '') {
             memberCt++;
         }
     }
     let countTxt = (memberCt > 0) ? (' + ' + memberCt + ' others') : '';
     for (let i in members) {
-        if (members[i].active == 1 && members[i].backupID == null) {
+        if (members[i].active == 1 && members[i].backupID == '') {
             if ($('#members' + groupID).html('')) {
                 $('#members' + groupID).append('<div class="groupUserFirst">' + toTitleCase(members[i].Fname) + ' ' + toTitleCase(members[i].Lname) + countTxt + '</div>');
             }
@@ -175,8 +175,8 @@ function populateMembers(groupID = -1, members = []) {
  * @param {int} groupID - ID of group
  * @param {int} userID - ID of user being added
  */
-function addUser(groupID = -1, userID = -1) {
-    if (groupID < 0 || userID < 0) {
+function addUser(groupID = -1, userID = '') {
+    if (groupID < 0 || userID == '') {
         return;
     } else {
         $.ajax({
@@ -194,14 +194,17 @@ function addUser(groupID = -1, userID = -1) {
  * @param {int} groupID - ID of group
  * @param {int} userID - ID of user being removed
  */
-function removeUser(groupID = -1, userID = -1) {
-    if (groupID < 0 || userID < 0) {
+function removeUser(groupID = -1, userID = '') {
+    if (groupID < 0 || userID == '') {
         return;
     } else {
         $.ajax({
-            type: 'DELETE',
-            url: "../api/service/" + groupID + "/members/_" + userID + '?' +
-                $.param({'CSRFToken': '<!--{$CSRFToken}-->'}),
+            type: 'POST',
+            url: "../api/service/" + groupID + "/members/_" + userID,
+            data: {'CSRFToken': '<!--{$CSRFToken}-->'},
+            fail: function(err) {
+                console.log(err);
+            },
             cache: false
         });
     }
@@ -219,15 +222,15 @@ function importUser(serviceID = 0, selectedUserName = '') {
     if (selectedUserName === '') {
         console.log('Invalid username');
     }
+
     $.ajax({
         type: 'POST',
         url: '<!--{$orgchartPath}-->/api/employee/import/_' + selectedUserName,
         data: {CSRFToken: '<!--{$CSRFToken}-->'},
         success: function(res) {
-            if(!isNaN(res)) {
+            if (!isNaN(res)) {
                 addUser(serviceID, selectedUserName); // add identified user into portal.
-            }
-            else {
+            } else {
                 alert(res);
             }
         },
@@ -282,28 +285,101 @@ function initiateModal(serviceID = 0, serviceName = '') {
                 dialog.setContent(
                     '<div class="leaf-float-right"><button class="usa-button leaf-btn-small" onclick="viewHistory('+serviceID+')">View History</button></div>' +
                     '<a class="leaf-group-link" href="<!--{$orgchartPath}-->/?a=view_group&groupID=' + serviceID + '" title="groupID: ' + serviceID + '" target="_blank"><h2 role="heading" tabindex="-1">' + serviceName + '</h2></a><h3 role="heading" tabindex="-1" class="leaf-marginTop-1rem">Add Employee</h3><div id="employeeSelector"></div></br><div id="employees"></div>');
-                $('#employees').html('<div id="employee_table" class="leaf-marginTopBot-1rem"></div>');
+
+                $('#employees').html('<div id="employee_table" style="display: table-header-group"></div><br /><div id="showInactive" class="fas fa-angle-right" style="cursor: pointer;"></div><div id="inactive_table" style="display: none"></div>');
+                let employee_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Local</th><th>Actions</th></tr></thead><tbody>';
+                let inactive_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Local</th><th>Actions</th></tr></thead><tbody>';
+
                 let counter = 0;
                 for(let i in res) {
-                    // Check for active members to list
-                    if (res[i].active == 1) {
-                        if (res[i].backupID == null) {
-                            let removeButton = '- <a href="#" class="text-secondary-darker leaf-font0-7rem leaf-remove-button" id="removeMember_' + counter + '">REMOVE</a>';
-                            $('#employee_table').append('<a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=' + res[i].empUID + '" class="leaf-user-link" title="' + res[i].empUID + ' - ' + res[i].userName + '" target="_blank"><div class="leaf-marginTop-halfRem leaf-bold leaf-font0-9rem">' + toTitleCase(res[i].Lname) + ', ' + toTitleCase(res[i].Fname) + '</a> <span class="leaf-font-normal">' + removeButton + '</span></div>');
-                            // Check for Backups
-                            for (let j in res) {
-                                if (res[i].userName == res[j].backupID) {
-                                    $('#employee_table').append('<div class="leaf-font0-8rem leaf-marginLeft-qtrRem">&bull; ' + toTitleCase(res[j].Fname) + ' ' + toTitleCase(res[j].Lname) + ' - <span class="text-secondary-darker leaf-font0-7rem">Backup for ' + toTitleCase(res[i].Fname) + ' ' + toTitleCase(res[i].Lname) + '</span></div>');
-                                }
+                    if (res[i].backupID == '') {
+                        let employeeName = `<td class="leaf-user-link" title="${res[i].empUID} - ${res[i].userName}" style="font-size: 1em; font-weight: 700;"><a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${res[i].empUID}" target="_blank">${toTitleCase(res[i].Lname)}, ${toTitleCase(res[i].Fname)}</a></td>`;
+                        let employeeUserName = `<td  class="leaf-user-link" title="${res[i].empUID} - ${res[i].userName}" style="font-size: 1em; font-weight: 600;"><a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${res[i].empUID}" target="_blank">${res[i].userName}</a></td>`;
+                        let backups = `<td style="font-size: 0.8em">`;
+                        let isLocal = `<td style="font-size: 0.8em;">${res[i].locallyManaged > 0 ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
+                        let isRegional = `<td style="font-size: 0.8em;">${res[i].regionallyManaged ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
+                        let removeButton = `<td style="font-size: 0.8em; text-align: center;"><button id="removeMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Remove this user from this group">Remove</button>`;
+
+                        // Check for Backups
+                        for (let j in res) {
+                            if (res[i].userName == res[j].backupID) {
+                                backups += ('<div class="leaf-font0-8rem">' + toTitleCase(res[j].Fname) + ' ' + toTitleCase(res[j].Lname) + '\n');
                             }
-                            $('#removeMember_' + counter).on('click', function (userID) {
-                                return function () {
-                                    removeUser(serviceID, userID);
-                                    dialog.hide();
-                                };
-                            }(res[i].userName));
-                            counter++;
                         }
+                        // close of actions and backups column
+                        backups += '</td>';
+
+                        if (res[i].active === 1) {
+                            let actions = `${removeButton}`;
+
+                            actions += '</td>';
+                            employee_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${actions}</tr>`;
+                        } else {
+                            let pruneMemberButton = '';
+
+                            if (res[i].locallyManaged == 1) {
+                                pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="pruneMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Prune this user from this group">Prune</button>`;
+                            } else {
+                                pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="reactivateMember_${counter}" class="usa-button usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Reactivate this user for this group">Reactivate</button>`;
+                            }
+
+                            let actions = `${pruneMemberButton}`;
+                            actions += '</td>';
+                            inactive_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${actions}</tr>`;
+                        }
+                        counter++;
+                    }
+                }
+                employee_table += '</tbody></table>';
+                inactive_table += '</tbody></table>';
+                // generate formatted table
+                $('#employee_table').html(employee_table);
+                $('#inactive_table').html(inactive_table);
+
+                if ($('#inactive_table > .table-bordered > tbody > tr').length === null || $('#inactive_table > .table-bordered > tbody > tr').length === 0){
+                    $('#showInactive').hide();
+                } else {
+                    $('#showInactive').on('click', function () {
+                        $('#showInactive').toggleClass("fa-angle-right fa-angle-down");
+                        $('#inactive_table').slideToggle();
+                    });
+                }
+
+                // add functionality to action buttons after table generation
+                counter = 0;
+                for (let i in res) {
+                    if (res[i].backupID == "") {
+                        if (res[i].active === 1) {
+                            $('#removeMember_' + counter).on('click', function () {
+                                dialog_confirm.setContent('Are you sure you want to remove this member?');
+                                dialog_confirm.setSaveHandler(function () {
+                                    removeUser(serviceID, res[i].userName);
+                                    dialog_confirm.hide();
+                                    dialog.hide();
+                                });
+                                dialog_confirm.show();
+                            });
+                        } else {
+                            $('#pruneMember_' + counter).on('click', function () {
+                                dialog_confirm.setContent('Are you sure you want to prune this member?');
+                                dialog_confirm.setSaveHandler(function () {
+                                    pruneMember(serviceID, res[i].userName);
+                                    dialog_confirm.hide();
+                                    dialog.hide();
+                                });
+                                dialog_confirm.show();
+                            });
+                            $('#reactivateMember_' + counter).on('click', function () {
+                                dialog_confirm.setContent('Are you sure you want to reactivate this member?');
+                                dialog_confirm.setSaveHandler(function () {
+                                    reactivateMember(serviceID, res[i].userName);
+                                    dialog_confirm.hide();
+                                    dialog.hide();
+                                });
+                                dialog_confirm.show();
+                            });
+                        }
+                        counter++;
                     }
                 }
 
@@ -340,6 +416,31 @@ function initiateModal(serviceID = 0, serviceName = '') {
             cache: false
         });
     }
+}
+
+function pruneMember(groupID, userID) {
+    console.log('pruneMember');
+    $.ajax({
+        type: 'POST',
+        url: "../api/service/" + groupID + "/members/_" + userID + "/prune",
+        data: {'CSRFToken': '<!--{$CSRFToken}-->'},
+        fail: function(err) {
+            console.log(err);
+        },
+        cache: false
+    });
+}
+
+function reactivateMember(groupID, userID) {
+    $.ajax({
+        type: 'POST',
+        url: "../api/service/" + groupID + "/members/_" + userID + "/reactivate",
+        data: {'CSRFToken': '<!--{$CSRFToken}-->'},
+        fail: function(err) {
+            console.log(err);
+        },
+        cache: false
+    });
 }
 
 /**
@@ -383,7 +484,7 @@ function getGroupList() {
 	    	$('#groupList').append('<h2>'+ toTitleCase(quadrads[i].name) +'</h2><div class="leaf-displayFlexRow" id="group_'+ quadrads[i].groupID +'"></div>');
 	    }
 	    for(let i in services) {
-	    	$('#group_' + services[i].groupID).append('<div tabindex="0" id="'+ services[i].serviceID +'" title="serviceID: '+ services[i].serviceID +'" class="groupBlockWhite">'
+            $('#group_' + services[i].groupID).append('<div tabindex="0" id="'+ services[i].serviceID +'" title="serviceID: '+ services[i].serviceID +'" class="groupBlockWhite">'
                     + '<h2 id="groupTitle'+ services[i].serviceID +'">'+ services[i].service +'</h2>'
                     + '<div id="members'+ services[i].serviceID +'"></div>'
                     + '</div>');

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -216,29 +216,26 @@ function removeUser(groupID = -1, userID = '') {
  * @param {string} selectedUserName - Username being imported
  */
 function importUser(serviceID = 0, selectedUserName = '') {
-    if (serviceID === 0) {
-        console.log('Invalid serviceID');
+    if (serviceID === 0 || selectedUserName === '') {
+        return;
+    } else {
+        $.ajax({
+            type: 'POST',
+            url: '<!--{$orgchartPath}-->/api/employee/import/_' + selectedUserName,
+            data: {CSRFToken: '<!--{$CSRFToken}-->'},
+            success: function(res) {
+                if (!isNaN(res)) {
+                    addUser(serviceID, selectedUserName); // add identified user into portal.
+                } else {
+                    alert(res);
+                }
+            },
+            fail: function(err) {
+                console.log(err);
+            },
+            cache: false
+        });
     }
-    if (selectedUserName === '') {
-        console.log('Invalid username');
-    }
-
-    $.ajax({
-        type: 'POST',
-        url: '<!--{$orgchartPath}-->/api/employee/import/_' + selectedUserName,
-        data: {CSRFToken: '<!--{$CSRFToken}-->'},
-        success: function(res) {
-            if (!isNaN(res)) {
-                addUser(serviceID, selectedUserName); // add identified user into portal.
-            } else {
-                alert(res);
-            }
-        },
-        fail: function(err) {
-            console.log(err);
-        },
-        cache: false
-    });
 }
 
 /**
@@ -419,28 +416,36 @@ function initiateModal(serviceID = 0, serviceName = '') {
 }
 
 function pruneMember(groupID, userID) {
-    console.log('pruneMember');
-    $.ajax({
-        type: 'POST',
-        url: "../api/service/" + groupID + "/members/_" + userID + "/prune",
-        data: {'CSRFToken': '<!--{$CSRFToken}-->'},
-        fail: function(err) {
-            console.log(err);
-        },
-        cache: false
-    });
+    if (groupID === 0 || userID === '') {
+        return;
+    } else {
+        $.ajax({
+            type: 'POST',
+            url: "../api/service/" + groupID + "/members/_" + userID + "/prune",
+            data: {'CSRFToken': '<!--{$CSRFToken}-->'},
+            fail: function(err) {
+                console.log(err);
+            },
+            cache: false
+        });
+    }
+
 }
 
 function reactivateMember(groupID, userID) {
-    $.ajax({
-        type: 'POST',
-        url: "../api/service/" + groupID + "/members/_" + userID + "/reactivate",
-        data: {'CSRFToken': '<!--{$CSRFToken}-->'},
-        fail: function(err) {
-            console.log(err);
-        },
-        cache: false
-    });
+    if (groupID === 0 || userID === '') {
+        return;
+    } else {
+        $.ajax({
+            type: 'POST',
+            url: "../api/service/" + groupID + "/members/_" + userID + "/reactivate",
+            data: {'CSRFToken': '<!--{$CSRFToken}-->'},
+            fail: function(err) {
+                console.log(err);
+            },
+            cache: false
+        });
+    }
 }
 
 /**

--- a/LEAF_Request_Portal/api/controllers/GroupController.php
+++ b/LEAF_Request_Portal/api/controllers/GroupController.php
@@ -90,6 +90,10 @@ class GroupController extends RESTfulResponse
                 return $group->importGroup(\Leaf\XSSHelpers::sanitizeHTML($_POST['title'])); // POST for title of group
             });
 
+            $this->index['POST']->register('group/[digit]/members/[text]/reactivate', function ($args) use ($group) {
+                return $group->reActivateMember($args[1], $args[0]);
+            });
+
             $this->index['POST']->register('group/[digit]/members/[text]/prune', function ($args) use ($group) {
                 return $group->removeMember($args[1], $args[0]);
             });

--- a/LEAF_Request_Portal/api/controllers/ServiceController.php
+++ b/LEAF_Request_Portal/api/controllers/ServiceController.php
@@ -70,6 +70,19 @@ class ServiceController extends RESTfulResponse
                     return $service->addMember($args[0], $_POST['userID']);
                 });
 
+                $this->index['POST']->register('service/[digit]/members/[text]', function ($args) use ($service) {
+                    return $service->deactivateChief($args[0], $args[1]);
+                });
+
+                $this->index['POST']->register('service/[digit]/members/[text]/reactivate', function ($args) use ($service) {
+
+                    return $service->reactivateChief($args[1], $args[0]);
+                });
+
+                $this->index['POST']->register('service/[digit]/members/[text]/prune', function ($args) use ($service) {
+                    return $service->pruneChief($args[0], $args[1]);
+                });
+
                 return $this->index['POST']->runControl($act['key'], $act['args']);
             }
         }

--- a/LEAF_Request_Portal/api/controllers/SystemController.php
+++ b/LEAF_Request_Portal/api/controllers/SystemController.php
@@ -41,7 +41,15 @@ class SystemController extends RESTfulResponse
         });
 
         $this->index['GET']->register('system/updateService/[digit]', function ($args) use ($system) {
-            return $system->updateService($args[0]);
+            $updated_service = $system->updateService($args[0]);
+
+            if ($updated_service['status']['code'] == 4) {
+                $return_value = $updated_service['status']['message'];
+            } else {
+                $return_value = "groupID: " . $args[0] . " updated";
+            }
+
+            return $return_value;
         });
 
         $this->index['GET']->register('system/updateGroup/[digit]', function ($args) use ($system) {

--- a/LEAF_Request_Portal/scripts/sync_services.php
+++ b/LEAF_Request_Portal/scripts/sync_services.php
@@ -19,6 +19,6 @@ $tag = new Orgchart\Tag($oc_db, $login);
 $group_portal = new Portal\Group($db, $login);
 $service_portal = new Portal\Service($db, $login);
 $system_portal = new Portal\System($db, $login);
-$syncing = $system_portal->syncSystem($group_portal, $service_portal, $group, $employee, $tag, $position);
+$syncing = $system_portal->syncSystem($group);
 
 echo $syncing;

--- a/LEAF_Request_Portal/sources/Group.php
+++ b/LEAF_Request_Portal/sources/Group.php
@@ -359,6 +359,8 @@ class Group
      * @param int $groupID
      *
      * @return void
+     *
+     * Created at: 8/16/2023, 3:01:10 PM (America/New_York)
      */
     public function deactivateMember($member, $groupID): void
     {

--- a/LEAF_Request_Portal/sources/Group.php
+++ b/LEAF_Request_Portal/sources/Group.php
@@ -234,11 +234,7 @@ class Group
                             $dirRes[0]['primary_admin'] = $member['primary_admin'];
                         }
 
-                        if ($member['locallyManaged'] == 1) {
-                            $dirRes[0]['backupID'] = "";
-                        } else {
-                            $dirRes[0]['backupID'] = $member['backupID'];
-                        }
+                        $dirRes[0]['backupID'] = $member['backupID'];
 
                         $dirRes[0]['locallyManaged'] = $member['locallyManaged'];
                         $dirRes[0]['active'] = $member['active'];
@@ -298,36 +294,14 @@ class Group
             if (!empty($backups)) {
                 foreach ($backups as $backup) {
                     $vars = array(':userID' => $backup['userName'],
-                        ':groupID' => $groupID);
-                    $sql = 'SELECT `locallyManaged`
-                            FROM `users`
-                            WHERE `userID` = :userID
-                            AND `groupID` = :groupID';
+                        ':groupID' => $groupID,
+                        ':backupID' => $emp[0]['userName']);
+                    $sql = 'INSERT INTO `users` (`userID`, `groupID`, `backupID`)
+                            VALUES (:userID, :groupID, :backupID)
+                            ON DUPLICATE KEY UPDATE `userID` = :userID,
+                                `groupID` = :groupID, `backupID` = :backupID';
 
-                    $res = $this->db->pdo_select_query($sql, $vars);
-
-                    if ($res['status']['code'] == 2) {
-                        // Check for locallyManaged users
-                        if ($res['data'][0]['locallyManaged'] == 1) {
-                            $vars[':backupID'] = '';
-                        } else {
-                            $vars[':backupID'] = $emp[0]['userName'];
-                        }
-                        $sql = 'INSERT INTO `users` (`userID`, `groupID`, `backupID`)
-                                VALUES (:userID, :groupID, :backupID)
-                                ON DUPLICATE KEY UPDATE `userID` = :userID, `groupID` = :groupID,
-                                    `backupID` = :backupID';
-
-                        $return_value = $this->db->pdo_insert_query($sql, $vars);
-                    } else {
-                        $return_value = array (
-                            'status' => array (
-                                'code' => 4,
-                                'message' => 'Backup could not be found'
-                            )
-                        );
-                        break;
-                    }
+                    $return_value = $this->db->pdo_insert_query($sql, $vars);
                 }
 
                 $return_value = array (
@@ -388,12 +362,9 @@ class Group
      */
     public function deactivateMember($member, $groupID): void
     {
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
-        $employee = new \Orgchart\Employee($oc_db, $this->login);
-
         if (is_numeric($groupID) && $member != '')
         {
-            $sql_vars = array(':userID' => $member,
+            $vars = array(':userID' => $member,
                           ':groupID' => $groupID, );
 
             $this->dataActionLogger->logAction(\Leaf\DataActions::MODIFY, \Leaf\LoggableTypes::EMPLOYEE, [
@@ -401,24 +372,19 @@ class Group
                 new \Leaf\LogItem("users", "groupID", $groupID, $this->getGroupName($groupID))
             ]);
 
-            $this->db->prepared_query('UPDATE users SET active = 0, locallyManaged = 1 WHERE userID=:userID AND groupID=:groupID', $sql_vars);
+            $sql = 'UPDATE `users`
+                    SET `active` = 0
+                    WHERE `userID` = :userID
+                    AND `groupID` = :groupID';
 
-            // include the backups of employee
+            $this->db->prepared_query($sql, $vars);
 
-            $emp = $employee->lookupLogin($member);
-            $backups = $employee->getBackups($emp[0]['empUID']);
-            foreach ($backups as $backup) {
-                $sql_vars = array(':userID' => $backup['userName'],
-                    ':groupID' => $groupID,
-                    ':backupID' => $member,);
+            $sql = 'UPDATE `users`
+                    SET `active` = 0
+                    WHERE `backupID` = :userID
+                    AND `groupID` = :groupID';
 
-                $res = $this->db->prepared_query('SELECT locallyManaged FROM users WHERE userID=:userID AND groupID=:groupID AND backupID=:backupID', $sql_vars);
-
-                // Check for locallyManaged users
-                if ($res[0]['locallyManaged'] == 0) {
-                    $this->db->prepared_query('DELETE FROM users WHERE userID=:userID AND groupID=:groupID AND backupID=:backupID', $sql_vars);
-                }
-            }
+            $this->db->prepared_query($sql, $vars);
         }
     }
 
@@ -461,6 +427,43 @@ class Group
                 }
             }
         }
+    }
+
+    /**
+     * @param string $member
+     * @param int $groupID
+     *
+     * @return array
+     *
+     * Created at: 8/16/2023, 8:55:54 AM (America/New_York)
+     */
+    public function reActivateMember(string $member, int $groupID): array
+    {
+        if (is_numeric($groupID) && $member != '') {
+            $this->dataActionLogger->logAction(\Leaf\DataActions::ADD, \Leaf\LoggableTypes::EMPLOYEE, [
+                new \Leaf\LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
+                new \Leaf\LogItem("users", "groupID", $groupID, $this->getGroupName($groupID))
+            ]);
+
+            $sql_vars = array(':userID' => $member,
+                          ':groupID' => $groupID);
+            $sql = 'UPDATE `users`
+                    SET `active` = 1
+                    WHERE `groupID` = :groupID
+                    AND (`userID` = :userID
+                        OR `backupID` = :userID)';
+
+            $return_value = $this->db->pdo_update_query($sql, $sql_vars);
+        } else {
+            $return_value = array (
+                'status' => array (
+                    'code' => 4,
+                    'message' => 'Improperly formatted data'
+                )
+            );
+        }
+
+        return $return_value;
     }
 
     /**

--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -144,19 +144,29 @@ class Service
         return true;
     }
 
+    /**
+     * @param int $groupID
+     * @param string $member
+     *
+     * @return bool
+     *
+     * Created at: 8/16/2023, 8:45:10 AM (America/New_York)
+     */
     public function addMember($groupID, $member)
     {
         $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
         $employee = new \Orgchart\Employee($oc_db, $this->login);
 
         if (is_numeric($groupID) && $member != '') {
-            $sql_vars = array(':userID' => $member,
-                    ':serviceID' => $groupID,);
+            $vars = array(':userID' => $member,
+                        ':serviceID' => $groupID);
+            $sql = 'INSERT INTO `service_chiefs` (
+                        `serviceID`, `userID`, `backupID`, `locallyManaged`, `active`)
+                    VALUES (:serviceID, :userID, "", 1, 1)
+                    ON DUPLICATE KEY UPDATE `locallyManaged` = 1, `active` = 1';
 
             // Update on duplicate keys
-            $this->db->prepared_query('INSERT INTO service_chiefs (serviceID, userID, backupID, locallyManaged, active)
-                                                    VALUES (:serviceID, :userID, null, 1, 1)
-                                                    ON DUPLICATE KEY UPDATE serviceID=:serviceID, userID=:userID, backupID=null, locallyManaged=1, active=1', $sql_vars);
+            $this->db->prepared_query($sql, $vars);
 
             $this->dataActionLogger->logAction(\Leaf\DataActions::ADD, \Leaf\LoggableTypes::SERVICE_CHIEF, [
                 new \Leaf\LogItem("service_chiefs","serviceID", $groupID, $this->getServiceName($groupID)),
@@ -165,38 +175,44 @@ class Service
             ]);
 
             // check if this service is also an ELT
-            $sql_vars = array(':groupID' => $groupID);
-            $res = $this->db->prepared_query('SELECT * FROM services
-   												WHERE serviceID=:groupID', $sql_vars);
-            // if so, update groups table
-            if ($res[0]['groupID'] == $groupID)
-            {
-                $sql_vars = array(':userID' => $member,
-                              ':groupID' => $groupID, );
-                $this->db->prepared_query('INSERT INTO users (userID, groupID, backupID)
-                                                VALUES (:userID, :groupID, "")', $sql_vars);
+            $vars = array(':groupID' => $groupID);
+            $sql = 'SELECT `groupID`
+                    FROM `services`
+   					WHERE `serviceID` = :groupID';
+            $res = $this->db->prepared_query($sql, $vars);
+
+
+            if ($res[0]['groupID'] == $groupID) {
+                $vars = array(':userID' => $member,
+                            ':serviceID' => $groupID);
+                $sql = 'INSERT INTO `users` (
+                            `groupID`, `userID`, `backupID`, `locallyManaged`, `active`)
+                        VALUES (:serviceID, :userID, "", 1, 1)
+                        ON DUPLICATE KEY UPDATE `locallyManaged` = 1, `active` = 1';
+
+                $this->db->prepared_query($sql, $vars);
             }
 
             // include the backups of employees
             $emp = $employee->lookupLogin($member);
             $backups = $employee->getBackups($emp[0]['empUID']);
             foreach ($backups as $backup) {
-                $sql_vars = array(':userID' => $backup['userName'],
-                    ':serviceID' => $groupID,
-                    ':backupID' => $emp[0]['userName'],);
+                $vars = array(':userID' => $backup['userName'],
+                        ':serviceID' => $groupID,
+                        ':backupID' => $emp[0]['userName']);
+                $sql = 'INSERT INTO `service_chiefs` (`userID`, `serviceID`, `backupID`)
+                        VALUES (:userID, :serviceID, :backupID)
+                        ON DUPLICATE KEY UPDATE `userID` = :userID, `serviceID` = :serviceID,
+                            `backupID` = :backupID';
 
-                $res = $this->db->prepared_query('SELECT * FROM service_chiefs WHERE userID=:userID AND serviceID=:serviceID', $sql_vars);
+                $this->db->prepared_query($sql, $vars);
 
-                // Check for locallyManaged users
-                if ($res[0]['locallyManaged'] == 1) {
-                    $sql_vars[':backupID'] = null;
-                } else {
-                    $sql_vars[':backupID'] = $emp[0]['userName'];
-                }
-                // Add backupID check for updates
-                $this->db->prepared_query('INSERT INTO service_chiefs (userID, serviceID, backupID)
-                                                    VALUES (:userID, :serviceID, :backupID)
-                                                    ON DUPLICATE KEY UPDATE userID=:userID, serviceID=:serviceID, backupID=:backupID', $sql_vars);
+                $sql = 'INSERT INTO `users` (`userID`, `groupID`, `backupID`)
+                        VALUES (:userID, :serviceID, :backupID)
+                        ON DUPLICATE KEY UPDATE `userID` = :userID, `groupID` = :serviceID,
+                            `backupID` = :backupID';
+
+                $this->db->prepared_query($sql, $vars);
             }
         }
 
@@ -227,7 +243,133 @@ class Service
 
         return $this->db->prepared_query('INSERT INTO service_chiefs (serviceID, userID, backupID, locallyManaged, active)
                                                     VALUES (:serviceID, :userID, :backupID, 0, 1)
-                                                    ON DUPLICATE KEY UPDATE serviceID=:serviceID, userID=:userID, backupID=:backupID, locallyManaged=0, active=1', $sql_vars);
+                                                    ON DUPLICATE KEY UPDATE serviceID=:serviceID, userID=:userID, backupID=:backupID', $sql_vars);
+    }
+
+    /**
+     * @param int $groupID
+     * @param string $member
+     *
+     * @return array
+     *
+     * Created at: 8/16/2023, 8:46:21 AM (America/New_York)
+     */
+    public function deactivateChief(int $groupID, string $member): array
+    {
+        if (is_numeric($groupID) && $member != '') {
+            $this->dataActionLogger->logAction(\Leaf\DataActions::MODIFY, \Leaf\LoggableTypes::EMPLOYEE, [
+                new \Leaf\LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
+                new \Leaf\LogItem("users", "groupID", $groupID, $this->getServiceName($groupID))
+            ]);
+
+            $vars = array(':userID' => $member,
+                          ':serviceID' => $groupID, );
+            $sql = 'UPDATE `service_chiefs`
+                    SET `active` = 0
+                    WHERE `serviceID` = :serviceID
+                    AND (`userID` = :userID
+                        OR `backupID` = :userID)';
+
+            $this->db->prepared_query($sql, $vars);
+
+            $sql = 'UPDATE `users`
+                    SET `active` = 0
+                    WHERE `groupID` = :serviceID
+                    AND (`userID` = :userID
+                        OR `backupID` = :userID)';
+
+            $this->db->prepared_query($sql, $vars);
+
+            $return_value = array(
+                'status' => array(
+                    'code' => 2,
+                    'message' => 'All processed properly'
+                )
+            );
+        } else {
+            $return_value = array(
+                'status' => array(
+                    'code' => 4,
+                    'message' => 'data formatted incorrectly'
+                )
+            );
+        }
+
+        return $return_value;
+    }
+
+    /**
+     * @param int $serviceID
+     * @param string $userName
+     *
+     * @return array
+     *
+     * Created at: 8/16/2023, 8:46:50 AM (America/New_York)
+     */
+    public function pruneChief(int $serviceID, string $userName): array
+    {
+        $this->dataActionLogger->logAction(\Leaf\DataActions::DELETE, \Leaf\LoggableTypes::EMPLOYEE, [
+            new \Leaf\LogItem("users", "userID", $userName, $this->getEmployeeDisplay($userName)),
+            new \Leaf\LogItem("users", "groupID", $serviceID, $this->getServiceName($serviceID))
+        ]);
+
+        $vars = array(':serviceID' => $serviceID,
+                ':userID' => $userName);
+        $sql = 'DELETE
+                FROM `service_chiefs`
+                WHERE `serviceID` = :serviceID
+                AND (`userID` = :userID
+                    OR `backupID` = :userID)';
+
+        $return_value = $this->db->pdo_delete_query($sql, $vars);
+
+        $sql = 'DELETE
+                FROM `users`
+                WHERE `groupID` = :serviceID
+                AND (`userID` = :userID
+                    OR `backupID` = :userID)';
+
+        $return_value = $this->db->pdo_delete_query($sql, $vars);
+
+        return $return_value;
+    }
+
+    /**
+     * @param string $member
+     * @param int $serviceID
+     *
+     * @return array
+     *
+     * Created at: 8/16/2023, 8:47:05 AM (America/New_York)
+     */
+    public function reactivateChief(string $member, int $serviceID): array
+    {
+        $this->dataActionLogger->logAction(\Leaf\DataActions::ADD, \Leaf\LoggableTypes::EMPLOYEE, [
+            new \Leaf\LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
+            new \Leaf\LogItem("users", "groupID", $serviceID, $this->getServiceName($serviceID))
+        ]);
+
+        $vars = array(':serviceID' => $serviceID,
+                ':userID' => $member);
+        $sql = 'UPDATE `service_chiefs`
+                SET `active` = 1
+                WHERE `serviceID` = :serviceID
+                AND (`userID` = :userID
+                    OR `backupID` = :userID)';
+
+        $return_value = $this->db->pdo_update_query($sql, $vars);
+
+        $vars = array(':serviceID' => $serviceID,
+                ':userID' => $member);
+        $sql = 'UPDATE `users`
+                SET `active` = 1
+                WHERE `groupID` = :serviceID
+                AND (`userID` = :userID
+                    OR `backupID` = :userID)';
+
+        $return_value = $this->db->pdo_update_query($sql, $vars);
+
+        return $return_value;
     }
 
     public function removeMember($groupID, $member)
@@ -317,62 +459,59 @@ class Service
      *
      * Created at: 9/14/2022, 11:33:53 AM (America/New_York)
      */
-    public function removeChief(int $serviceID, string $userID, string|null $backupID): array
+    public function removeChief(int $serviceID, string $userID, string $backupID = ""): array
     {
         $this->dataActionLogger->logAction(\Leaf\DataActions::DELETE,\Leaf\LoggableTypes::SERVICE_CHIEF,[
             new \Leaf\LogItem("service_chiefs","serviceID", $serviceID, $this->getServiceName($serviceID)),
             new \Leaf\LogItem("service_chiefs", "userID", $userID, $this->getEmployeeDisplay($userID))
         ]);
 
-        if ($backupID == NULL){
-            $sql_vars = array(':userID' => $userID,
-                          ':serviceID' => $serviceID,);
+        $vars = array(':userID' => $userID,
+                    ':serviceID' => $serviceID,
+                    ':backupID' => $backupID);
+        $sql = 'DELETE
+                FROM `service_chiefs`
+                WHERE `userID` = :userID
+                AND `serviceID` = :serviceID
+                AND `backupID` = :backupID';
 
-            $result = $this->db->prepared_query('DELETE FROM service_chiefs
-                                            WHERE userID=:userID
-                                            AND serviceID=:serviceID
-                                            AND backupID IS NULL',
-                                            $sql_vars);
-        } else {
-            $sql_vars = array(':userID' => $userID,
-                          ':serviceID' => $serviceID,
-                          ':backupID' => $backupID, );
-
-            $result = $this->db->prepared_query('DELETE FROM service_chiefs
-                                            WHERE userID=:userID
-                                            AND serviceID=:serviceID
-                                            AND backupID=:backupID',
-                                            $sql_vars);
-        }
+        $result = $this->db->prepared_query($sql, $vars);
 
         return $result;
     }
 
     public function getMembers($groupID)
     {
-        if (!is_numeric($groupID))
-        {
+        if (!is_numeric($groupID)) {
             return;
         }
+
         $sql_vars = array(':groupID' => $groupID);
-        $res = $this->db->prepared_query('SELECT * FROM service_chiefs WHERE serviceID=:groupID ORDER BY userID', $sql_vars);
+        $sql = 'SELECT `userID`, `backupID`, `locallyManaged`, `active`
+                FROM `service_chiefs`
+                WHERE `serviceID` = :groupID
+                ORDER BY `userID`';
+
+        $res = $this->db->prepared_query($sql, $sql_vars);
 
         $members = array();
-        if (count($res) > 0)
-        {
-            $dir = new VAMC_Directory();
-            foreach ($res as $member)
-            {
-                $dirRes = $dir->lookupLogin($member['userID']);
+        $dir = new VAMC_Directory();
 
-                if (isset($dirRes[0]))
-                {
+        if (count($res) > 0) {
+            foreach ($res as $member) {
+                $dirRes = $dir->lookupLogin($member['userID'], false, true);
+
+                if (isset($dirRes[0])) {
                     $temp = $dirRes[0];
-                    if($member['locallyManaged'] == 1) {
-                        $temp['backupID'] = null;
-                    } else {
-                        $temp['backupID'] = $member['backupID'];
+                    $temp['regionallyManaged'] = 'no';
+
+                    foreach ($dirRes[0]['groups'] as $group) {
+                        if ($groupID == $group['groupID']) {
+                            $temp['regionallyManaged'] = 'yes';
+                        }
                     }
+
+                    $temp['backupID'] = $member['backupID'];
                     $temp['locallyManaged'] = $member['locallyManaged'];
                     $temp['active'] = $member['active'];
                     $members[] = $temp;

--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -258,8 +258,8 @@ class Service
     {
         if (is_numeric($groupID) && $member != '') {
             $this->dataActionLogger->logAction(\Leaf\DataActions::MODIFY, \Leaf\LoggableTypes::SERVICE_CHIEF, [
-                new \Leaf\LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
-                new \Leaf\LogItem("users", "groupID", $groupID, $this->getServiceName($groupID))
+                new \Leaf\LogItem("service_chiefs", "userID", $member, $this->getEmployeeDisplay($member)),
+                new \Leaf\LogItem("service_chiefs", "serviceID", $groupID, $this->getServiceName($groupID))
             ]);
 
             $vars = array(':userID' => $member,
@@ -309,8 +309,8 @@ class Service
     public function pruneChief(int $serviceID, string $userName): array
     {
         $this->dataActionLogger->logAction(\Leaf\DataActions::DELETE, \Leaf\LoggableTypes::SERVICE_CHIEF, [
-            new \Leaf\LogItem("users", "userID", $userName, $this->getEmployeeDisplay($userName)),
-            new \Leaf\LogItem("users", "groupID", $serviceID, $this->getServiceName($serviceID))
+            new \Leaf\LogItem("service_chiefs", "userID", $userName, $this->getEmployeeDisplay($userName)),
+            new \Leaf\LogItem("service_chiefs", "serviceID", $serviceID, $this->getServiceName($serviceID))
         ]);
 
         $vars = array(':serviceID' => $serviceID,

--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -449,8 +449,6 @@ class Service
     }
 
     /**
-     * [Description for removeChief]
-     *
      * @param int $serviceID
      * @param string $userID
      * @param string $backupID

--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -257,7 +257,7 @@ class Service
     public function deactivateChief(int $groupID, string $member): array
     {
         if (is_numeric($groupID) && $member != '') {
-            $this->dataActionLogger->logAction(\Leaf\DataActions::MODIFY, \Leaf\LoggableTypes::EMPLOYEE, [
+            $this->dataActionLogger->logAction(\Leaf\DataActions::MODIFY, \Leaf\LoggableTypes::SERVICE_CHIEF, [
                 new \Leaf\LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
                 new \Leaf\LogItem("users", "groupID", $groupID, $this->getServiceName($groupID))
             ]);
@@ -308,7 +308,7 @@ class Service
      */
     public function pruneChief(int $serviceID, string $userName): array
     {
-        $this->dataActionLogger->logAction(\Leaf\DataActions::DELETE, \Leaf\LoggableTypes::EMPLOYEE, [
+        $this->dataActionLogger->logAction(\Leaf\DataActions::DELETE, \Leaf\LoggableTypes::SERVICE_CHIEF, [
             new \Leaf\LogItem("users", "userID", $userName, $this->getEmployeeDisplay($userName)),
             new \Leaf\LogItem("users", "groupID", $serviceID, $this->getServiceName($serviceID))
         ]);
@@ -318,7 +318,8 @@ class Service
         $sql = 'DELETE
                 FROM `service_chiefs`
                 WHERE `serviceID` = :serviceID
-                AND (`userID` = :userID
+                AND ((`userID` = :userID
+                    AND `backupID` = "")
                     OR `backupID` = :userID)';
 
         $return_value = $this->db->pdo_delete_query($sql, $vars);
@@ -326,7 +327,8 @@ class Service
         $sql = 'DELETE
                 FROM `users`
                 WHERE `groupID` = :serviceID
-                AND (`userID` = :userID
+                AND ((`userID` = :userID
+                    AND `backupID` = "")
                     OR `backupID` = :userID)';
 
         $return_value = $this->db->pdo_delete_query($sql, $vars);

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -116,7 +116,7 @@ class System
                             $tagged = $tag->groupIsTagged($serviceID, Config::$orgchartImportTags[0]);
 
                             if ($serviceID == $quadID && $tagged['status']['code'] == 2 && !empty($tagged['data'])) {
-                                $this->updateGroup($serviceID);
+                                $this->updateGroup($serviceID, $oc_db);
                             } else {
                                 // make sure this is not in the groups table?
                                 $this->removeGroup($serviceID);
@@ -143,7 +143,7 @@ class System
      *
      * Created at: 6/30/2023, 1:24:51 PM (America/New_York)
      */
-    public function updateGroup(int $groupID): array
+    public function updateGroup(int $groupID, ?\Leaf\Db $oc_db = null): array
     {
         if (!is_numeric($groupID)) {
             $return_value = array(
@@ -160,7 +160,10 @@ class System
                 )
             );
         } else {
-            $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+            if ($oc_db === null) {
+                $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+            }
+
             $group = new \Orgchart\Group($oc_db, $this->login);
             $position = new \Orgchart\Position($oc_db, $this->login);
             $tag = new \Orgchart\Tag($oc_db, $this->login);
@@ -765,9 +768,10 @@ class System
         }
 
         $groups = $this->getOrgchartImportTags($nexus_group);
+        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
 
         foreach ($groups as $group) {
-            $this->updateGroup($group['groupID']);
+            $this->updateGroup($group['groupID'], $oc_db);
         }
 
         return 'Syncing has finished. You are set to go.';

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -114,9 +114,6 @@ class System
                             // check if this service is also an ELT
                             // if so, update groups table
                             $tagged = $tag->groupIsTagged($serviceID, Config::$orgchartImportTags[0]);
-                            error_log(print_r($serviceID, true));
-                            error_log(print_r($quadID, true));
-                            error_log(print_r($tagged, true));
 
                             if ($serviceID == $quadID && $tagged['status']['code'] == 2 && !empty($tagged['data'])) {
                                 $this->updateGroup($serviceID);

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -349,7 +349,7 @@ class System
         return $return_value;
     }
 
-    public function getServices()
+    public function getServices(): array
     {
         return $this->db->prepared_query('SELECT groupID as parentID,
         							serviceID as groupID,
@@ -364,7 +364,7 @@ class System
      *
      * @return string the current database version
      */
-    public function getDatabaseVersion()
+    public function getDatabaseVersion(): string
     {
         $version = $this->db->prepared_query('SELECT data FROM settings WHERE setting = "dbVersion"', array());
         if (count($version) > 0 && $version[0]['data'] !== null)
@@ -375,7 +375,7 @@ class System
         return 'unknown';
     }
 
-    public function getGroups()
+    public function getGroups(): array
     {
         return $this->db->prepared_query('SELECT * FROM `groups`
     								WHERE groupID > 1

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023072000-2023082400.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023072000-2023082400.sql
@@ -1,0 +1,32 @@
+START TRANSACTION;
+
+UPDATE `service_chiefs`
+SET `backupID` = ""
+WHERE `backupID` IS NULL;
+
+ALTER TABLE `service_chiefs` MODIFY `backupID` varchar(50) NOT NULL DEFAULT '';
+
+ALTER TABLE `service_chiefs` DROP INDEX `serviceID_2`;
+
+ALTER TABLE `service_chiefs` ADD PRIMARY KEY(`userID`, `serviceID`, `backupID`);
+
+UPDATE `settings` SET `data` = '2023082400' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+ /**** Revert DB *****
+ START TRANSACTION;
+ ALTER TABLE `service_chiefs` DROP PRIMARY KEY;
+
+ALTER TABLE `service_chiefs` ADD PRIMARY KEY(`userID`, `groupID`);
+
+ALTER TABLE `service_chiefs` MODIFY `backupID` varchar(50);
+
+UPDATE `service_chiefs`
+SET `backupID` = NULL
+WHERE `backupID` = "";
+
+ UPDATE `settings` SET `data` = '2023072000' WHERE `settings`.`setting` = 'dbversion';
+ COMMIT;
+ */

--- a/libs/logger/DataActionLogger.php
+++ b/libs/logger/DataActionLogger.php
@@ -120,10 +120,7 @@ class DataActionLogger
 
     public function fetchLogData($filterById, $filterByColumnName, $logType)
     {
-
         $filterResults = isset($filterById) && isset($filterByColumnName);
-
-
 
         $sqlCreateTemp =
             "

--- a/libs/logger/formatters/ServiceChiefFormatter.php
+++ b/libs/logger/formatters/ServiceChiefFormatter.php
@@ -10,6 +10,10 @@ class ServiceChiefFormatter
             "variables"=>"userID"
         ],
         DataActions::DELETE.'-'.LoggableTypes::SERVICE_CHIEF=> [
+            "message"=>"pruned <strong>user:</strong> %s",
+            "variables"=>"userID"
+        ],
+        DataActions::MODIFY.'-'.LoggableTypes::SERVICE_CHIEF=> [
             "message"=>"removed <strong>user:</strong> %s",
             "variables"=>"userID"
         ],


### PR DESCRIPTION
This started out as a revamp of services but because of found bugs it became a revamp of services and update of user groups.

This will require a db update, I would recommend keeping a copy of the db as it is before testing this so that you can go back to that db if you need to work on something else.

For testing it is important to check both sides, Portal and Nexus. When a change happens on the Nexus side it should be reflected on the portal upon a sync services or closing out of the group modal. Also, multiple backups should be checked along with mutual backups of people.

I think the biggest part of testing is going to be emails. Making sure that the correct people get the emails and such.

I also updated the inactive user section for both user and services. You are only allowed to prune locally managed non Nexus members so in place of the prune button I put a reactivate button for that person (This will prevent the user from having to add them locally or removing the group and re-adding them)

The services modal section is now updated to look like user access groups. The exception to this is a local member shouldn't be allowed to be added to Nexus so that button was removed. It also doesn't show a Nexus check mark.