### PR TITLE
LEAF-3949 Only load relevant data

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -839,7 +839,8 @@ var LeafFormSearch = function (containerID) {
         });
         break;
       case "data":
-        url = rootURL === '' ? './api/form/indicator/list' : rootURL + 'api/form/indicator/list';
+        let resultFilter = '?x-filterData=indicatorID,categoryName,name,format';
+        url = rootURL === '' ? `./api/form/indicator/list${resultFilter}` : rootURL + `api/form/indicator/list${resultFilter}`;
         $.ajax({
           type: "GET",
           url,
@@ -1146,8 +1147,7 @@ var LeafFormSearch = function (containerID) {
             if (callback != undefined) {
               callback();
             }
-          },
-          cache: false,
+          }
         });
         break;
       default:

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -390,7 +390,7 @@ function loadSearchPrereqs() {
     searchPrereqsLoaded = true;
     $.ajax({
         type: 'GET',
-        url: './api/form/indicator/list',
+        url: './api/form/indicator/list?x-filterData=name,indicatorID,categoryID,categoryName,parentCategoryID,parentStaples',
         dataType: 'text json',
         success: function(res) {
             var buffer = '';
@@ -616,8 +616,7 @@ function loadSearchPrereqs() {
                     });
                 }
             });
-        },
-        cache: false
+        }
     });
 }
 


### PR DESCRIPTION
This improves load time in two key areas:
1. Homepage -> (Search) Advanced Options -> Select "Data Field"
2. Creating a new report in the Report Builder

Observed ~50% improvement on larger sites. The x-filterData parameter is used to limit data transfer to the requested content.

This also disables jQuery's cache-busting workaround. It's redundant because the cache behavior for API responses on Prod is configured correctly.

Testing:
- Report Builder should function normally
- Advanced Searches on the homepage should function normally
