### PR TITLE
LEAF-3950 LEAF-S and Admin user flow update

### DIFF
--- a/LEAF_Nexus/api/RESTfulResponse.php
+++ b/LEAF_Nexus/api/RESTfulResponse.php
@@ -67,8 +67,11 @@ abstract class RESTfulResponse
 
                 break;
             case 'DELETE':
-                if ($_GET['CSRFToken'] == $_SESSION['CSRFToken'])
-                {
+                $DELETE_vars = [];
+                parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
+
+                if ($_GET['CSRFToken'] == $_SESSION['CSRFToken'] // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
+                    || $DELETE_vars['CSRFToken'] == $_SESSION['CSRFToken']) {
                     $this->output($this->delete($action));
                 }
                 else

--- a/LEAF_Request_Portal/admin/templates/mod_system.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_system.tpl
@@ -182,16 +182,26 @@ function renderSettings(res) {
                 query.addTerm('stepID', '=', 'resolved');
                 query.join('recordResolutionData');
                 query.onSuccess(function(data) {
-                    var mostRecentID = null;
-                    var mostRecentDate = 0;
-                    for(var i in data) {
-                        if(data[i].recordResolutionData.lastStatus == 'Approved'
-                            && data[i].recordResolutionData.fulfillmentTime > mostRecentDate) {
-                            mostRecentDate = data[i].recordResolutionData.fulfillmentTime;
-                            mostRecentID = i;
-                        }
+                    if(Object.keys(data).length == 0) {
+                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <a class="buttonNorm" href="../report.php?a=LEAF_start_leaf_secure_certification">Start Certification Process</a>');
+                        $.ajax({
+                            type: 'DELETE',
+                            url: '../api/system/settings/leaf-secure',
+                            data: {CSRFToken: CSRFToken}
+                        });
                     }
-                    $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: green; color: white; font-weight: bold">Certified</span> <a class="buttonNorm" href="../index.php?a=printview&recordID='+ mostRecentID +'">View details</a>');
+                    else {
+                        let mostRecentID = null;
+                        let mostRecentDate = 0;
+                        for(let i in data) {
+                            if(data[i].recordResolutionData.lastStatus == 'Approved'
+                                && data[i].recordResolutionData.fulfillmentTime > mostRecentDate) {
+                                mostRecentDate = data[i].recordResolutionData.fulfillmentTime;
+                                mostRecentID = i;
+                            }
+                        }
+                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: green; color: white; font-weight: bold">Certified</span> <a class="buttonNorm" href="../index.php?a=printview&recordID='+ mostRecentID +'">View details</a>');
+                    }
                 });
                 query.execute();
             }
@@ -203,7 +213,7 @@ function renderSettings(res) {
                     }
                     else {
                         var recordID = data[Object.keys(data)[0]].recordID;
-                        $('#leafSecureStatus').html('<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <a class="buttonNorm" href="../index.php?a=printview&recordID='+ recordID +'">Check Certification Progress</a>');
+                        $('#leafSecureStatus').html(`<span style="font-size: 120%; padding: 4px; background-color: red; color: white; font-weight: bold">Not Certified</span> <a class="buttonNorm" href="../index.php?a=printview&recordID=${recordID}&masquerade=nonAdmin">Check Certification Progress</a>`);
                     }
                 });
                 query.execute();

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -55,7 +55,11 @@ abstract class RESTfulResponse
 
                 break;
             case 'DELETE':
-                if ($_GET['CSRFToken'] == $_SESSION['CSRFToken']) {
+                $DELETE_vars = [];
+                parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
+
+                if ($_GET['CSRFToken'] == $_SESSION['CSRFToken'] // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
+                    || $DELETE_vars['CSRFToken'] == $_SESSION['CSRFToken']) {
                     $return_value = $this->output($this->delete($action));
                 } else {
                     $return_value = $this->output('Invalid Token.');

--- a/LEAF_Request_Portal/api/controllers/SystemController.php
+++ b/LEAF_Request_Portal/api/controllers/SystemController.php
@@ -164,6 +164,10 @@ class SystemController extends RESTfulResponse
                 return $system->removeFile($_GET['file']);
             });
 
+            $this->index['DELETE']->register('system/settings/leaf-secure', function () use ($system) {
+                return $system->removeLeafSecure();
+            });
+
             return $this->index['DELETE']->runControl($act['key'], $act['args']);
         }
 

--- a/LEAF_Request_Portal/js/LeafSecureReviewDialog.js
+++ b/LEAF_Request_Portal/js/LeafSecureReviewDialog.js
@@ -18,10 +18,12 @@ var LeafSecureReviewDialog = function(domId) {
             temp = res[i];
             temp.recordID = res[i].indicatorID;
             if(res[i].is_sensitive == '1') {
-            sensitiveFields.push(temp);
+                sensitiveFields.push(temp);
             }
             else {
-            nonSensitiveFields.push(temp);
+                if(temp.categoryID.indexOf('leaf_') == -1) {
+                    nonSensitiveFields.push(temp);
+                }
             }
         }
 

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -1451,4 +1451,10 @@ class System
         }
 
     }
+
+    // removeLeafSecure removes the LEAF secure status of the current site
+    public function removeLeafSecure()
+    {
+        $this->db->prepared_query("UPDATE settings SET data = 0 WHERE setting = 'leafSecure'", []);
+    }
 }

--- a/LEAF_Request_Portal/templates/form.tpl
+++ b/LEAF_Request_Portal/templates/form.tpl
@@ -29,7 +29,7 @@
     </div>
     <div class="col span_1_of_5" style="float: left">
         <div id="tools" class="tools"><h1 style="font-size: 12px; text-align: center; margin: 0; padding: 2px">Tools</h1>
-            <div id="showSinglePage" role="button" onclick="window.location='?a=printview&amp;recordID=<!--{$recordID}-->'" title="View full form"><img src="dynicons/?img=edit-find-replace.svg&amp;w=32" alt="View full form"  /> Show single page</div>
+            <div id="showSinglePage" role="button" onclick="window.location='?a=printview&amp;recordID=<!--{$recordID}-->&masquerade=nonAdmin'" title="View full form"><img src="dynicons/?img=edit-find-replace.svg&amp;w=32" alt="View full form"  /> Show single page</div>
             <br /><br />
             <button tabindex="0" class="tools" aria-label="Cancel request" onclick="cancelRequest()"><img src="dynicons/?img=process-stop.svg&amp;w=16" alt="Cancel Request" title="Cancel Request" style="vertical-align: middle"/> Cancel Request</button>
         </div>
@@ -85,7 +85,7 @@ function getNext() {
     	if(<!--{$isIframe}-->) {
     		iframeURL = '&iframe=1';
     	}
-        window.location.href="index.php?a=printview&recordID=<!--{$recordID}-->" + iframeURL;
+        window.location.href="index.php?a=printview&recordID=<!--{$recordID}-->&masquerade=nonAdmin" + iframeURL;
     }
 
     return true;

--- a/LEAF_Request_Portal/templates/reports/LEAF_start_leaf_secure_certification.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_start_leaf_secure_certification.tpl
@@ -14,9 +14,9 @@ $(function() {
         }
     })
     .then(function(res) {
-    	var recordID = parseFloat(res);
+    	let recordID = parseFloat(res);
         if(!isNaN(recordID) && isFinite(recordID) && recordID != 0) {
-            window.location = "index.php?a=view&recordID=" + recordID;
+            window.location = `index.php?a=view&recordID=${recordID}&masquerade=nonAdmin`;
         }
     });
 });


### PR DESCRIPTION
This helps Admins avoid taking actions on records that are not explicitly assigned to them, by displaying the review screen in a non-admin context.

This also resolves an issue where an approved and then deleted "LEAF Secure" record would appear to remain certified, but would navigate to a broken link.

Testing:
- [x] After a LEAF Secure record is deleted, refreshing the Admin Panel -> Site Settings page should allow the user to start a new certification, instead of show a broken link
- [x] After a LEAF Secure record is submitted, and the supervisor/privacy officer are not the admin, the approve button does not show up by default
- [x] LEAF-S related data fields do not show up on the LEAF-S form
- [x] Fields marked as sensitive data shows up on the LEAF-S form