### PR TITLE
LEAF 3947 fix incorrect backups notification

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1071,7 +1071,7 @@ class FormWorkflow
 
                     $dir = new VAMC_Directory;
 
-                    $author = $dir->lookupLogin($this->login->getUserID());
+                    $author = $dir->lookupLogin($approvers[0]['userID']);
                     $email->setSender($author[0]['Email']);
 
                     // Get backups to requester so they can be notified as well
@@ -1123,7 +1123,7 @@ class FormWorkflow
 
                     $dir = new VAMC_Directory;
 
-                    $author = $dir->lookupLogin($this->login->getUserID());
+                    $author = $dir->lookupLogin($approvers[0]['userID']);
                     $email->setSender($author[0]['Email']);
 
                     $eventData = json_decode($event['eventData']);


### PR DESCRIPTION
Notify the requestor events have been getting the logged in user ID rather than the request initiator ID.

This had caused the backups of the last action-taker to get emails intended for the backups of request initiators.