### PR TITLE
Leaf 3973 hotfix sync services

### DIFF
--- a/LEAF_Nexus/sources/Group.php
+++ b/LEAF_Nexus/sources/Group.php
@@ -413,19 +413,26 @@ class Group extends Data
 
     /**
      * List groups by tag
+     *
      * @param string $tag
-     * @param int $offset
-     * @param int $quantity
+     * @param int|null $offset
+     * @param int|null $quantity
+     *
      * @return array
+     *
+     * Created at: 8/29/2023, 7:58:53 AM (America/New_York)
      */
-    public function listGroupsByTag($tag, $offset = null, $quantity = null)
+    public function listGroupsByTag(string $tag, ?int $offset = null, ?int $quantity = null): array
     {
         $this->db->limit($offset, $quantity);
         $vars = array(':tag' => $tag);
-        $res = $this->db->prepared_query('SELECT * FROM group_tags
-                                            LEFT JOIN `groups` USING (groupID)
-                                            WHERE tag=:tag
-                                            ORDER BY groupTitle ASC', $vars);
+        $sql = 'SELECT *
+                FROM `group_tags`
+                RIGHT JOIN `groups` USING (`groupID`)
+                WHERE `tag` = :tag
+                ORDER BY `groupTitle` ASC';
+
+        $res = $this->db->prepared_query($sql, $vars);
 
         return $res;
     }


### PR DESCRIPTION
This changes the query to perform a right join rather than a left join getting only groups that actually exist.  This exists because a tag was added to a group and then the group was subsequently removed but the tag was left. So when getting the tags from Nexus it used to get all the tags even though the group no longer exists. By changing this to right join we only get the valid groups, or groups that exist in the groups table.