### PR TITLE
LEAF-3979 - Compatibility for upcoming large query handler

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -258,7 +258,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
     if (query.getData != undefined && query.getData.length == 0) {
       delete query.getData;
     }
-    if (query.limit == undefined || isNaN(query.limit) || parseInt(query.limit) > 9999) {
+    if (query.limit == undefined || isNaN(query.limit) || parseInt(query.limit) > 1000) {
       return getBulkData();
     }
 


### PR DESCRIPTION
This helps avoid conflicting with the new upcoming behavior in LEAF-3427 (large queries).

Prior to this change, a custom implementation of formQuery.js could request 1001 rows, trigger the new LEAF-3427 behavior, and appear to return no data.

After this change, customizations can request 1001 rows and return normally.