### PR TITLE
LEAF-3978 - Optimize autoloader DB connections

### DIFF
--- a/LEAF_Request_Portal/scripts/events/CustomEvent_LeafSecure_DeveloperConsole.php
+++ b/LEAF_Request_Portal/scripts/events/CustomEvent_LeafSecure_DeveloperConsole.php
@@ -41,7 +41,7 @@ class CustomEvent_LeafSecure_DeveloperConsole
         $res = $this->db->prepared_query('SELECT userID FROM records WHERE recordID=:recordID', $vars);
 
         // get the initiator's empUID
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $login = new \Orgchart\Login($oc_db, $oc_db);
         $employee = new \Orgchart\Employee($oc_db, $login);
 

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -398,7 +398,7 @@ class Email
     function initNexusDB(): void
     {
         // set up org chart assets
-        $this->nexus_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $this->nexus_db = OC_DB;
     }
 
     /**

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -39,7 +39,7 @@ class Form
         $this->db = $db;
         $this->login = $login;
 
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $oc_login = new \Orgchart\Login($oc_db, $oc_db);
         $oc_login->loginUser();
         $this->oc_dbName = \ORGCHART_DB;

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -32,7 +32,7 @@ class FormWorkflow
         $this->db = $db;
         $this->login = $login;
         $this->recordID = is_numeric($recordID) ? $recordID : 0;
-        $this->oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $this->oc_db = OC_DB;
 
         // For Jira Ticket:LEAF-2471/remove-all-http-redirects-from-code
 //        $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http';

--- a/LEAF_Request_Portal/sources/Group.php
+++ b/LEAF_Request_Portal/sources/Group.php
@@ -267,7 +267,7 @@ class Group
      */
     public function addMember(string $member, int $groupID): array
     {
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $employee = new \Orgchart\Employee($oc_db, $this->login);
 
         $vars = array(':userID' => $member,

--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -154,7 +154,7 @@ class Service
      */
     public function addMember($groupID, $member)
     {
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $employee = new \Orgchart\Employee($oc_db, $this->login);
 
         if (is_numeric($groupID) && $member != '') {
@@ -378,7 +378,7 @@ class Service
 
     public function removeMember($groupID, $member)
     {
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $employee = new \Orgchart\Employee($oc_db, $this->login);
 
         if (is_numeric($groupID) && $member != '') {

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -55,7 +55,7 @@ class System
                 )
             );
         } else {
-            $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+            $oc_db = OC_DB;
             $group = new \Orgchart\Group($oc_db, $this->login);
             $position = new \Orgchart\Position($oc_db, $this->login);
             $tag = new \Orgchart\Tag($oc_db, $this->login);
@@ -173,7 +173,7 @@ class System
             );
         } else {
             if ($oc_db === null) {
-                $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+                $oc_db = OC_DB;
             }
 
             $group = new \Orgchart\Group($oc_db, $this->login);
@@ -293,7 +293,7 @@ class System
             //$this->db->prepared_query('DELETE FROM users WHERE groupID=:groupID AND backupID IS NULL', $vars);
             $this->db->prepared_query('DELETE FROM `groups` WHERE groupID=:groupID', $vars);
 
-            $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+            $oc_db = OC_DB;
             $group = new \Orgchart\Group($oc_db, $this->login);
             $position = new \Orgchart\Position($oc_db, $this->login);
             $employee = new \Orgchart\Employee($oc_db, $this->login);
@@ -782,7 +782,7 @@ class System
 
         $this->removeGroups();
         $groups = $this->getOrgchartImportTags($nexus_group);
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
 
         foreach ($groups as $group) {
             $this->updateGroup($group['groupID'], $oc_db);
@@ -1031,7 +1031,7 @@ class System
      */
     private function addBackups(int $groupID, bool $group = true): array
     {
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $employee = new \Orgchart\Employee($oc_db, $this->login);
 
         // get all users for this group

--- a/LEAF_Request_Portal/sources/VAMC_Directory.php
+++ b/LEAF_Request_Portal/sources/VAMC_Directory.php
@@ -47,7 +47,7 @@ class VAMC_Directory
     // Connect to the database
     public function __construct()
     {
-        $oc_db = new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);
+        $oc_db = OC_DB;
         $login = new \Orgchart\Login($oc_db, $oc_db);
         $this->Employee = new \Orgchart\Employee($oc_db, $login);
         $this->Group = new \Orgchart\Group($oc_db, $login);


### PR DESCRIPTION
The autoloader creates more database connections than it needs to. When accessing ./api/form/version, this PR reduces the number of connections opened by 20%.

Original:
- new \Leaf\Db(\DIRECTORY_HOST, \DIRECTORY_USER, \DIRECTORY_PASS, \ORGCHART_DB);

Replacement:
- OC_DB;

Are these equivalent? Seems so:
1. OC_DB is defined globally here: https://github.com/department-of-veterans-affairs/LEAF/blob/autoloader-db-optimization/libs/loaders/Leaf_autoloader.php#L127
2. ... by using $oc_db defined here: https://github.com/department-of-veterans-affairs/LEAF/blob/autoloader-db-optimization/libs/loaders/Leaf_autoloader.php#L55 
3. ... which references $site_paths['orgchart_database']. This is the only difference compared to the Original DB connection, and...
4. ... ORGCHART_DB is actually assigned to $site_paths['orgchart_database'] here: https://github.com/department-of-veterans-affairs/LEAF/blob/autoloader-db-optimization/libs/loaders/Leaf_autoloader.php#L126

