### PR TITLE
LEAF-3998 - Improve ergonomics of getData() when using many indicators 

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -132,10 +132,6 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
 	else if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
 	    query.getData.push(indicatorID);
 	}
-		if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
-			query.getData.push(indicatorID);
-		}
-	}
   }
 
   /**

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -119,13 +119,21 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   }
 
   /**
-   * @param {string|number} indicatorID
+   * getData includes data associated with $indicatorID in the result set
+   * @param {string|number|array} indicatorID
    * @memberOf LeafFormQuery
    */
   function getData(indicatorID = "") {
-    if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
-      query.getData.push(indicatorID);
-    }
+	if(Array.isArray(indicatorID)) {
+		indicatorID.forEach(id => {
+			getData(id);
+		});
+	}
+	else {
+		if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
+			query.getData.push(indicatorID);
+		}
+	}
   }
 
   /**

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -129,7 +129,9 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
 			getData(id);
 		});
 	}
-	else {
+	else if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
+	    query.getData.push(indicatorID);
+	}
 		if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
 			query.getData.push(indicatorID);
 		}


### PR DESCRIPTION
This improves the ergonomics of formQuery.js -> getData() when many indicatorIDs need to be referenced. The change is backward compatible.

Before:
```js
query.getData(1);
query.getData(2);
query.getData(3);
```

After:
```js
query.getData([1, 2, 3]);
```
