### PR TITLE
Exclude Java from CodeQL

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,3 @@
+ excluded_languages:
+   - name: java
+     reason: "Java code is inactive and only used for archival purposes."


### PR DESCRIPTION
Excludes Java from CodeQL scans since the code is only stored for archival purposes.