### PR TITLE
LEAF-3995 - Optimize queries for actionable records 

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -144,7 +144,6 @@ class FormWorkflow
             LEFT JOIN records USING (recordID)
             LEFT JOIN workflow_steps USING (stepID)
             LEFT JOIN step_dependencies USING (stepID)
-            LEFT JOIN dependencies USING (dependencyID)
             LEFT JOIN records_dependencies USING (recordID, dependencyID)
             WHERE recordID IN ({$recordIDs})
                 AND filled=0";

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -140,7 +140,7 @@ class FormWorkflow
         }
         $recordIDs = trim($recordIDs, ',');
 
-        $strSQL = "SELECT dependencyID, recordID, stepID, stepTitle, blockingStepID, workflowID, serviceID, filled, stepBgColor, stepFontColor, stepBorder, description, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, jsSrc, userID, requiresDigitalSignature FROM records_workflow_state
+        $strSQL = "SELECT dependencyID, recordID, serviceID, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, userID FROM records_workflow_state
             LEFT JOIN records USING (recordID)
             LEFT JOIN workflow_steps USING (stepID)
             LEFT JOIN step_dependencies USING (stepID)

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -973,7 +973,6 @@ class FormWorkflow
       * @return string
       */
     public function getEmpUIDByUserName(string $userName): ?string
-
     {
         if(isset($this->cache['getEmpUIDByUserName'.$userName])) {
             return $this->cache['getEmpUIDByUserName'.$userName];

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -972,7 +972,8 @@ class FormWorkflow
       * @param string $userName Username
       * @return string
       */
-    public function getEmpUIDByUserName(string $userName): string|null
+    public function getEmpUIDByUserName(string $userName): ?string
+
     {
         if(isset($this->cache['getEmpUIDByUserName'.$userName])) {
             return $this->cache['getEmpUIDByUserName'.$userName];

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1273,8 +1273,16 @@ $(function() {
         let offset = 0;
         let queryResult = {};
         let abortLoad = false;
+        let masquerade = '';
+        let urlParams = new URLSearchParams(window.location.search);
+        let addMasqueradeParam = '';
+        urlMasqueradeParam = urlParams.get('masquerade');
+        if(urlMasqueradeParam == 'nonAdmin') {
+            addMasqueradeParam = '&masquerade=nonAdmin';
+        }
+
         leafSearch.getLeafFormQuery().setLimit(offset, batchSize);
-        leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(','));
+        leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
 
         leafSearch.getLeafFormQuery().onSuccess(function(res, resStatus, resJqXHR) {
             queryResult = Object.assign(queryResult, res);


### PR DESCRIPTION
This improves ./api/form/query performance when searching for actionable records and many parallel workflow requirements exist. For employee clearance processes with 20+ parallel requirements, this can provide a 20x improvement (Martinsburg) in load time.

Additionally this enables the masquerade=nonAdmin parameter in the Report Builder, allowing admins to view reports in a non-admin context.

- The original getActionable() was copied and renamed to a private function retrieveRecordDependencies()
- Dependencies on the old getActionable() were updated to the new function to minimize impact on functionality that depends on the original behavior.
- getActionable() was updated to align with its intended behavior, as described in the function comments: "add an isActionable parameter"
- getActionable() was optimized to focus on actionable records by updating the query to include a "filled=0" term, which represent requirements that have not already been acted on. The second optimization uses an internal index based on the recordID instead of dependencyID, since the intent of identifying actionable records is based on the recordID.
- Updates getEmpUIDByUserName() to include null as a return type hint

### Potential Impacts:
- Dependencies on ./api/form/query , such as the Report Builder

### Testing:

Report Builder -> Search for "Status IS Actionable"
- [x] Results as an admin are the same as before
- [x] Results as a non-admin are the same as before
- [x] As an admin, add "&masquerade=nonAdmin" to the URL. Results should appear as if you're not an admin.