### PR TITLE
LEAF-4007 - Prepare for fulltext search feature

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -97,6 +97,9 @@
                                             .slideDown();
                                         $('#requestTitle').attr('tabindex', '0');
                                         $('#requestInfo').attr('tabindex', '0');
+                                    },
+                                    fail: function() {
+                                        triggerGenericLoadError();
                                     }
                                 })
                             }
@@ -191,6 +194,10 @@
         $('#progressContainer').slideUp();
         $('#loading').slideUp();
         $('.inbox').fadeIn();
+    }
+
+    function triggerGenericLoadError() {
+        alert('Error loading data. This error has been automatically reported. Please refresh the page and try again.');
     }
 
     // renderInbox iterates through the specified sites and renders the view, organized by form
@@ -674,6 +681,9 @@
                 res.forEach(w => {
                     dataWorkflowCategories[w.categoryID] = 1;
                 });
+            },
+            fail: function() {
+                triggerGenericLoadError();
             }
         });
     }

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023082401-2023091100.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023082401-2023091100.sql
@@ -1,0 +1,18 @@
+START TRANSACTION;
+
+ALTER TABLE `data` ADD FULLTEXT `data` (`data`);
+
+UPDATE `settings` SET `data` = '2023091100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `data` DROP INDEX `data`;
+
+UPDATE `settings` SET `data` = '2023082401' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
This is a prerequisite for an upcoming change to mitigate certain worst-case response time scenarios when users run broad searches.

### Why?
The "CONTAINS" comparator is the default when users run a broad search such as "any data field contains...". It takes about 20-30 seconds for the DB to respond when there's ~16M rows in the "data" table.

The 20-30s query looks like:
```sql
SELECT * FROM records
LEFT JOIN services USING (serviceID) LEFT JOIN (SELECT * FROM records_workflow_state) lj_status USING (recordID)
LEFT JOIN (SELECT stepID, stepTitle FROM workflow_steps) lj_steps ON (lj_status.stepID = lj_steps.stepID)
LEFT JOIN (SELECT recordID, indicatorID, series, data FROM data) lj_data ON (lj_data.recordID = records.recordID)
INNER JOIN (SELECT indicatorID, format FROM indicators 
                         WHERE format != 'orgchart_employee'
                             AND format != 'orgchart_position'
                             AND format != 'orgchart_group') rj_AllData ON (lj_data.indicatorID = rj_AllData.indicatorID)
WHERE (lj_data.data LIKE '%asdfghjkl%') AND (deleted = '0') ORDER BY date DESC LIMIT 50
```

In the future change, we will add a "CONTAINS WORD" comparator as the default. This provides similar search results.

In testing, the modified query runs in about 0.01s:
```sql
SELECT * FROM records
LEFT JOIN services USING (serviceID) LEFT JOIN (SELECT * FROM records_workflow_state) lj_status USING (recordID)
LEFT JOIN (SELECT stepID, stepTitle FROM workflow_steps) lj_steps ON (lj_status.stepID = lj_steps.stepID)
LEFT JOIN (SELECT recordID, indicatorID, series, data FROM data) lj_data ON (lj_data.recordID = records.recordID)
INNER JOIN (SELECT indicatorID, format FROM indicators 
                         WHERE format != 'orgchart_employee'
                             AND format != 'orgchart_position'
                             AND format != 'orgchart_group') rj_AllData ON (lj_data.indicatorID = rj_AllData.indicatorID)
WHERE (MATCH (lj_data.data) AGAINST ('asdfghjkl' IN BOOLEAN MODE)) AND (deleted = '0') ORDER BY date DESC LIMIT 50
```


### Potential Impacts
- Database storage usage will increase by about 50%
- May cause high database load while many indexes are being created
   - Note that creating indexes does not lock InnoDB tables: https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-index-syntax-notes
   - HOWEVER there's a note about "Adding the first FULLTEXT index rebuilds the table if there is no user-defined FTS_DOC_ID column. Additional FULLTEXT indexes may be added without rebuilding the table." Not sure if this means writes would be locked out.

### Deployment Prerequisites
- [ ] Check and ensure the database has enough storage
- [ ] Likely requires update during off-hours to avoid disruption

### Testing
- [ ] The modified query returns similar data as the original, and runs much faster on large databases