### PR TITLE
LEAF-4011 - Mobile Template Selector Fix

### DIFF
--- a/LEAF_Request_Portal/admin/css/mod_templates.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates.css
@@ -573,10 +573,10 @@
 }
 
 .templateFiles {
-    width: 85%;
+    width: 100%;
     padding: 10px;
     font-size: .8rem;
-    border: none;
+    border: 2px solid #333;
     border-radius: 5px;
 }
 

--- a/LEAF_Request_Portal/admin/css/mod_templates_email.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_email.css
@@ -675,13 +675,17 @@ legend {
     padding: 10px 0;
     margin: 0 0 10px 0;
 }
+.template_select_container {
+    display: flex;
+}
 
 .templateFiles {
-    width: 85%;
+    width: 90%;
     padding: 10px;
     font-size: .8rem;
-    border: none;
+    border: 2px solid #333;
     border-radius: 5px;
+    margin: 0 auto;
 }
 
 .mobileToolsNav {
@@ -734,7 +738,7 @@ legend {
 #form-select-dropdown,
 #indicator-select-dropdown,
 #indicator-id {
-    border: none;
+    border: 2px solid #333;
     margin-top: 10px;
     padding: 10px;
     border-radius: 5px;

--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -241,6 +241,10 @@
     cursor: pointer;
 }
 
+.mobile_new_report_btn {
+    display: none;
+}
+
 .main-content {
     display: flex;
     justify-content: space-evenly;
@@ -646,11 +650,15 @@
     margin: 0 0 10px 0;
 }
 
+.template_select_container {
+    width: 78%;
+}
+
 .templateFiles {
-    width: 80%;
+    width: 100%;
     padding: 10px;
     font-size: .8rem;
-    border: none;
+    border: 2px solid #333;
     border-radius: 5px;
 }
 
@@ -797,5 +805,9 @@
 
     .keyboard_shortcuts_section {
         width: 100%;
+    }
+
+    .mobile_new_report_btn {
+        display: block;
     }
 }

--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -890,17 +890,17 @@
         $.ajax({
             type: 'GET',
             url: '../api/template/',
-            success: function(res) {
+            success: function (res) {
                 $.ajax({
                     type: 'GET',
                     url: '../api/template/custom',
                     dataType: 'json',
-                    success: function(result) {
+                    success: function (result) {
                         let template_excluded = 'import_from_webHR.tpl';
                         let res_array = $.parseJSON(result);
                         let buffer = '<ul class="leaf-ul">';
-                        let filesMobile = '<h3>Template Files:</h3><select class="templateFiles">';
-
+                        let filesMobile = '<h3>Template Files:</h3><div class="template_select_container"><select class="templateFiles">';
+                        
                         if (res_array.status['code'] === 2) {
                             for (let i in res) {
                                 if (res[i] === template_excluded) {
@@ -914,36 +914,46 @@
                                     custom = '';
                                 }
 
-                                file = res[i].replace('.tpl', '');
+                                let file = res[i].replace('.tpl', '');
 
-                                buffer += '<li onclick="loadContent(\'' + res[i] + '\');"><div class="template_files"><a href="#">' +
-                                    file + '</a> ' + custom + '</div></li>';
+                                buffer += '<li><div class="template_files"><a href="#" data-file="' + res[i] + '">' + file + '</a> ' + custom + '</div></li>';
 
-                                filesMobile += '<option onclick="loadContent(\'' + res[i] + '\');"><div class="template_files"><a href="#">' +
-                                    file + '</a> ' + custom + '</div></option>';
+                                filesMobile += '<option value="' + res[i] + '">' + file + ' ' + custom + '</option>';
                             }
                         } else if (res_array.status['code'] === 4) {
-                            buffer += '<li><div class="template_files">' + res_array
-                                .status['message'] + '</div></li>';
-                            filesMobile += '<select><option>' + res_array
-                                .status['message'] + '</option></select>';
+                            buffer += '<li><div class="template_files">' + res_array.status['message'] + '</div></li>';
+                            filesMobile += '<select><option>' + res_array.status['message'] + '</option></select>';
                         } else {
-                            buffer +=
-                                '<li>Internal error occurred, if this persists contact your Primary Admin.</li>';
+                            buffer += '<li>Internal error occurred, if this persists contact your Primary Admin.</li>';
                         }
 
                         buffer += '</ul>';
-                        filesMobile += '</select>';
+                        filesMobile += '</select></div>';
                         $('#fileList').html(buffer);
                         $('.filesMobile').html(filesMobile);
+
+                        // Attach click event handler to template links in the buffer
+                        $('#fileList a').on('click', function (e) {
+                            e.preventDefault();
+                            let selectedFile = $(this).data('file');
+                            loadContent(selectedFile);
+                        });
+
+                        // Attach onchange event handler to templateFiles select element
+                        $('.template_select_container').on('change', 'select.templateFiles', function () {
+                            let selectedFile = $(this).val();
+                            loadContent(selectedFile);
+                        });
                     },
-                    error: function(error) {
+                    error: function (error) {
                         console.log(error);
                     }
                 });
             },
             cache: false
         });
+
+
 
         initializePage();
 

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -840,7 +840,7 @@
     }
     // loads all files and retreave's them
     function loadContent(name, file, subjectFile, emailToFile, emailCcFile) {
-        // console.log(name, file, subjectFile, emailToFile, emailCcFile);
+        console.log(name, file, subjectFile, emailToFile, emailCcFile);
         if (file === undefined) {
             name = currentName;
             file = currentFile;
@@ -1206,60 +1206,83 @@
         $.ajax({
             type: 'GET',
             url: '../api/emailTemplates',
-            success: function(res) {
+            success: function (res) {
                 $.ajax({
                     type: 'GET',
                     url: '../api/emailTemplates/custom',
                     dataType: 'json',
-                    success: function(result) {
+                    success: function (result) {
                         let res_array = $.parseJSON(result);
                         let buffer = '<ul class="leaf-ul">';
-                        let filesMobile = '<h3>Template Files:</h3><select class="templateFiles">';
+                        let filesMobile = '<h3>Template Files:</h3><div class="template_select_container"><select class="templateFiles">';
 
                         if (res_array.status['code'] === 2) {
-
                             for (let i in res) {
+                                let custom = '';
+
                                 if (result.includes(res[i].fileName)) {
                                     custom = '<span class=\'custom_file\' style=\'color: red; font-size: .75em\'>(custom)</span>';
-                                } else {
-                                    custom = '';
-                                }
-                                // This displays the mobile file dropdown
-                                filesMobile += '<option onclick="loadContent(\'' + res[i].displayName + '\' , ' + '\'' + res[i].fileName + '\'';
-
-                                buffer += '<li onclick="loadContent(\'' + res[i].displayName + '\', ' + '\'' + res[i].fileName + '\'';
-
-                                if (res[i].subjectFileName != '') {
-                                    buffer += ', \'' + res[i].subjectFileName + '\', ' + '\'' + res[i].emailToFileName + '\', ' + '\'' + res[i].emailCcFileName + '\'';
-                                    filesMobile += ', \'' + res[i].subjectFileName + '\', ' + '\'' + res[i].emailToFileName + '\', ' + '\'' + res[i].emailCcFileName + '\'';
-                                } else {
-                                    buffer += ', undefined, undefined, undefined';
-                                    filesMobile += ', undefined, undefined, undefined';
                                 }
 
-                                buffer += ');"><div class="template_files"><a href="#">' + res[i].displayName + '</a> ' + custom + ' </div></li>';
-                                filesMobile += ');"><div class="template_files"><a href="#">' + res[i].displayName + '</a> ' + custom + '</div></option>';
+                                // Construct the option element with data- attributes for filesMobile
+                                filesMobile += '<option data-template-data=\'' + JSON.stringify({
+                                    displayName: res[i].displayName,
+                                    fileName: res[i].fileName,
+                                    subjectFileName: res[i].subjectFileName || '',
+                                    emailToFileName: res[i].emailToFileName || '',
+                                    emailCcFileName: res[i].emailCcFileName || '',
+                                }) + '\'>' + res[i].displayName + custom + '</option>';
 
+                                // Construct the li element for buffer
+                                buffer += '<li>' + '<div class="template_files"><a href="#" data-template-index="' + i + '">' + res[i].displayName + '</a> ' + custom + ' </div>' + '</li>';
                             }
+
+                            filesMobile += '</select></div>';
+                            buffer += '</ul>';
                         } else if (res_array.status['code'] === 4) {
                             buffer += '<li>' + res_array.status['message'] + '</li>';
                             filesMobile += '<select><option>' + res_array.status['message'] + '</option></select>';
                         } else {
-                            buffer += '<li>Internal error occured, if this persists contact your Primary Admin.</li>';
+                            buffer += '<li>Internal error occurred. If this persists, contact your Primary Admin.</li>';
+                            filesMobile += '<div>Internal error occurred. If this persists, contact your Primary Admin.</div>';
                         }
 
-                        buffer += '</ul>';
-                        filesMobile += '</select>';
                         $('#fileList').html(buffer);
                         $('.filesMobile').html(filesMobile);
+
+                        // Attach onchange event handler to templateFiles select element
+                        $('.template_select_container').on('change', 'select.templateFiles', function () {
+                            let selectedOption = $(this).find(':selected');
+                            let templateData = selectedOption.data('template-data');
+
+                            if (templateData) {
+                                // Call the loadContent function with the required parameters
+                                loadContent(templateData.displayName, templateData.fileName, templateData.subjectFileName, templateData.emailToFileName, templateData.emailCcFileName);
+                            }
+                        });
+
+                        // Attach click event handler to template links in the buffer
+                        $('.template_files a').on('click', function (e) {
+                            e.preventDefault();
+                            let templateIndex = $(this).data('template-index');
+                            let template = res[templateIndex];
+
+                            // Call the loadContent function with the required parameters
+                            loadContent(template.displayName, template.fileName, template.subjectFileName || '', template.emailToFileName || '', template.emailCcFileName || '');
+                        });
                     },
-                    error: function(error) {
+                    error: function (error) {
                         console.log(error);
                     }
                 });
             },
             cache: false
         });
+
+
+
+
+
         // Load content from those templates to the current main template
         initializePage();
         // Refresh CodeMirror

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -111,6 +111,7 @@
                 <button id="open_file_button"
                     class="usa-button usa-button--accent-cool leaf-btn-med leaf-display-block leaf-marginTop-1rem leaf-width-14rem"" onclick="
                     runReport();">Open File</button>
+                <button class="new-report mobile_new_report_btn" onclick="newReport();">New File</button>
                 <button id="deleteButton"
                     class="usa-button usa-button--secondary leaf-btn-med leaf-display-block leaf-marginTop-1rem leaf-width-14rem"" onclick="
                     deleteReport();">Delete File
@@ -799,30 +800,79 @@
     }
     // example report templates
     function updateFileList() {
+        // $.ajax({
+        //     type: 'GET',
+        //     url: '../api/applet',
+        //     success: function(res) {
+        //         let buffer = '<ul class="leaf-ul">';
+        //         let bufferExamples = '<div class="leaf-bold">Examples</div><ul class="leaf-ul">';
+        //         let filesMobile = '<h3>Template Files:</h3><div class="template_select_container"><select class="templateFiles">';
+        //         for (let i in res) {
+        //             let file = res[i].replace('.tpl', '');
+        //             if (!isExcludedFile(file)) {
+        //                 buffer += '<li onclick="loadContent(\'' + file + '\');"><a href="#">' + file + '</a></li>';
+        //                 filesMobile += '<option value="' + file + '"><div class="template_files">' + file + '</div></option>';
+        //             } else {
+        //                 bufferExamples += '<li onclick="loadContent(\'' + file + '\');" ><a href="#">' + file + '</a></li>';
+        //             }
+        //         }
+        //         buffer += '</ul>';
+        //         bufferExamples += '</ul>';
+        //         filesMobile += '</select><div>';
+        //         $('#fileList').html(buffer + bufferExamples);
+        //         $('.filesMobile').html(filesMobile);
+        //         $('.template_select_container').on('change', 'select.templateFiles',
+        //             function() {
+        //                 let selectedFile = $(this).val();
+        //                 loadContent(selectedFile);
+        //             }
+        //         );
+        //     },
+        //     cache: false
+        // });
+
         $.ajax({
             type: 'GET',
             url: '../api/applet',
-            success: function(res) {
+            success: function (res) {
                 let buffer = '<ul class="leaf-ul">';
                 let bufferExamples = '<div class="leaf-bold">Examples</div><ul class="leaf-ul">';
-                let filesMobile = '<h3>Template Files:</h3><select class="templateFiles">';
+                let filesMobile = '<h3>Template Files:</h3><div class="template_select_container"><select class="templateFiles">';
+                
                 for (let i in res) {
                     let file = res[i].replace('.tpl', '');
+                    
                     if (!isExcludedFile(file)) {
-                        buffer += '<li onclick="loadContent(\'' + file + '\');"><a href="#">' + file + '</a></li>';
-                        filesMobile += '<option onclick="loadContent(\'' + file + '\');"><div class="template_files">' + file + '</div></option>';
+                        buffer += '<li><a href="#" data-file="' + file + '">' + file + '</a></li>';
+                        filesMobile += '<option value="' + file + '"><div class="template_files">' + file + '</div></option>';
                     } else {
-                        bufferExamples += '<li onclick="loadContent(\'' + file + '\');" ><a href="#">' + file + '</a></li>';
+                        bufferExamples += '<li><a href="#" data-file="' + file + '">' + file + '</a></li>';
                     }
                 }
+                
                 buffer += '</ul>';
                 bufferExamples += '</ul>';
-                filesMobile += '</select>';
+                filesMobile += '</select></div>';
+                
                 $('#fileList').html(buffer + bufferExamples);
                 $('.filesMobile').html(filesMobile);
+                
+                // Attach click event handler to template links in the buffer
+                $('#fileList a').on('click', function (e) {
+                    e.preventDefault();
+                    let selectedFile = $(this).data('file');
+                    loadContent(selectedFile);
+                });
+                
+                // Attach onchange event handler to templateFiles select element
+                $('.template_select_container').on('change', 'select.templateFiles', function () {
+                    let selectedFile = $(this).val();
+                    loadContent(selectedFile);
+                });
             },
             cache: false
         });
+
     }
     // Displays  user's history when creating, merge, and so on
     function viewHistory() {


### PR DESCRIPTION
Previously, users encountered difficulties when attempting to select templates from the responsive view in the template editor. Specifically, when the page width was 1024px, the dropdown menu for selecting templates was not displaying the correct data in Edge and Chrome browsers. Fortunately, this issue has been successfully resolved, and now users can select templates without any problems on all major browsers, including Firefox.