### PR TITLE
Leaf 4027 - Inbox v2 UX update

### DIFF
--- a/LEAF_Request_Portal/templates/email/LEAF_notify_next_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_notify_next_body.tpl
@@ -1,6 +1,6 @@
 The following request requires your review.<br />
 <br />
-Please review your inbox at: {{$siteRoot}}?a=inbox<br />
+Please review your inbox at: {{$siteRoot}}report.php?a=LEAF_Inbox<br />
 <br />
 Request ID#: {{$recordID}}<br />
 Request title: {{$fullTitle}}<br />

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -729,7 +729,29 @@
                     };
                 }).filter((site) => site.url.includes(window.location.hostname));
 
-                sites.push(...formattedSiteMap);
+                // Parse base URLs, order matters
+                formattedSiteMap.map(site => {
+                    if(site.url.indexOf('/admin/') != -1) {
+                        site.url = site.url.substring(0, site.url.indexOf('/admin/') + 1);
+                    }
+                    else if(site.url.indexOf('/?') != -1) {
+                        site.url = site.url.substring(0, site.url.indexOf('/?') + 1);
+                    }
+                    else if(site.url.indexOf('/index.php?') != -1) {
+                        site.url = site.url.substring(0, site.url.indexOf('/index.php?') + 1);
+                    }
+                    else if(site.url.indexOf('/report.php?') != -1) {
+                        site.url = site.url.substring(0, site.url.indexOf('/report.php?') + 1);
+                    }
+                });
+
+                // Remove duplicate URLs
+                let uniqueSites = {};
+                formattedSiteMap.forEach(site => {
+                    uniqueSites[site.url] = site;
+                });
+
+                sites.push(...Object.values(uniqueSites));
                 resolve();
             },
             fail: function(err) {

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -802,7 +802,7 @@
             let queue = new intervalQueue();
             queue.setWorker(site => {
                 $('#progressbar').progressbar('option', 'value', queue.getLoaded());
-                $('#progressDetail').html(`Retrieving <span id="progressCount"></span>records from ${site.name}...`);
+                $('#progressDetail').html(`Searching <span id="progressCount"></span>records from ${site.name}...`);
                 return loadInboxData(site).then(() => {
                     if(Object.keys(dataInboxes[site.url]).length > 0) {
                         return buildWorkflowCategoryCache(site);


### PR DESCRIPTION
This improves Inbox UX when sitemaps are configured with LEAF URLs that link to specific pages, instead of a typical homepage. 

Other minor changes:
- Wording change that clarifies a status message
- Email template change that updates the URL to the new Inbox

The sitemap URL list is parsed to obtain base URLs and removes duplicates.

### Potential Impact
- No other dependencies

### Testing
Multiple URLs:
1. Configure a sitemap with multiple identical LEAF URLs
2. When viewing the Inbox, there should be fewer duplicates compared to the previous version

Specific pages:
1. Configure a sitemap that contains links to the Admin area or reports
2. When viewing the Inbox, there should not be a warning on the top of the screen: "Not all records have been loaded"