### PR TITLE
Leaf 4002.2 - making backward compatible

### DIFF
--- a/libs/php-commons/Setting.php
+++ b/libs/php-commons/Setting.php
@@ -5,8 +5,6 @@
 
 namespace Leaf;
 
-use App\Leaf\Db;
-
 class setting
 {
     protected $settings;


### PR DESCRIPTION
This reverted a change that should not have been made. I double checked all the other classes to make sure something similar did not happen to them as well.