### PR TITLE
LEAF - 4035 - New Account Updater Search Bug

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1114,7 +1114,7 @@ class Employee extends Data
                         AND deleted = 0
                         {$this->limit}";
 
-        $vars = array(':phone' => $this->parseWildcard('*' . $phone));
+        $vars = array(':phone' => $this->parseWildcard('*' . $phone)); 
 
         return $this->db->prepared_query($sql, $vars);
     }
@@ -1339,7 +1339,7 @@ class Employee extends Data
                 $searchResult = $this->lookupEmail($input);
 
                 break;
-            // Format: Loginname && will search all active and disabled accounts
+            // Format: Loginname && Will search all active and disabled accounts
             case substr(strtolower($input), 0, 3) === 'vha':
             case substr(strtolower($input), 0, 4) === 'vaco':
             case substr(strtolower($input), 0, 3) === 'vba':
@@ -1352,8 +1352,33 @@ class Employee extends Data
                     $this->log[] = 'Format Detected: Loginname';
                 }
                 $input = str_replace('username:', '', strtolower($input));
-                $searchResult = $this->lookupLogin($input, true);
+                $searchResult = $this->lookupLogin($input);
 
+                break;
+            //explicit search for disabled accounts
+            case substr(strtolower($input), 0, 18) === 'username_disabled:':
+                if ($this->debug)
+                {
+                    $this->log[] = 'Format Detected: Loginname';
+                }
+                $input = str_replace('username_disabled:', '', strtolower($input));
+                $searchResult = $this->lookupLogin($input, true);
+                break;
+            case substr(strtolower($input), 0, 9) === 'disabled:':
+                if ($this->debug)
+                {
+                    $this->log[] = 'Format Detected: Loginname';
+                }
+                $input = str_replace('disabled:', '', strtolower($input));
+                $searchResult = $this->lookupLogin($input, true);
+                break;
+            case substr(strtolower($input), 0, 14) === 'disabled.user:':
+                if ($this->debug)
+                {
+                    $this->log[] = 'Format Detected: Loginname';
+                }
+                $input = str_replace('disabled.user:', '', strtolower($input));
+                $searchResult = $this->lookupLogin($input, true);
                 break;
             // Format: ID number
             case (substr($input, 0, 1) == '#') && is_numeric(substr($input, 1)):

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1355,7 +1355,7 @@ class Employee extends Data
                 }
 
                 break;
-            // Format: Loginname && Will search all active and disabled accounts
+            // Format: Loginname
             case substr(strtolower($input), 0, 3) === 'vha':
             case substr(strtolower($input), 0, 4) === 'vaco':
             case substr(strtolower($input), 0, 3) === 'vba':

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -887,7 +887,7 @@ class Employee extends Data
      * @param string $login
      * @param bool $searchDeleted
      */
-    public function lookupLogin($login, bool $searchDeleted = true): array
+    public function lookupLogin($login, bool $searchDeleted = false): array
     {
         $cacheHash = "lookupLogin{$login}";
         if (isset($this->cache[$cacheHash]))
@@ -1339,7 +1339,7 @@ class Employee extends Data
                 $searchResult = $this->lookupEmail($input);
 
                 break;
-            // Format: Loginname
+            // Format: Loginname && will search all active and disabled accounts
             case substr(strtolower($input), 0, 3) === 'vha':
             case substr(strtolower($input), 0, 4) === 'vaco':
             case substr(strtolower($input), 0, 3) === 'vba':
@@ -1352,17 +1352,8 @@ class Employee extends Data
                     $this->log[] = 'Format Detected: Loginname';
                 }
                 $input = str_replace('username:', '', strtolower($input));
-                $searchResult = $this->lookupLogin($input);
-
-                break;
-            //explicit search for disabled accounts
-            case substr(strtolower($input), 0, 18) === 'username_disabled:':
-                if ($this->debug)
-                {
-                    $this->log[] = 'Format Detected: Loginname';
-                }
-                $input = str_replace('username_disabled:', '', strtolower($input));
                 $searchResult = $this->lookupLogin($input, true);
+
                 break;
             // Format: ID number
             case (substr($input, 0, 1) == '#') && is_numeric(substr($input, 1)):

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -887,7 +887,7 @@ class Employee extends Data
      * @param string $login
      * @param bool $searchDeleted
      */
-    public function lookupLogin($login, bool $searchDeleted = false): array
+    public function lookupLogin($login, bool $searchDeleted = true): array
     {
         $cacheHash = "lookupLogin{$login}";
         if (isset($this->cache[$cacheHash]))
@@ -896,7 +896,7 @@ class Employee extends Data
         }
 
         $sqlVars = array(':login' => $login);
-        $accountStatus = $searchDeleted ? "" : " AND deleted = 0";
+        $accountStatus = $searchDeleted ? '' : ' AND deleted = 0';
         $strSQL = "SELECT empUID, userName, lastName, firstName, middleName,
             phoneticFirstName, phoneticLastName, domain, deleted, lastUpdated, new_empUUID
             FROM {$this->tableName} WHERE userName = :login".$accountStatus;
@@ -1098,7 +1098,6 @@ class Employee extends Data
                 LEFT JOIN {$this->tableName} USING (empUID)
                 WHERE indicatorID = 6
                     AND data = :email
-                    AND deleted = 0
                 {$this->limit}";
 
         $vars = array(':email' => $email);
@@ -1346,6 +1345,7 @@ class Employee extends Data
             case substr(strtolower($input), 0, 3) === 'vba':
             case substr(strtolower($input), 0, 3) === 'cem':
             case substr(strtolower($input), 0, 3) === 'oit':
+            case substr(strtolower($input), 0, 3) === 'vtr':
             case substr(strtolower($input), 0, 9) === 'username:':
                 if ($this->debug)
                 {

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -959,6 +959,7 @@ class Employee extends Data
         $sql = "SELECT *
                 FROM {$this->tableName}
                 WHERE lastName LIKE :lastName
+                AND deleted = 0
                 ORDER BY {$this->sortBy} {$this->sortDir}
                 {$this->limit}";
 
@@ -969,6 +970,7 @@ class Employee extends Data
             $sql = "SELECT *
                     FROM {$this->tableName}
                     WHERE phoneticLastName LIKE :lastName
+                    AND deleted = 0
                     ORDER BY {$this->sortBy} {$this->sortDir}
                     {$this->limit}";
 


### PR DESCRIPTION
This issue was brought up by a user saying that he wasn't able to pull disabled users by email or alias. The issue has been resolved and the way to test this by:

1. Going to the admin panel and click on New Account Updater
2. Search for the user that is disabled using the email or alias.

This can also be tested in the Nexus org chart, by searching for email or alias.