### PR TITLE
Leaf 4037 - Resolve data type issues

### DIFF
--- a/LEAF_Nexus/sources/Position.php
+++ b/LEAF_Nexus/sources/Position.php
@@ -290,7 +290,7 @@ class Position extends Data
         $res = $this->db->prepared_query('SELECT * FROM positions
                                             WHERE positionID=:positionID', $vars);
 
-        if (count($res[0]) > 0)
+        if (isset($res[0]))
         {
             $data['employeeList'] = $this->getEmployees($positionID);
 

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -664,7 +664,7 @@ class FormWorkflow
      * @param string $comment
      * @return array {status(int), errors[string]}
      */
-    public function handleAction(int $dependencyID, string $actionType, string $comment = ''): array
+    public function handleAction(int $dependencyID, string $actionType, ?string $comment = ''): array
     {
         if (!is_numeric($dependencyID))
         {

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -661,7 +661,7 @@ class FormWorkflow
      * Handle an action
      * @param int $dependencyID
      * @param string $actionType
-     * @param string $comment
+     * @param string (optional) $comment
      * @return array {status(int), errors[string]}
      */
     public function handleAction(int $dependencyID, string $actionType, ?string $comment = ''): array
@@ -1118,7 +1118,7 @@ class FormWorkflow
      * @param int $workflowID
      * @param int $stepID
      * @param string $actionType
-     * @param string $comment
+     * @param string (optional) $comment
      * @return array {status(int), errors[]}
      * @throws Exception
      */

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1122,7 +1122,7 @@ class FormWorkflow
      * @return array {status(int), errors[]}
      * @throws Exception
      */
-    public function handleEvents(int $workflowID, int $stepID, string $actionType, string $comment): array
+    public function handleEvents(int $workflowID, int $stepID, string $actionType, ?string $comment = ''): array
     {
         $errors = array();
 


### PR DESCRIPTION
This resolves a couple data type issues that result in fatal errors.

1. Uncaught TypeError: count(): Argument #***** ($value) must be of type Countable|array in orgchart/sources/Position.php:293
2. Uncaught TypeError: Portal\FormWorkflow::handleAction(): Argument #***** ($comment) must be of type string, null given in sources/FormWorkflow.php:667
    - The comment is supposed to be optional, based on the original handleAction() definition.

### Potential Impacts
1. No known negative impacts

### Testing
- [URL_TO_NEXUS]?a=view_position&positionID=1 should have the same output as before
- Automated API test case: it should be possible to execute an action with no comment provided to the server (./portal/api/formWorkflow/[digit]/apply)
