### PR TITLE
Leaf 4039 - Optimize "person designated" queries

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -928,16 +928,14 @@ class Employee extends Data
             return $this->cache["lookupEmpUID_{$empUID}"];
         }
 
-        $strSQL = "SELECT * FROM {$this->tableName} WHERE empUID = :empUID AND deleted = 0";
+        $strSQL = "SELECT empUID, userName, lastName, firstName, middleName, domain, 
+                        deleted, lastUpdated, new_empUUID, data as email FROM {$this->tableName}
+                    LEFT JOIN employee_data USING (empUID)
+                    WHERE empUID = :empUID
+                        AND deleted = 0
+                        AND indicatorID = 6";
         $sqlVars = array(':empUID' => $empUID);
         $result = $this->db->prepared_query($strSQL, $sqlVars);
-
-        $strSQL = "SELECT data AS email FROM {$this->dataTable} WHERE empUID=:empUID AND indicatorID = 6";
-        $resEmail = $this->db->prepared_query($strSQL, $sqlVars);
-
-        if(isset($result[0]) && isset($resEmail[0])) {
-            $result[0] = array_merge($result[0], $resEmail[0]);
-        }
 
         $this->cache["lookupEmpUID_{$empUID}"] = $result;
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3560,9 +3560,9 @@ class Form
         // check actionable
         if ($filterActionable)
         {
-            $FormWorkflow = $this->getFormWorkflow();
+            $formWorkflow = $this->getFormWorkflow();
 
-            $actionable = $FormWorkflow->getActionable($this, $data);
+            $actionable = $formWorkflow->getActionable($this, $data);
 
             $actionLookup = [];
             foreach($actionable as $t) {

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -141,7 +141,7 @@ class FormWorkflow
      * includePersonDesignatedApproverData efficiently merges approver data to $srcRecords, for a
      * given list of $pdRecordList and $pdIndicators.
      * 
-     * WARNING: This function should only be used to support getRecordsDependencyData().
+     * WARNING: This function should only be used to support getRecordsDependencyData() and getActionable().
      *          Usage in other areas must be carefully reviewed as this retrieves data without
      *          checking for valid access. The $pdIndicators variable must only contain indicator IDs
      *          that are related to a "person designated" field AND workflow that utilizes the "person 

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -150,6 +150,7 @@ class FormWorkflow
      * @param array $pdRecords list of record IDs that utilize "person designated"
      * @param array $pdIndicator list of indicator IDs mapped to "person designated" fields
      * @param bool $skipNames set true to exclude employee lookups
+     * @return array Amended records
      */
     private function includePersonDesignatedData(array $srcRecords, array $pdRecords, array $pdIndicators, bool $skipNames = false): array
     {

--- a/LEAF_Request_Portal/sources/VAMC_Directory.php
+++ b/LEAF_Request_Portal/sources/VAMC_Directory.php
@@ -101,10 +101,7 @@ class VAMC_Directory
             $tdata = $result;
             $tdata['Lname'] = $result['lastName'];
             $tdata['Fname'] = $result['firstName'];
-
-            // orgchart data
-            $ocData = $this->Employee->getAllData($result['empUID']);
-            $tdata['Email'] = $ocData[6]['data'];
+            $tdata['Email'] = $result['email'];
             $data[] = $tdata;
         }
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -266,7 +266,7 @@
                 let uDD = dataInboxes[sites[i].url][j].unfilledDependencyData[depID];
                 let roleID = depID;
                 let description = uDD.description;
-                if(roleID < 0) { // handle "smart requirements"
+                if(roleID < 0 && uDD.approverUID != undefined) { // handle "smart requirements"
                     roleID = Sha1.hash(uDD.approverUID);
                     description = uDD.approverName;
                 }
@@ -375,13 +375,16 @@
 			<span style="font-size: 130%; font-weight: bold">${categoryName}</span></div>
 			<div id="depList${hash}_${depID}" style="width: 90%; margin: auto; display: none"></div></div>`);
         $('#depLabel' + hash + '_' + depID).on('click', function() {
+            buildInboxGridView(res, depID, categoryName, recordIDs, site, hash, categoryIDs);
             if ($('#depList' + hash + '_' + depID).css('display') == 'none') {
                 $('#depList' + hash + '_' + depID).css('display', 'inline');
             } else {
                 $('#depList' + hash + '_' + depID).css('display', 'none');
             }
         });
+    }
 
+    function buildInboxGridView(res, stepID, stepName, recordIDs, site, hash, categoryIDs = undefined) {
         let customColumns = false;
         if (categoryIDs != undefined) {
             categoryIDs.forEach(categoryID => {
@@ -407,116 +410,11 @@
                 }
             });
         }
+
         let customCols = [];
         if (customColumns == false) {
             site.columns = site.columns ?? 'UID,service,title,status';
         }
-        site.columns.split(',').forEach(col => {
-            if (isNaN(col)) {
-                customCols.push(headerDefinitions[col](site));
-            } else {
-                customCols.push({
-                    name: (dataDictionary[site.url]?.[col]?.name ?? dataDictionary[site.url]?.[col]?.description), indicatorID: parseInt(col), editable: false
-                });
-            }
-        });
-
-        let headers = [{
-            name: 'Action',
-            indicatorID: 'action',
-            editable: false,
-            sortable: false,
-            callback: function(data, blob) {
-                let depDescription = 'Take Action';
-                $('#' + data.cellContainerID).css('text-align', 'center');
-                $('#' + data.cellContainerID).html('<button id="btn_action' + hash + '_' + depID + '_' +
-                                                   data.recordID +
-                                                   '" class="buttonNorm" style="text-align: center; font-weight: bold; white-space: normal">' +
-                                                   depDescription + '</button>');
-                $('#btn_action' + hash + '_' + depID + '_' + data.recordID).on('click', function() {
-                    loadWorkflow(data.recordID, formGrid.getPrefixID(), site.url);
-                    waitForElm('iframe').then((el) => {
-                        if (!sites.some(site => el.getAttribute('src').includes(site.url))) {
-                            el.setAttribute('src', site.url + el.getAttribute('src'));
-                            el.addEventListener('load', () => {
-                                if (!sites.some(site => el.contentWindow?.document?.querySelector('#record').getAttribute('action').includes(site.url))) {
-                                    el.contentWindow?.document?.querySelector('#record').setAttribute('action', site.url + el.contentWindow?.document?.querySelector('#record').getAttribute('action'));
-                                }
-                            });
-                        }
-                    });
-                })
-            }
-        }];
-        headers = customCols.concat(headers);
-
-        let formGrid = new LeafFormGrid('depList' + hash + '_' + depID);
-        formGrid.setRootURL(site.url);
-        formGrid.disableVirtualHeader(); // TODO: figure out why headers aren't sized correctly
-        formGrid.setDataBlob(res);
-        formGrid.hideIndex();
-        formGrid.setHeaders(headers);
-        let tGridData = [];
-        let hasServices = false;
-        recordIDs.forEach(recordID => {
-            if (res[recordID].service != null) {
-                hasServices = true;
-            }
-            tGridData.push(res[recordID]);
-        });
-        // remove service column if there's no services
-        if (hasServices == false) {
-            let tHeaders = formGrid.headers();
-            for (let i = 0; i < tHeaders.length; i++) {
-                if (tHeaders[i].indicatorID == 'service') {
-                    tHeaders.splice(i, 1);
-                }
-            }
-            formGrid.setHeaders(tHeaders);
-        }
-        formGrid.setData(tGridData);
-        formGrid.sort('recordID', 'asc');
-        formGrid.renderBody();
-        //formGrid.loadData(tGridData.map(v => v.recordID).join(','));
-        $('#' + formGrid.getPrefixID() + 'table').css('width', '99%');
-        $('#' + formGrid.getPrefixID() + 'header_title').css('width', '60%');
-        $('#depContainerIndicator_' + depID).css('display', 'none');
-    }
-
-    // Build forms and grids for the inbox's requests based on the list of $recordIDs, organized by step
-    function buildDepInboxByStep(res, stepID, stepName, recordIDs, site) {
-        let hash = Sha1.hash(site.url);
-		let categoryName = '';
-        if(Object.keys(recordIDs).length > 0) {
-            categoryName = `${res[recordIDs[0]].categoryName} - ${res[recordIDs[0]].stepTitle}`;
-        }
-
-        let icon = getIcon(site.icon, site.name);
-        if (document.getElementById('siteContainer' + hash) == null) {
-            $('#indexSites').append('<li style="font-size: 130%; line-height: 150%"><a href="#' + hash + '">' + site.name + '</a></li>');
-            $('#inbox').append(`<a name="${hash}"></a>
-				<div id="siteContainer${hash}" style="box-shadow: 0 2px 3px #a7a9aa; border: 1px solid black; 
-				background-color: ${site.backgroundColor}; margin: 0px auto 1.5rem">
-				<div style="font-weight: bold; font-size: 200%; line-height: 240%; background-color: ${site.backgroundColor}; color: ${site.fontColor}; ">${icon} ${site.name} </div>
-				<div id="siteFormContainer${hash}" class="siteFormContainers"></div>
-    			</div>`);
-        }
-        $(`#siteFormContainer${hash}`).append(`<div id="depContainer${hash}_${stepID}" class="depContainer">
-            <div id="depLabel${hash}_${stepID}" class="depInbox" style="padding: 8px; background-color: ${site.backgroundColor}">
-			<span style="float: right; text-decoration: underline; font-weight: bold">View ${recordIDs.length} requests</span>
-			<span style="font-size: 130%; font-weight: bold">${stepName}</span><br />
-            <span>${categoryName}</span></div>
-			<div id="depList${hash}_${stepID}" style="width: 90%; margin: auto; display: none"></div></div>`);
-        $('#depLabel' + hash + '_' + stepID).on('click', function() {
-            if ($('#depList' + hash + '_' + stepID).css('display') == 'none') {
-                $('#depList' + hash + '_' + stepID).css('display', 'inline');
-            } else {
-                $('#depList' + hash + '_' + stepID).css('display', 'none');
-            }
-        });
-
-        let customCols = [];
-        site.columns = site.columns ?? 'UID,service,title,status';
         site.columns.split(',').forEach(col => {
             if (isNaN(col)) {
                 customCols.push(headerDefinitions[col](site));
@@ -587,6 +485,40 @@
         $('#' + formGrid.getPrefixID() + 'table').css('width', '99%');
         $('#' + formGrid.getPrefixID() + 'header_title').css('width', '60%');
         $('#depContainerIndicator_' + stepID).css('display', 'none');
+    }
+
+    // Build forms and grids for the inbox's requests based on the list of $recordIDs, organized by step
+    function buildDepInboxByStep(res, stepID, stepName, recordIDs, site) {
+        let hash = Sha1.hash(site.url);
+		let categoryName = '';
+        if(Object.keys(recordIDs).length > 0) {
+            categoryName = `${res[recordIDs[0]].categoryName} - ${res[recordIDs[0]].stepTitle}`;
+        }
+
+        let icon = getIcon(site.icon, site.name);
+        if (document.getElementById('siteContainer' + hash) == null) {
+            $('#indexSites').append('<li style="font-size: 130%; line-height: 150%"><a href="#' + hash + '">' + site.name + '</a></li>');
+            $('#inbox').append(`<a name="${hash}"></a>
+				<div id="siteContainer${hash}" style="box-shadow: 0 2px 3px #a7a9aa; border: 1px solid black; 
+				background-color: ${site.backgroundColor}; margin: 0px auto 1.5rem">
+				<div style="font-weight: bold; font-size: 200%; line-height: 240%; background-color: ${site.backgroundColor}; color: ${site.fontColor}; ">${icon} ${site.name} </div>
+				<div id="siteFormContainer${hash}" class="siteFormContainers"></div>
+    			</div>`);
+        }
+        $(`#siteFormContainer${hash}`).append(`<div id="depContainer${hash}_${stepID}" class="depContainer">
+            <div id="depLabel${hash}_${stepID}" class="depInbox" style="padding: 8px; background-color: ${site.backgroundColor}">
+			<span style="float: right; text-decoration: underline; font-weight: bold">View ${recordIDs.length} requests</span>
+			<span style="font-size: 130%; font-weight: bold">${stepName}</span><br />
+            <span>${categoryName}</span></div>
+			<div id="depList${hash}_${stepID}" style="width: 90%; margin: auto; display: none"></div></div>`);
+        $('#depLabel' + hash + '_' + stepID).on('click', function() {
+            buildInboxGridView(res, stepID, stepName, recordIDs, site, hash);
+            if ($('#depList' + hash + '_' + stepID).css('display') == 'none') {
+                $('#depList' + hash + '_' + stepID).css('display', 'inline');
+            } else {
+                $('#depList' + hash + '_' + stepID).css('display', 'none');
+            }
+        });
     }
 
     let dataInboxes = {};

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023999999-2023092100.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2023999999-2023092100.sql
@@ -1,0 +1,18 @@
+START TRANSACTION;
+
+ALTER TABLE `relation_employee_backup` ADD INDEX `backupEmpUID` (`backupEmpUID`);
+
+UPDATE `settings` SET `data` = '2023092100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `relation_employee_backup` DROP INDEX `backupEmpUID`;
+
+UPDATE `settings` SET `data` = '2023999999' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
This optimizes form/query performance when there are many "person designated" records, primarily by reducing DB roundtrips. Observed ~60% improvement when testing 500 "person designated" records.

### Summary
- When filtering for actionable records, or retrieving Inbox related data, "person designated" records are batched into a single query instead of running 500 queries
- employee->lookupEmpUID() - Consolidated 2 queries into 1
- VAMC_Directory->lookupEmpUID() - Removed redundant query
- checkEmployeeAccess() - Consolidated O(n) queries into 1. Instead of running a query for each user to determine if the current user is a backup, we run one query to see who the current user is a backup for. A new DB index has also been added to accommodate this.
- LEAF_Inbox.tpl has been updated to render LeafFormGrid components "just in time" to provide a smoother UX

### Opportunities for further improvement
- The employee email field should be denormalized and stored as a column in the employee table. This should be organized in separate efforts as many other components will need to be updated.
- A batched version of employee lookupEmpUID() would reduce DB roundtrips

### Potential Impacts
- Inbox v2
- Report Builder queries for Current Status IS Actionable
- [ ] Database version number must be updated before deployment

### Testing
- [ ] Results from the Inbox and Report Builder are identical as before
