### PR TITLE
Leaf 4042 - remove double unlink in mailer

### DIFF
--- a/LEAF_Request_Portal/mailer/mailer.php
+++ b/LEAF_Request_Portal/mailer/mailer.php
@@ -56,15 +56,13 @@ foreach ($queue as $item)
     if (strlen($item) == 40)
     {
         // attempt to resend email if its 5 minutes old
-        if (time() - filemtime($folder . $item) >= 300)
+        if (file_exists($folder . $item) && time() - filemtime($folder . $item) >= 300)
         {
             $email = unserialize(file_get_contents($folder . $item));
             if (strlen(trim($email['recipient'])) == 0)
             {
                 // delete invalid cache
-                if (file_exists($folder . $item)) {
-                    unlink($folder . $item);
-                }
+                unlink($folder . $item);
 
                 trigger_error('Mail no recipient: ' . $email['subject']);
             }
@@ -73,9 +71,7 @@ foreach ($queue as $item)
                 touch($folder . $item);    // reset timer
                 if (mail($email['recipient'], $email['subject'], $email['body'], $email['headers']))
                 {
-                    if (file_exists($folder . $item)) {
-                        unlink($folder . $item);
-                    }
+                    unlink($folder . $item);
                     trigger_error('Queued mail sent: ' . $email['subject']);
                     if ($webMode)
                     {

--- a/LEAF_Request_Portal/mailer/mailer.php
+++ b/LEAF_Request_Portal/mailer/mailer.php
@@ -62,7 +62,10 @@ foreach ($queue as $item)
             if (strlen(trim($email['recipient'])) == 0)
             {
                 // delete invalid cache
-                unlink($folder . $item);
+                if (file_exists($folder . $item)) {
+                    unlink($folder . $item);
+                }
+
                 trigger_error('Mail no recipient: ' . $email['subject']);
             }
             else
@@ -70,7 +73,9 @@ foreach ($queue as $item)
                 touch($folder . $item);    // reset timer
                 if (mail($email['recipient'], $email['subject'], $email['body'], $email['headers']))
                 {
-                    unlink($folder . $item);
+                    if (file_exists($folder . $item)) {
+                        unlink($folder . $item);
+                    }
                     trigger_error('Queued mail sent: ' . $email['subject']);
                     if ($webMode)
                     {


### PR DESCRIPTION
This just places an if statement around the last two unlinks checking to make sure the file exists before trying to unlink it.