### PR TITLE
Leaf 4043 - more info in dbupdate log

### DIFF
--- a/LEAF_Request_Portal/scripts/updateDatabase.php
+++ b/LEAF_Request_Portal/scripts/updateDatabase.php
@@ -55,7 +55,7 @@ function updateDB($thisVer, $updateList, $folder, $db)
     {
         echo 'Update found: ' . $updateList[$thisVer] . BR;
         $update = file_get_contents($folder . $updateList[$thisVer]);
-        echo 'Processing update... ';
+        echo 'Processing update for ' . PORTAL_PATH . ' ...';
         $db->prepared_query($update, array());
         echo ' ... Complete.' . BR;
         $res = $db->prepared_query('SELECT * FROM settings WHERE setting="dbversion"', array());


### PR DESCRIPTION
This just adds the Portal Path to the log file when doing a db update. This will help to know which db's got updated and which failed.