### PR TITLE
Leaf 4048 - file found

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_access_matrix.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_access_matrix.tpl
@@ -24,7 +24,7 @@ button.buttonNorm {
 
 <!--{include file="site_elements/generic_xhrDialog.tpl"}-->
 <!--{include file="site_elements/generic_confirm_xhrDialog.tpl"}-->
-<script src="{$app_js_path}/LEAF/intervalQueue.js"></script>
+<script src="<!--{$app_js_path}-->/LEAF/intervalQueue.js"></script>
 <script>
 var CSRFToken = '<!--{$CSRFToken}-->';
 

--- a/LEAF_Request_Portal/auth_domain/LEAF_coach_key.php
+++ b/LEAF_Request_Portal/auth_domain/LEAF_coach_key.php
@@ -4,7 +4,7 @@ require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 
 ini_set('display_errors', 1);
 
-$db_national = new Leaf\DB(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
+$db_national = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
 $login->setBaseDir('../');
 $login->loginUser();
 


### PR DESCRIPTION
Summary
In our last release a reference to a file was incorrect, causing a 404 not found error. The reference has been modified to the correct location.

Potential Impact
This shouldn't cause any other issues as it is contained within the access matrix

Testing
Be sure that the access matrix page loads and that there aren't any other errors on the page.