### PR TITLE
LEAF 4051 - Remove cache workaround, update form*.js files in /app/libs/js/LEAF

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -940,7 +940,6 @@ var LeafFormSearch = function (containerID) {
                             callback();
                         }
                     },
-                    cache: false,
                 });
                 break;
             case "data":

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -14,14 +14,15 @@ var LeafFormGrid = function (containerID, options) {
   var isDataLoaded = false;
   var defaultLimit = 50;
   var currLimit = 50;
-  var headerColor = "#d1dfff";
   var dataBlob = {}; // if data needs to be passed in
   var postProcessDataFunc = null;
   var preRenderFunc = null;
   var postRenderFunc = null;
+  let postSortRequestFunc = null;
   var rootURL = "";
   var isRenderingVirtualHeader = true;
   var isRenderingBody = false;
+  let renderHistory = {}; // index of rendered recordIDs
 
   $("#" + containerID).html(
     '<div id="' +
@@ -47,8 +48,6 @@ var LeafFormGrid = function (containerID, options) {
       'tfoot"></tfoot></table>'
   );
 
-  $("#" + prefixID + "thead").css({ "background-color": headerColor });
-
   if (options == undefined) {
     form = new LeafForm(prefixID + "form");
   }
@@ -59,6 +58,107 @@ var LeafFormGrid = function (containerID, options) {
    */
   function hideIndex() {
     showIndex = false;
+  }
+
+  /**
+   * @param values (required) object of cells and names to generate grid
+   * @param showScriptTags (default false) whether to display script tags
+   * @memberOf LeafFormGrid
+   * Returns copy of values with cells property html entities decoded
+   */
+  function decodeCellHTMLEntities(values, showScriptTags = false) {
+    let gridInfo = { ...values };
+    if (gridInfo?.cells) {
+      let cells = gridInfo.cells.slice();
+      cells.forEach((arrRowVals, ci) => {
+        arrRowVals = arrRowVals.map((v) => {
+          v = v.replaceAll("<", "&lt;"); //handle old data values
+          v = v.replaceAll(">", "&gt;");
+          let elDiv = document.createElement("div");
+          elDiv.innerHTML = v;
+          let text = elDiv.innerText;
+          if (showScriptTags !== true)
+            text = text.replaceAll(
+              /(<script[\s\S]*?>)|(<\/script[\s\S]*?>)/gi,
+              ""
+            );
+          return text;
+        });
+        cells[ci] = arrRowVals.slice();
+      });
+      gridInfo.cells = cells;
+    }
+    return gridInfo;
+  }
+
+  /**
+   * @param values (required) object of cells and names to generate grid
+   * @memberOf LeafFormGrid
+   */
+  function printTableReportBuilder(values, columnValues) {
+    // remove unused columns
+    values = decodeCellHTMLEntities(values);
+    if (columnValues !== null && columnValues !== undefined) {
+      values.format = values.format.filter(function (value) {
+        return columnValues.includes(value.id);
+      });
+    }
+
+    var gridBodyBuffer = "";
+    var gridHeadBuffer = "";
+    var rows = values.cells === undefined ? 0 : values.cells.length;
+    var columns = values.format.length;
+    var columnOrder = [];
+    var delim = '<span class="nodisplay">^;</span>'; // invisible delimiters to help Excel users
+    var delimLF = "\r\n";
+    var tDelim = "";
+
+    //finds and displays column names
+    for (let i = 0; i < columns; i++) {
+      tDelim = i === columns - 1 ? "" : delim;
+      gridHeadBuffer +=
+        '<td style="width: 100px;">' + values.format[i].name + tDelim + "</td>";
+      columnOrder.push(values.format[i].id);
+    }
+
+    //populates table
+    for (var i = 0; i < rows; i++) {
+      var gridRow = "<tr>";
+      var rowBuffer = [];
+
+      //makes array of cells
+      for (var j = 0; j < columns; j++) {
+        rowBuffer.push('<td style="width:100px"></td>');
+      }
+
+      //for all values with matching column id, replaces cell with value
+      for (var j = 0; j < values.columns.length; j++) {
+        tDelim = j == values.columns.length - 1 ? "" : delim;
+        if (columnOrder.indexOf(values.columns[j]) !== -1) {
+          var value =
+            values.cells[i] === undefined || values.cells[i][j] === undefined
+              ? ""
+              : values.cells[i][j];
+          rowBuffer.splice(
+            columnOrder.indexOf(values.columns[j]),
+            1,
+            '<td style="width:100px">' + value + tDelim + "</td>"
+          );
+        }
+      }
+
+      //combines cells into html and pushes row to body buffer
+      gridRow += rowBuffer.join("") + delimLF + "</tr>";
+      gridBodyBuffer += gridRow;
+    }
+    return (
+      '<table class="table" style="word-wrap:break-word; max-width: 100%; padding: 20px; text-align: center; table-layout: fixed;"><thead>' +
+      gridHeadBuffer +
+      delimLF +
+      "</thead><tbody>" +
+      gridBodyBuffer +
+      "</tbody></table>"
+    );
   }
 
   /**
@@ -82,16 +182,27 @@ var LeafFormGrid = function (containerID, options) {
             ? response[indicatorID].displayedValue
             : response[indicatorID].value;
         if (
-          response[indicatorID].format == "checkboxes" &&
+          (response[indicatorID].format == "checkboxes" ||
+            response[indicatorID].format == "multiselect") &&
           Array.isArray(data)
         ) {
           var tData = "";
-          for (var i in data) {
+          for (let i in data) {
             if (data[i] != "no") {
               tData += ", " + data[i];
             }
           }
           data = tData.substr(2);
+        }
+        if (response[indicatorID].format == "grid") {
+          data = printTableReportBuilder(data);
+        }
+        if (response[indicatorID].format == "date") {
+          data = new Date(data).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          });
         }
         $("#" + prefixID + recordID + "_" + indicatorID)
           .empty()
@@ -119,10 +230,11 @@ var LeafFormGrid = function (containerID, options) {
     var virtualHeader = '<tr id="' + prefixID + "tVirt_tr" + '">';
     if (showIndex) {
       temp +=
-        '<th id="' +
+        '<th tabindex="0" id="' +
         prefixID +
         'header_UID" style="text-align: center">UID</th>';
-      virtualHeader += '<th style="text-align: center">UID</th>';
+      virtualHeader +=
+        '<th id="Vheader_UID" style="text-align: center">UID</th>';
     }
     $("#" + prefixID + "thead").html(temp);
 
@@ -130,33 +242,14 @@ var LeafFormGrid = function (containerID, options) {
       $("#" + prefixID + "header_UID").css("cursor", "pointer");
       $("#" + prefixID + "header_UID").on("click", null, null, function (data) {
         if (headerToggle == 0) {
-          sort("recordID", "asc");
+          sort("recordID", "asc", postSortRequestFunc);
           headerToggle = 1;
         } else {
-          sort("recordID", "desc");
+          sort("recordID", "desc", postSortRequestFunc);
           headerToggle = 0;
         }
         renderBody(0, Infinity);
       });
-      // todo: move this into a stylesheet
-      $("#" + prefixID + "header_UID").on(
-        "mouseover",
-        null,
-        null,
-        function (data) {
-          $("#" + prefixID + "header_UID").css("background-color", "#79a2ff");
-        }
-      );
-      $("#" + prefixID + "header_UID").on(
-        "mouseout",
-        null,
-        null,
-        function (data) {
-          $("#" + prefixID + "header_UID").css({
-            "background-color": headerColor,
-          });
-        }
-      );
     }
 
     for (var i in headers) {
@@ -200,10 +293,10 @@ var LeafFormGrid = function (containerID, options) {
           headers[i].indicatorID,
           function (data) {
             if (headerToggle == 0) {
-              sort(data.data, "asc");
+              sort(data.data, "asc", postSortRequestFunc);
               headerToggle = 1;
             } else {
-              sort(data.data, "desc");
+              sort(data.data, "desc", postSortRequestFunc);
               headerToggle = 0;
             }
             renderBody(0, Infinity);
@@ -217,36 +310,14 @@ var LeafFormGrid = function (containerID, options) {
           function (data) {
             if (data.keyCode == 13) {
               if (headerToggle == 0) {
-                sort(data.data, "asc");
+                sort(data.data, "asc", postSortRequestFunc);
                 headerToggle = 1;
               } else {
-                sort(data.data, "desc");
+                sort(data.data, "desc", postSortRequestFunc);
                 headerToggle = 0;
               }
               renderBody(0, Infinity);
             }
-          }
-        );
-        // todo: move this into a stylesheet
-        $("#" + prefixID + "header_" + headers[i].indicatorID).on(
-          "mouseover",
-          null,
-          headers[i].indicatorID,
-          function (data) {
-            $("#" + prefixID + "header_" + data.data).css(
-              "background-color",
-              "#79a2ff"
-            );
-          }
-        );
-        $("#" + prefixID + "header_" + headers[i].indicatorID).on(
-          "mouseout",
-          null,
-          headers[i].indicatorID,
-          function (data) {
-            $("#" + prefixID + "header_" + data.data).css({
-              "background-color": headerColor,
-            });
           }
         );
       }
@@ -297,8 +368,9 @@ var LeafFormGrid = function (containerID, options) {
         }
       }
 
+      // render additional segment right before the user scrolls to it
       if (
-        scrollPos > tableHeight - pageHeight * 0.8 &&
+        scrollPos + pageHeight * 1.2 > tableHeight &&
         isDataLoaded &&
         isRenderingBody
       ) {
@@ -311,22 +383,46 @@ var LeafFormGrid = function (containerID, options) {
   }
 
   /**
+   * Sort the current dataset based on rendered data in table cells
+   * @param key key to sort on
+   * @param order Sort order: asc/desc
+   * @param callback (optional)
    * @memberOf LeafFormGrid
    */
-  function sort(key, order) {
+  function sort(key, order, callback) {
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
 
     $("." + prefixID + "sort").css("display", "none");
     if (order.toLowerCase() == "asc") {
-      $("#" + prefixID + "header_" + key + "_sort").html(" &#9650;");
+      $("#" + prefixID + "header_" + key).attr("aria-live", "assertive");
+      $("#" + prefixID + "header_" + key).attr(
+        "aria-label",
+        "Sorting by ascending " + key
+      );
+      $("#" + prefixID + "header_" + key + "_sort").html(
+        '<div style="position: absolute" aria-label="Sorting by ascending ' +
+          key +
+          '"></div>' +
+          " &#9650;"
+      );
       $("#" + prefixID + "header_" + key + "_sort").css(
         "vertical-align",
         "super"
       );
     } else {
-      $("#" + prefixID + "header_" + key + "_sort").html(" &#9660;");
+      $("#" + prefixID + "header_" + key).attr("aria-live", "assertive");
+      $("#" + prefixID + "header_" + key).attr(
+        "aria-label",
+        "Sorting by descending " + key
+      );
+      $("#" + prefixID + "header_" + key + "_sort").html(
+        '<div style="position: absolute" aria-label="Sorting by descending ' +
+          key +
+          '"></div>' +
+          " &#9660;"
+      );
       $("#" + prefixID + "header_" + key + "_sort").css(
         "vertical-align",
         "sub"
@@ -336,38 +432,34 @@ var LeafFormGrid = function (containerID, options) {
     var array = [];
     var isIndicatorID = $.isNumeric(key);
     var isDate = false;
+    var isNumeric = true;
     var idKey = "id" + key;
     var tDate;
-    for (var i in currentData) {
-      currentData[i].recordID = parseInt(currentData[i].recordID);
+    for (let i in currentData) {
       if (currentData[i][key] == undefined) {
         currentData[i][key] = $(
           "#" + prefixID + currentData[i].recordID + "_" + key
         ).html();
         currentData[i][key] =
           currentData[i][key] == undefined ? "" : currentData[i][key];
-
-        // IE workaround... it adds zero-width "left-to-right mark" spaces for some reason, and we need to take it out
-        currentData[i][key] = currentData[i][key].replace(
-          /[\u200B-\u200E]/g,
-          ""
-        );
       }
-
+      if (currentData[i].s1 == undefined) {
+        currentData[i].s1 = {};
+      }
+      if (
+        currentData[i].s1[idKey] == undefined ||
+        currentData[i].s1[idKey] == ""
+      ) {
+        if (currentData[i].sDate == undefined) {
+          currentData[i].sDate = {};
+        }
+        //Workaround for sorting manually created grid
+        currentData[i].s1[idKey] = !isNaN(currentData[i][key])
+          ? currentData[i][key]
+          : "";
+        currentData[i].sDate[key] = 0;
+      }
       if (isIndicatorID) {
-        if (currentData[i].s1 == undefined) {
-          currentData[i].s1 = {};
-        }
-        if (
-          currentData[i].s1[idKey] == undefined ||
-          currentData[i].s1[idKey] == ""
-        ) {
-          if (currentData[i].sDate == undefined) {
-            currentData[i].sDate = {};
-          }
-          currentData[i].s1[idKey] = "";
-          currentData[i].sDate[key] = 0;
-        }
         tDate = null;
         if (
           isNaN(currentData[i].s1[idKey]) &&
@@ -383,10 +475,6 @@ var LeafFormGrid = function (containerID, options) {
           }
           currentData[i].sDate[key] = 0;
           currentData[i].sDate[key] = !isNaN(tDate) ? tDate : 0;
-        }
-
-        if ($.isNumeric(currentData[i].s1[idKey])) {
-          currentData[i].s1[idKey] = parseFloat(currentData[i].s1[idKey]);
         }
       }
       // detect date fields for other non-indicatorID columns
@@ -412,6 +500,12 @@ var LeafFormGrid = function (containerID, options) {
         }
       }
 
+      if ($.isNumeric(currentData[i].s1[idKey]) & (isNumeric == true)) {
+        currentData[i].s1[idKey] = parseFloat(currentData[i].s1[idKey]);
+      } else {
+        isNumeric = false;
+      }
+
       array.push(currentData[i]);
     }
     if (isDate) {
@@ -424,7 +518,7 @@ var LeafFormGrid = function (containerID, options) {
         }
         return 0;
       });
-    } else if ($.isNumeric(key)) {
+    } else if ($.isNumeric(key) || isNumeric) {
       array.sort(function (a, b) {
         if (b.s1[idKey] > a.s1[idKey]) {
           return 1;
@@ -445,6 +539,10 @@ var LeafFormGrid = function (containerID, options) {
         return 0;
       });
     } else {
+      var collator = new Intl.Collator("en", {
+        numeric: true,
+        sensitivity: "base",
+      });
       array.sort(function (a, b) {
         if (a[key] == undefined) {
           a[key] = "";
@@ -452,19 +550,17 @@ var LeafFormGrid = function (containerID, options) {
         if (b[key] == undefined) {
           b[key] = "";
         }
-        if (b[key].toLowerCase() > a[key].toLowerCase()) {
-          return 1;
-        }
-        if (b[key].toLowerCase() < a[key].toLowerCase()) {
-          return -1;
-        }
-        return 0;
+        return collator.compare(b[key], a[key]);
       });
     }
     if (order == "asc") {
       array.reverse();
     }
     currentData = array;
+
+    if (callback != undefined && typeof callback === "function") {
+      callback(key, order);
+    }
   }
 
   /**
@@ -529,6 +625,7 @@ var LeafFormGrid = function (containerID, options) {
     if (startIdx == undefined || startIdx == 0) {
       startIdx = 0;
       $("#" + prefixID + "tbody").empty();
+      renderHistory = {};
       fullRender = true;
     }
 
@@ -544,12 +641,19 @@ var LeafFormGrid = function (containerID, options) {
       );
     }
     var counter = 0;
+    var validateHtml = document.createElement("div");
     for (var i = startIdx; i < currentData.length; i++) {
       if (counter >= limit) {
         currentRenderIndex = i;
         break;
       }
 
+      // Prevent duplicate DOM IDs from being generated
+      if (renderHistory[currentData[i].recordID] != undefined) {
+        continue;
+      }
+
+      renderHistory[currentData[i].recordID] = 1;
       buffer +=
         '<tr id="' + prefixID + "tbody_tr" + currentData[i].recordID + '">';
       if (showIndex) {
@@ -589,21 +693,85 @@ var LeafFormGrid = function (containerID, options) {
               currentData[i].s1["id" + headers[j].indicatorID] != undefined
                 ? currentData[i].s1["id" + headers[j].indicatorID]
                 : "";
-            buffer +=
-              '<td id="' +
-              prefixID +
-              currentData[i].recordID +
-              "_" +
-              headers[j].indicatorID +
-              '" data-editable="' +
-              editable +
-              '" data-record-id="' +
-              currentData[i].recordID +
-              '" data-indicator-id="' +
-              headers[j].indicatorID +
-              '">' +
-              data.data +
-              "</td>";
+            validateHtml.innerHTML = data.data;
+            data.data = validateHtml.innerHTML;
+            if (
+              currentData[i].s1["id" + headers[j].indicatorID + "_htmlPrint"] !=
+              undefined
+            ) {
+              var htmlPrint =
+                '<textarea id="data_' +
+                currentData[i].recordID +
+                "_" +
+                headers[j].indicatorID +
+                '_1" style="display: none">' +
+                data.data +
+                "</textarea>";
+              htmlPrint += currentData[i].s1[
+                "id" + headers[j].indicatorID + "_htmlPrint"
+              ]
+                .replace(
+                  /{{ iID }}/g,
+                  currentData[i].recordID + "_" + headers[j].indicatorID
+                )
+                .replace(/{{ recordID }}/g, currentData[i].recordID);
+              buffer +=
+                '<td id="' +
+                prefixID +
+                currentData[i].recordID +
+                "_" +
+                headers[j].indicatorID +
+                '" data-editable="' +
+                editable +
+                '" data-record-id="' +
+                currentData[i].recordID +
+                '" data-indicator-id="' +
+                headers[j].indicatorID +
+                '">' +
+                htmlPrint +
+                "</td>";
+            } else {
+              if (headers[j].cols !== undefined) {
+                if (
+                  currentData[i].s1[data.data] !== undefined &&
+                  data.data.search("gridInput") &&
+                  headers[j].cols.length > 0
+                ) {
+                  data.data = printTableReportBuilder(
+                    currentData[i].s1[data.data],
+                    headers[j].cols
+                  );
+                }
+              } else {
+                if (
+                  currentData[i].s1[data.data] !== undefined &&
+                  data.data.search("gridInput")
+                ) {
+                  data.data = printTableReportBuilder(
+                    currentData[i].s1[data.data],
+                    null
+                  );
+                }
+              }
+              buffer += `<td id="${prefixID + currentData[i].recordID}_${
+                headers[j].indicatorID
+              }"
+                                           data-editable="${editable}"
+                                           data-record-id="${
+                                             currentData[i].recordID
+                                           }"
+                                           data-indicator-id="${
+                                             headers[j].indicatorID
+                                           }"
+                                           data-format="${
+                                             currentData[i].s1[
+                                               "id" +
+                                                 headers[j].indicatorID +
+                                                 "_format"
+                                             ]
+                                           }">
+                                            ${data.data}</td>`;
+            }
           } else if (headers[j].callback != undefined) {
             buffer +=
               '<td id="' +
@@ -673,6 +841,7 @@ var LeafFormGrid = function (containerID, options) {
     $("#" + prefixID + "tbody td[data-clickable=true]").addClass(
       "table_editable"
     );
+    $("#" + prefixID + "tbody").unbind("click"); //prevents multiple firing on same report builder element, which causes subsequent problems with icheck
     $("#" + prefixID + "tbody").on(
       "click",
       "td[data-editable=true]",
@@ -687,19 +856,33 @@ var LeafFormGrid = function (containerID, options) {
         form.dialog().show();
       }
     );
-    for (var i in callbackBuffer) {
+    for (let i in callbackBuffer) {
       callbackBuffer[i]();
     }
 
     $("#" + prefixID + "table>tbody>tr>td").css({
       border: "1px solid black",
       padding: "8px",
-      "font-size": "12px",
     });
     if (postRenderFunc != null) {
       postRenderFunc();
     }
     renderVirtualHeader();
+  }
+
+  /**
+   * @memberOf LeafFormGrid
+   */
+  function announceResults() {
+    let term = $('[name="searchtxt"]').val();
+
+    if (currentData.length == 0) {
+      $(".status").text("No results found for term " + term);
+    } else {
+      $(".status").text(
+        "Search results found for term " + term + " listed below"
+      );
+    }
   }
 
   /**
@@ -767,7 +950,7 @@ var LeafFormGrid = function (containerID, options) {
 
   /**
    * Set the working data set
-   * @params array - Expects format: [{recordID, indicatorID}, ...]
+   * @params array - Expects format: [{recordID}, ...]
    * @memberOf LeafFormGrid
    */
   function setData(data) {
@@ -802,9 +985,11 @@ var LeafFormGrid = function (containerID, options) {
     containerID = prefixID + "gridToolbar";
     $("#" + containerID).css("display", "block");
     $("#" + containerID).html(
-      '<button type="button" id="' +
+      '<br/><button type="button" id="' +
         prefixID +
-        'getExcel" class="buttonNorm"><img src="dynicons/?img=x-office-spreadsheet.svg&w=32" alt="Icon of Spreadsheet" /> Export</button>'
+        'getExcel" class="buttonNorm"><img src="' +
+        rootURL +
+        'dynicons/?img=x-office-spreadsheet.svg&w=16" alt="Icon of Spreadsheet" /> Export</button>'
     );
 
     $("#" + prefixID + "getExcel").on("click", function () {
@@ -813,52 +998,88 @@ var LeafFormGrid = function (containerID, options) {
       }
       var output = [];
       var headers = [];
+      //removes triangle symbols so that ascii chars are not present in exported headers.
+      $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
+        $(val).html("");
+      });
       $("#" + prefixID + "thead>tr>th").each(function (idx, val) {
         headers.push($(val).text().trim());
       });
+      output.push(headers); //first row will be headers
 
-      var line = {};
+      var line = [];
       var i = 0;
       var thisSite = document.createElement("a");
       var numColumns = headers.length - 1;
-      $("#" + prefixID + "tbody>tr>td").each(function (idx, val) {
-        line[headers[i]] = $(val).text().trim();
-        if (i == 0 && headers[i] == "UID") {
-          line[headers[i]] =
-            '=HYPERLINK("' +
-            window.location.origin +
-            window.location.pathname +
-            "?a=printview&recordID=" +
-            $(val).text().trim() +
-            '", "' +
-            $(val).text().trim() +
-            '")';
-        }
-        i++;
-        if (i > numColumns) {
-          output.push(line);
-          line = {};
-          i = 0;
-        }
+      document
+        .querySelectorAll("#" + prefixID + "tbody>tr>td")
+        .forEach(function (val) {
+          var foundScripts = val.querySelectorAll("script");
+
+          for (var tIdx = 0; tIdx < foundScripts.length; tIdx++) {
+            foundScripts[tIdx].parentNode.removeChild(foundScripts[tIdx]);
+          }
+
+          var trimmedText = val.innerText.trim();
+          line[i] = trimmedText;
+          //prevent some values from being interpretted as dates by excel
+          const dataFormat = val.getAttribute("data-format");
+          const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
+          line[i] =
+            dataFormat !== null &&
+            dataFormat !== "date" &&
+            testDateFormat.test(line[i])
+              ? `="${line[i]}"`
+              : line[i];
+          if (i == 0 && headers[i] == "UID") {
+            line[i] =
+              '=HYPERLINK("' +
+              window.location.origin +
+              window.location.pathname +
+              "?a=printview&recordID=" +
+              trimmedText +
+              '", "' +
+              trimmedText +
+              '")';
+          }
+          i++;
+          if (i > numColumns) {
+            output.push(line); //add new row
+            line = [];
+            i = 0;
+          }
+        });
+
+      rows = "";
+      output.forEach(function (thisRow) {
+        //escape double quotes
+        thisRow.forEach(function (col, idx) {
+          thisRow[idx] = col.replace(/\"/g, '""');
+        });
+        //add to csv string
+        rows += '"' + thisRow.join('","') + '",\r\n';
       });
-      var tForm = $(document.createElement("form"));
-      tForm.attr({
-        action: rootURL + "api/converter/json?format=csv",
-        method: "POST",
-      });
-      var tInput = $(document.createElement("input"));
-      var tInput2 = $(document.createElement("input"));
-      tInput.attr({
-        type: "hidden",
-        name: "input",
-        value: JSON.stringify(output),
-      });
-      tInput2.attr({ type: "hidden", name: "CSRFToken", value: CSRFToken });
-      tForm.append(tInput);
-      tForm.append(tInput2);
-      tForm.appendTo("#" + containerID);
-      tForm.submit();
-      tForm.remove();
+
+      var download = document.createElement("a");
+      var now = new Date().getTime();
+      download.setAttribute(
+        "href",
+        "data:text/csv;charset=utf-8," + encodeURIComponent(rows)
+      );
+      download.setAttribute("download", "Exported_" + now + ".csv");
+      download.style.display = "none";
+
+      document.body.appendChild(download);
+      if (navigator.msSaveOrOpenBlob) {
+        rows = "\uFEFF" + rows;
+        navigator.msSaveOrOpenBlob(
+          new Blob([rows], { type: "text/csv;charset=utf-8;" }),
+          "Exported_" + now + ".csv"
+        );
+      } else {
+        download.click();
+      }
+      document.body.removeChild(download);
     });
   }
 
@@ -884,6 +1105,15 @@ var LeafFormGrid = function (containerID, options) {
    */
   function setPostRenderFunc(func) {
     postRenderFunc = func;
+  }
+
+  /**
+   * @memberOf LeafFormGrid
+   * Set callback function to run after the user requests a sort.
+   * The function takes two parameters: key, sort direction (asc/desc)
+   */
+  function setPostSortRequestFunc(func) {
+    postSortRequestFunc = func;
   }
 
   /**
@@ -925,6 +1155,7 @@ var LeafFormGrid = function (containerID, options) {
     sort: sort,
     renderVirtualHeader: renderVirtualHeader,
     renderBody: renderBody,
+    announceResults: announceResults,
     loadData: loadData,
     setData: setData,
     setDataBlob: setDataBlob,
@@ -933,6 +1164,7 @@ var LeafFormGrid = function (containerID, options) {
     setPostProcessDataFunc: setPostProcessDataFunc,
     setPreRenderFunc: setPreRenderFunc,
     setPostRenderFunc: setPostRenderFunc,
+    setPostSortRequestFunc: setPostSortRequestFunc,
     setDefaultLimit: function (limit) {
       defaultLimit = limit;
     },

--- a/app/libs/js/LEAF/formQuery.js
+++ b/app/libs/js/LEAF/formQuery.js
@@ -10,6 +10,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   let extraParams = "";
   let results = {};
   let batchSize = 500;
+  let abortSignal;
 
   clearTerms();
 
@@ -119,13 +120,19 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   }
 
   /**
-   * @param {string|number} indicatorID
+   * getData includes data associated with $indicatorID in the result set
+   * @param {string|number|array} indicatorID
    * @memberOf LeafFormQuery
    */
   function getData(indicatorID = "") {
-    if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
-      query.getData.push(indicatorID);
-    }
+	if(Array.isArray(indicatorID)) {
+		indicatorID.forEach(id => {
+			getData(id);
+		});
+	}
+	else if (indicatorID !== "" && query.getData.indexOf(indicatorID) == -1) {
+	    query.getData.push(indicatorID);
+	}
   }
 
   /**
@@ -207,6 +214,15 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   }
 
   /**
+   * setAbortSignal assigns a DOM AbortSignal to determine whether further getBulkData() iterations should be cancelled
+   * @param {AbortSignal} signal
+   * @memberOf LeafFormQuery
+   */
+  function setAbortSignal(signal) {
+    abortSignal = signal;
+  }
+
+  /**
    * Execute search query in chunks
    * @param {number} limitOffset Used in subsequent recursive calls to track current offset
    * @returns Promise resolving to query response
@@ -234,7 +250,9 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
     }).then((res, resStatus, resJqXHR) => {
       results = Object.assign(results, res);
 
-      if (Object.keys(res).length == batchSize || resJqXHR.getResponseHeader("leaf-query") == "continue") {
+      if ((Object.keys(res).length == batchSize
+                || resJqXHR.getResponseHeader("leaf-query") == "continue")
+            && !abortSignal?.aborted) {
         let newOffset = limitOffset + batchSize;
         if (typeof progressCallback == "function") {
           progressCallback(newOffset);
@@ -258,7 +276,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
     if (query.getData != undefined && query.getData.length == 0) {
       delete query.getData;
     }
-    if (query.limit == undefined || isNaN(query.limit) || parseInt(query.limit) > 9999) {
+    if (query.limit == undefined || isNaN(query.limit) || parseInt(query.limit) > 1000) {
       return getBulkData();
     }
 
@@ -297,6 +315,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
     sort,
     onSuccess,
     onProgress,
+    setAbortSignal,
     execute
   };
 };

--- a/app/libs/js/LEAF/formSearch.js
+++ b/app/libs/js/LEAF/formSearch.js
@@ -16,7 +16,7 @@ var LeafFormSearch = function (containerID) {
     var leafFormQuery = new LeafFormQuery();
     var widgetCounter = 0;
     var rootURL = "";
-    let js_app_path;
+    var app_js_path = "";
 
     // constants
     var ALL_DATA_FIELDS = "0";
@@ -24,7 +24,7 @@ var LeafFormSearch = function (containerID) {
 
     function renderUI() {
         $("#" + containerID).html(
-            '<div>\
+            '<div style="display:flex; align-items:center; width:fit-content; width: -moz-fit-content;">\
 			    <img id="' +
                 prefixID +
                 'searchIcon" class="searchIcon" alt="search" style="vertical-align: middle; padding-right: 4px; display: inline;" src="' +
@@ -176,7 +176,8 @@ var LeafFormSearch = function (containerID) {
         if (
             !/Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
                 navigator.userAgent
-            )
+            ) &&
+            window.location.search !== ""
         ) {
             focus();
         }
@@ -211,8 +212,7 @@ var LeafFormSearch = function (containerID) {
 
     /**
      * @memberOf LeafFormSearch
-     * renderPreviousAdvancedSearch parses LeafFormQuery.getQuery().terms and renders the resulting UI
-     * prevQuery - optional array from LeafFormQuery.getQuery().terms
+     * prevQuery - optional JSON object
      */
     function renderPreviousAdvancedSearch(prevQuery) {
         var isJSON = true;
@@ -265,6 +265,9 @@ var LeafFormSearch = function (containerID) {
                                 $("#" + prefixID + "widgetCod_" + widgetID).val(
                                     operator
                                 );
+                                $(
+                                    "#" + prefixID + "widgetCod_" + widgetID
+                                ).trigger("change");
                                 $(
                                     "#" + prefixID + "widgetCod_" + widgetID
                                 ).trigger("chosen:updated");
@@ -360,7 +363,11 @@ var LeafFormSearch = function (containerID) {
             if (txt != "" && txt != q) {
                 q = txt;
 
-                if (currRequest != null) {
+                if (
+                    currRequest != null &&
+                    currRequest.abort != undefined &&
+                    typeof currRequest.abort == "function"
+                ) {
                     currRequest.abort();
                 }
 
@@ -421,7 +428,7 @@ var LeafFormSearch = function (containerID) {
                 url: orgchartPath + "/js/employeeSelector.js",
                 dataType: "script",
                 success: function () {
-                    empSel = new employeeSelector(
+                    let empSel = new employeeSelector(
                         prefixID + "widgetEmp_" + widgetID
                     );
                     empSel.apiPath = orgchartPath + "/api/";
@@ -439,6 +446,10 @@ var LeafFormSearch = function (containerID) {
                                           .userName;
                             $("#" + prefixID + "widgetMat_" + widgetID).val(
                                 selection
+                            );
+                            //uses id.  report builder/search will not take userName:<username>
+                            $("#" + empSel.prefixID + "input").val(
+                                "#" + empSel.selection
                             );
                         }
                     });
@@ -460,7 +471,9 @@ var LeafFormSearch = function (containerID) {
                 },
             });
         } else {
-            empSel = new employeeSelector(prefixID + "widgetEmp_" + widgetID);
+            let empSel = new employeeSelector(
+                prefixID + "widgetEmp_" + widgetID
+            );
             empSel.apiPath = orgchartPath + "/api/";
             empSel.rootPath = orgchartPath + "/";
             empSel.outputStyle = "micro";
@@ -472,6 +485,9 @@ var LeafFormSearch = function (containerID) {
                             ? empSel.selection
                             : empSel.selectionData[empSel.selection].userName;
                     $("#" + prefixID + "widgetMat_" + widgetID).val(selection);
+                    $("#" + empSel.prefixID + "input").val(
+                        "#" + empSel.selection
+                    );
                 }
             });
             empSel.setResultHandler(function () {
@@ -502,7 +518,7 @@ var LeafFormSearch = function (containerID) {
                 url: orgchartPath + "/js/positionSelector.js",
                 dataType: "script",
                 success: function () {
-                    posSel = new positionSelector(
+                    let posSel = new positionSelector(
                         prefixID + "widgetPos_" + widgetID
                     );
                     posSel.apiPath = orgchartPath + "/api/";
@@ -511,6 +527,9 @@ var LeafFormSearch = function (containerID) {
                     posSel.setSelectHandler(function () {
                         $("#" + prefixID + "widgetMat_" + widgetID).val(
                             posSel.selection
+                        );
+                        $("#" + posSel.prefixID + "input").val(
+                            "#" + posSel.selection
                         );
                     });
                     posSel.setResultHandler(function () {
@@ -522,7 +541,9 @@ var LeafFormSearch = function (containerID) {
                 },
             });
         } else {
-            posSel = new positionSelector(prefixID + "widgetPos_" + widgetID);
+            let posSel = new positionSelector(
+                prefixID + "widgetPos_" + widgetID
+            );
             posSel.apiPath = orgchartPath + "/api/";
             posSel.rootPath = orgchartPath + "/";
 
@@ -530,6 +551,7 @@ var LeafFormSearch = function (containerID) {
                 $("#" + prefixID + "widgetMat_" + widgetID).val(
                     posSel.selection
                 );
+                $("#" + posSel.prefixID + "input").val("#" + posSel.selection);
             });
             posSel.setResultHandler(function () {
                 $("#" + prefixID + "widgetMat_" + widgetID).val(
@@ -555,7 +577,7 @@ var LeafFormSearch = function (containerID) {
                 url: orgchartPath + "/js/groupSelector.js",
                 dataType: "script",
                 success: function () {
-                    grpSel = new groupSelector(
+                    let grpSel = new groupSelector(
                         prefixID + "widgetGrp_" + widgetID
                     );
                     grpSel.apiPath = orgchartPath + "/api/";
@@ -564,6 +586,9 @@ var LeafFormSearch = function (containerID) {
                     grpSel.setSelectHandler(function () {
                         $("#" + prefixID + "widgetMat_" + widgetID).val(
                             grpSel.selection
+                        );
+                        $("#" + grpSel.prefixID + "input").val(
+                            "group#" + grpSel.selection
                         );
                     });
                     grpSel.setResultHandler(function () {
@@ -575,13 +600,16 @@ var LeafFormSearch = function (containerID) {
                 },
             });
         } else {
-            grpSel = new groupSelector(prefixID + "widgetGrp_" + widgetID);
+            let grpSel = new groupSelector(prefixID + "widgetGrp_" + widgetID);
             grpSel.apiPath = orgchartPath + "/api/";
             grpSel.rootPath = orgchartPath + "/";
 
             grpSel.setSelectHandler(function () {
                 $("#" + prefixID + "widgetMat_" + widgetID).val(
                     grpSel.selection
+                );
+                $("#" + grpSel.prefixID + "input").val(
+                    "group#" + grpSel.selection
                 );
             });
             grpSel.setResultHandler(function () {
@@ -594,9 +622,35 @@ var LeafFormSearch = function (containerID) {
     }
 
     /**
+     * Render the query match condition's input type for dropdown and radio fields
+     * @param widgetID
+     * @param options <select> html section matching the widgetID
+     * @memberOf LeafFormSearch
+     */
+    function renderSingleSelectInputType(widgetID, options) {
+        switch ($("#" + prefixID + "widgetCod_" + widgetID).val()) {
+            case "LIKE":
+            case "NOT LIKE":
+                $("#" + prefixID + "widgetMatch_" + widgetID).html(
+                    '<input type="text" aria-label="text" id="' +
+                        prefixID +
+                        "widgetMat_" +
+                        widgetID +
+                        '" style="width: 200px" />'
+                );
+                break;
+            default:
+                $("#" + prefixID + "widgetMatch_" + widgetID).html(options);
+                chosenOptions();
+                break;
+        }
+    }
+
+    /**
      * @memberOf LeafFormSearch
      */
     function renderWidget(widgetID, callback) {
+        let url;
         switch ($("#" + prefixID + "widgetTerm_" + widgetID).val()) {
             case "title":
                 $("#" + prefixID + "widgetCondition_" + widgetID).html(
@@ -630,9 +684,13 @@ var LeafFormSearch = function (containerID) {
                         <option value="!=">IS NOT</option>\
                     </select>'
                 );
+                url =
+                    rootURL === ""
+                        ? "./api/system/services"
+                        : rootURL + "api/system/services";
                 $.ajax({
                     type: "GET",
-                    url: "./api/system/services",
+                    url,
                     dataType: "json",
                     success: function (res) {
                         var services =
@@ -683,7 +741,7 @@ var LeafFormSearch = function (containerID) {
                 );
                 if (!jQuery.ui) {
                     $.getScript(
-                        js_app_path + "/jquery/jquery-ui.custom.min.js",
+                        app_js_path + "/jquery/jquery-ui.custom.min.js",
                         function () {
                             $(
                                 "#" + prefixID + "widgetMat_" + widgetID
@@ -705,9 +763,13 @@ var LeafFormSearch = function (containerID) {
 	            		<option value="!=">IS NOT</option>\
 	            	</select>'
                 );
+                url =
+                    rootURL === ""
+                        ? "./api/workflow/categoriesUnabridged"
+                        : rootURL + "api/workflow/categoriesUnabridged";
                 $.ajax({
                     type: "GET",
-                    url: "./api/workflow/categoriesUnabridged",
+                    url,
                     dataType: "json",
                     success: function (res) {
                         var categories =
@@ -765,9 +827,13 @@ var LeafFormSearch = function (containerID) {
                         widgetID +
                         '" value="=" /> ='
                 );
+                url =
+                    rootURL === ""
+                        ? "./api/workflow/dependencies"
+                        : rootURL + "api/workflow/dependencies";
                 $.ajax({
                     type: "GET",
-                    url: "./api/workflow/dependencies",
+                    url,
                     dataType: "json",
                     success: function (res) {
                         var dependencies =
@@ -830,9 +896,13 @@ var LeafFormSearch = function (containerID) {
 	            		<option value="!=">IS NOT</option>\
 	            	</select>'
                 );
+                url =
+                    rootURL === ""
+                        ? "./api/workflow/steps"
+                        : rootURL + "api/workflow/steps";
                 $.ajax({
                     type: "GET",
-                    url: "./api/workflow/steps",
+                    url,
                     dataType: "json",
                     success: function (res) {
                         let allStepsData = res;
@@ -848,6 +918,9 @@ var LeafFormSearch = function (containerID) {
                             '<option value="deleted">Cancelled</option>';
                         categories +=
                             '<option value="resolved">Resolved</option>';
+                        categories +=
+                            '<option value="actionable">Actionable by me</option>';
+                        //categories += '<option value="destruction">Scheduled for Destruction</option>';
                         for (var i in allStepsData) {
                             categories +=
                                 '<option value="' +
@@ -867,13 +940,18 @@ var LeafFormSearch = function (containerID) {
                             callback();
                         }
                     },
-                    cache: false,
                 });
                 break;
             case "data":
+                let resultFilter =
+                    "?x-filterData=indicatorID,categoryName,name,format";
+                url =
+                    rootURL === ""
+                        ? `./api/form/indicator/list${resultFilter}`
+                        : rootURL + `api/form/indicator/list${resultFilter}`;
                 $.ajax({
                     type: "GET",
-                    url: "./api/form/indicator/list",
+                    url,
                     dataType: "json",
                     success: function (res) {
                         var indicators =
@@ -1052,8 +1130,7 @@ var LeafFormSearch = function (containerID) {
                                                 );
                                                 if (!jQuery.ui) {
                                                     $.getScript(
-                                                        js_app_path +
-                                                            "/jquery/jquery-ui.custom.min.js",
+                                                        "js/jquery/jquery-ui.custom.min.js",
                                                         function () {
                                                             $(
                                                                 "#" +
@@ -1186,7 +1263,6 @@ var LeafFormSearch = function (containerID) {
                                                     widgetID
                                                 );
                                                 break;
-                                            case "multiselect":
                                             case "dropdown":
                                             case "radio":
                                                 $(
@@ -1202,6 +1278,8 @@ var LeafFormSearch = function (containerID) {
                                                         '" class="chosen" aria-label="condition" style="width: 120px">\
                                                     <option value="=">IS</option>\
                                                     <option value="!=">IS NOT</option>\
+													<option value="LIKE">CONTAINS</option>\
+													<option value="NOT LIKE">DOES NOT CONTAIN</option>\
 								            		<option value=">">></option>\
 								            		<option value=">=">>=</option>\
 								            		<option value="<"><</option>\
@@ -1236,13 +1314,20 @@ var LeafFormSearch = function (containerID) {
                                                         "</option>";
                                                 }
                                                 options += "</select>";
+
+                                                renderSingleSelectInputType(
+                                                    widgetID,
+                                                    options
+                                                );
+
                                                 $(
-                                                    "#" +
-                                                        prefixID +
-                                                        "widgetMatch_" +
-                                                        widgetID
-                                                ).html(options);
-                                                chosenOptions();
+                                                    `#${prefixID}widgetCod_${widgetID}`
+                                                ).on("change", function () {
+                                                    renderSingleSelectInputType(
+                                                        widgetID,
+                                                        options
+                                                    );
+                                                });
                                                 break;
                                             default:
                                                 $(
@@ -1292,7 +1377,6 @@ var LeafFormSearch = function (containerID) {
                             callback();
                         }
                     },
-                    cache: false,
                 });
                 break;
             default:
@@ -1326,10 +1410,8 @@ var LeafFormSearch = function (containerID) {
      */
     function newSearchWidget(gate) {
         // @TODO IE Fix (No overloading)
-        // Validate gate parameter
-        const validGates = ["AND", "OR"];
-        if (!validGates.includes(gate)) {
-            gate = "AND"; // Set default value if gate is invalid
+        if (gate === undefined) {
+            gate = "AND";
         }
         let widget =
             '<tr id="' +
@@ -1519,7 +1601,7 @@ var LeafFormSearch = function (containerID) {
             rootURL = url;
         },
         setJsPath: function (url) {
-            js_app_path = url;
+            app_js_path = url;
         },
     };
 };


### PR DESCRIPTION
This saves some bandwidth by removing an anti-cache workaround in formSearch.js. This is safe because cache control is configured correctly for API endpoints in Prod.

Additionally I noticed the new /app/libs/js/LEAF folder contains outdated JS assets and has started to diverge. I've overwritten them with updated versions from LEAF_Request_Portal/js. When the file consolidation effort is complete, these files should only be present in one folder.

### Potential Impact
No impact expected if the /app/libs/js/LEAF files are currently unused.

### Testing
- [x] Search box on the homepage works normally