### PR TITLE
LEAF 4050 - Remove unused SQL JOIN

### DIFF
--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -724,7 +724,6 @@ class Email
             "LEFT JOIN dependency_privs USING (dependencyID) ".
             "LEFT JOIN users USING (groupID) ".
             "LEFT JOIN services AS ser USING (serviceID) ".
-            "LEFT JOIN data USING (recordID)".
             "WHERE recordID=:recordID AND (active=1 OR active IS NULL)";
         $approvers = $this->portal_db->prepared_query($strSQL, $vars);
 


### PR DESCRIPTION
This removes an unused JOIN, which caused poor performance when the following conditions are met: 1) record submission or workflow actions 2) there are many data fields on the form 3) an email notification is sent to the next approver. Removing the JOIN avoids around [# data fields] * 3 queries in the subsequent loop.

## Potential Impact
None because the query doesn't select any data from the joined table.

## Testing
- [x] Email "notify next approver" works normally