### PR TITLE
Leaf 4010-2 - update references to copied files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ LEAF_Request_Nexus/qrcode/cache/tmp*
 LEAF_Request_Portal/sources/DbConfig.php
 libs/dynicons/cache/*.svg
 libs/qrcode/cache/*.png
+app/libs/dynicons/cache/*.svg
+app/libs/qrcode/cache/*.png
+
 
 LEAF_Nexus/UPLOADS
 LEAF_Request_Portal/UPLOADS

--- a/LEAF_Nexus/qrcode/index.php
+++ b/LEAF_Nexus/qrcode/index.php
@@ -3,6 +3,7 @@
 use App\Leaf\XSSHelpers;
 
 require_once getenv('APP_LIBS_PATH') . '/globals.php';
+require_once getenv('APP_LIBS_PATH') . '/globals_plus.php';
 include_once getenv('APP_PATH') . '/Leaf/XSSHelpers.php';
 require_once getenv('APP_LIBS_PATH') . '/qrcode/qrlib.php';
 $cacheDir = 'cache/';

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -162,7 +162,7 @@ switch ($action) {
 
         $main->assign('javascripts', array(APP_JS_PATH . '/jsPlumb/dom.jsPlumb-min.js',
                                            $site_paths['orgchart_path'] . '/js/groupSelector.js',
-                                           '../../libs/jsapi/portal/LEAFPortalAPI.js',
+                                           APP_JS_PATH . '/portal/LEAFPortalAPI.js',
                                            APP_JS_PATH . '/LEAF/XSSHelpers.js',
         ));
         $main->assign('stylesheets', array('css/mod_workflow.css',
@@ -235,7 +235,7 @@ switch ($action) {
                                             APP_JS_PATH . '/codemirror/mode/htmlmixed/htmlmixed.js',
                                             APP_JS_PATH . '/codemirror/addon/display/fullscreen.js',
                                             APP_JS_PATH . '/LEAF/XSSHelpers.js',
-                                            '../../libs/jsapi/portal/LEAFPortalAPI.js',
+                                            APP_JS_PATH . '/portal/LEAFPortalAPI.js',
                                             APP_JS_PATH . '/choicesjs/choices.min.js',
                                             '../js/gridInput.js',
                                             '../js/formQuery.js',
@@ -536,8 +536,8 @@ switch ($action) {
 
         $main->assign('javascripts', array(
             APP_JS_PATH . '/LEAF/XSSHelpers.js',
-            '../../libs/jsapi/nexus/LEAFNexusAPI.js',
-            '../../libs/jsapi/portal/LEAFPortalAPI.js',
+            APP_JS_PATH . '/nexus/LEAFNexusAPI.js',
+            APP_JS_PATH . '/portal/LEAFPortalAPI.js',
         ));
 
         if ($login->checkGroup(1))

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -121,6 +121,7 @@ switch ($action) {
         $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
         $t_form->assign('timeZone', $tz);
         $t_form->assign('orgchartImportTag', $settings['orgchartImportTags'][0]);
+        $t_form->assign('app_libs', APP_LIBS_PATH);
 
         $main->assign('useUI', true);
         $main->assign('stylesheets', array('css/mod_groups.css',

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -78,7 +78,7 @@
     </main>
 </div>
 <!--Loading Modal-->
-<!--{include file="../../../app/libs/smarty/loading_spinner.tpl" title='User Groups'}-->
+<!--{include file="<!--{$app_libs}-->/smarty/loading_spinner.tpl" title='User Groups'}-->
 
 <!--{include file="site_elements/generic_xhrDialog.tpl"}-->
 <!--{include file="site_elements/import_dialog.tpl"}-->

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -78,7 +78,7 @@
     </main>
 </div>
 <!--Loading Modal-->
-<!--{include file="../../../libs/smarty/loading_spinner.tpl" title='User Groups'}-->
+<!--{include file="../../../app/libs/smarty/loading_spinner.tpl" title='User Groups'}-->
 
 <!--{include file="site_elements/generic_xhrDialog.tpl"}-->
 <!--{include file="site_elements/import_dialog.tpl"}-->

--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -172,7 +172,7 @@ switch ($action) {
             'js/formPrint.js',
             'js/jsdiff.js',
             APP_JS_PATH . '/LEAF/XSSHelpers.js',
-            '../libs/jsapi/portal/LEAFPortalAPI.js',
+            APP_JS_PATH . '/portal/LEAFPortalAPI.js',
             APP_JS_PATH . '/es6-promise/es6-promise.min.js',
             APP_JS_PATH . '/es6-promise/es6-promise.auto.min.js',
             APP_JS_PATH . '/jspdf/jspdf.min.js',
@@ -474,7 +474,7 @@ switch ($action) {
                'js/gridInput.js',
                'js/workflow.js',
                'js/lz-string/lz-string.min.js',
-               '../libs/jsapi/portal/LEAFPortalAPI.js',
+               APP_JS_PATH . '/portal/LEAFPortalAPI.js',
                APP_JS_PATH . '/LEAF/XSSHelpers.js',
                APP_JS_PATH . '/choicesjs/choices.min.js'
            ));

--- a/LEAF_Request_Portal/qrcode/index.php
+++ b/LEAF_Request_Portal/qrcode/index.php
@@ -3,6 +3,7 @@
 use App\Leaf\XSSHelpers;
 
 require_once getenv('APP_LIBS_PATH') . '/globals.php';
+require_once getenv('APP_LIBS_PATH') . '/globals_plus.php';
 include_once getenv('APP_PATH') . '/Leaf/XSSHelpers.php';
 require_once getenv('APP_LIBS_PATH') . '/qrcode/qrlib.php';
 $cacheDir = 'cache/';

--- a/LEAF_Request_Portal/qrcode/index.php
+++ b/LEAF_Request_Portal/qrcode/index.php
@@ -2,9 +2,9 @@
 
 use App\Leaf\XSSHelpers;
 
-require_once '/var/www/html/app/libs/globals.php';
-include_once '/var/www/html/app/Leaf/XSSHelpers.php';
-require_once '/var/www/html/app/libs/qrcode/qrlib.php';
+require_once getenv('APP_LIBS_PATH') . '/globals.php';
+include_once getenv('APP_PATH') . '/Leaf/XSSHelpers.php';
+require_once getenv('APP_LIBS_PATH') . '/qrcode/qrlib.php';
 $cacheDir = 'cache/';
 
 $encode = 'Invalid Input.';

--- a/LEAF_Request_Portal/report.php
+++ b/LEAF_Request_Portal/report.php
@@ -101,9 +101,9 @@ switch ($action) {
                 'js/gridInput.js',
                 'js/lz-string/lz-string.min.js',
                 APP_JS_PATH . '/LEAF/XSSHelpers.js',
-                '../libs/jsapi/nexus/LEAFNexusAPI.js',
-                '../libs/jsapi/portal/LEAFPortalAPI.js',
-                '../libs/jsapi/portal/model/FormQuery.js',
+                APP_JS_PATH . '/nexus/LEAFNexusAPI.js',
+                APP_JS_PATH . '/portal/LEAFPortalAPI.js',
+                APP_JS_PATH . '/portal/model/FormQuery.js',
                 APP_JS_PATH . '/choicesjs/choices.min.js'
             ));
 

--- a/LEAF_Request_Portal/templates/reports/coach_roster.tpl
+++ b/LEAF_Request_Portal/templates/reports/coach_roster.tpl
@@ -89,8 +89,8 @@ div.specialties {
 
 <div id="coaches"></div>
 
-<script src="../libs/jsapi/portal/model/FormQuery.js" type="text/javascript"></script>
-<script src="../libs/jsapi/portal/LEAFPortalAPI.js" type="text/javascript"></script>
+<script src="<!--{$app_js_path}-->/portal/model/FormQuery.js" type="text/javascript"></script>
+<script src="<!--{$app_js_path}-->/portal/LEAFPortalAPI.js" type="text/javascript"></script>
 
 <script type="text/javascript">
 /**

--- a/app/Leaf/Site.php
+++ b/app/Leaf/Site.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * As a work of the United States government, this project is in the public domain within the United States.
+ */
+
+namespace App\Leaf;
+
+use App\Leaf\Db;
+
+class Site
+{
+    private $db;
+
+    private $match;
+
+    private $portal_path;
+
+    private $site_paths;
+
+    public $error = false;
+
+    /**
+     * @param Db $db
+     *
+     * Created at: 9/5/2023, 10:56:00 AM (America/New_York)
+     */
+    public function __construct(Db $db, string $path)
+    {
+        $this->db = $db;
+
+        preg_match('(\/.+\/)', $path, $match);
+        $this->match = rtrim(str_replace('/var/www/html', '', $match[0]), '/');
+        // the only time that more than one folder gets removed is here so going to strip it here rather than wait.
+        $this->match = str_replace('/sources/../mailer', '', $this->match);
+
+        $portal_path = $this->checkPath();
+
+        if ($portal_path['status']['code'] == 2 && !empty($portal_path['data'])) {
+            $this->portal_path = $this->match;
+            $this->site_paths = $portal_path['data'][0];
+        } else {
+            // the original url does not produce a site, need to extract the end of the url and try again.
+            $this->stripLast();
+            $portal_path = $this->checkPath();
+
+            if ($portal_path['status']['code'] == 2 && !empty($portal_path['data'])) {
+                $this->portal_path = $this->match;
+                $this->site_paths = $portal_path['data'][0];
+            } else {
+                $this->error = true;
+            }
+        }
+    }
+
+    public function getPortalPath(): string
+    {
+        return $this->portal_path;
+    }
+
+    public function getSitePath(): array
+    {
+        return $this->site_paths;
+    }
+
+    private function stripLast(): void
+    {
+        $path_array = explode('/', $this->match);
+
+        $path = '';
+
+        // starting with 1 because the first element in the array will be blank
+        // need to subtract 1 from the count because of the blank first element
+        for ($i = 1; $i < count($path_array) - 1; $i++) {
+            $path .= '/' . $path_array[$i];
+        }
+
+        $this->match = $path;
+    }
+
+    private function checkPath(): array
+    {
+        $vars = array(':site_path' => $this->match);
+        $sql = 'SELECT `site_path`, `site_uploads`, `portal_database`, `orgchart_path`,
+                    `orgchart_database`
+                FROM `sites`
+                WHERE `site_path` = BINARY :site_path';
+
+        $return_value = $this->db->pdo_select_query($sql, $vars);
+
+        return $return_value;
+    }
+}

--- a/app/Leaf/Site.php
+++ b/app/Leaf/Site.php
@@ -65,12 +65,12 @@ class Site
     private function stripLast(): void
     {
         $path_array = explode('/', $this->match);
+        array_shift($path_array);
+        array_pop($path_array);
 
         $path = '';
 
-        // starting with 1 because the first element in the array will be blank
-        // need to subtract 1 from the count because of the blank first element
-        for ($i = 1; $i < count($path_array) - 1; $i++) {
+        for ($i = 0; $i < count($path_array); $i++) {
             $path .= '/' . $path_array[$i];
         }
 

--- a/app/libs/globals.php
+++ b/app/libs/globals.php
@@ -19,28 +19,3 @@ if (!defined('APP_LIBS_PATH')) define('APP_LIBS_PATH', getenv('APP_LIBS_PATH'));
 if (!defined('APP_CSS_PATH')) define('APP_CSS_PATH', getenv('APP_CSS_PATH'));
 if (!defined('APP_JS_PATH')) define('APP_JS_PATH', getenv('APP_JS_PATH'));
 if (!defined('LEAF_DOMAIN')) define('LEAF_DOMAIN', getenv('APP_URL_NEXUS'));
-
-/*
-    We need to extract the portal url from the SCRIPT_FILENAME so we can get the data from the sites table.
-    There are times where there is another folder tacked on to the end of the url, in those cases that folder
-    needs to be striped from the url
-
-    i.e. /Academy/Demo1/admin
-    I decided it best to put this into a class and have the class deal with it to keep this file clean
-*/
-
-require_once getenv('APP_PATH') . '/Leaf/Db.php';
-require_once getenv('APP_PATH') . '/Leaf/Site.php';
-
-$file_paths_db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
-
-$site = new App\Leaf\Site($file_paths_db, $_SERVER['SCRIPT_FILENAME']);
-
-if ($site->error) {
-    // redirect to 404 not found
-} else {
-    $my_path = $site->getPortalPath();
-    if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $my_path);
-    if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS') . trim($my_path) . '/');
-    $site_paths = $site->getSitePath();
-}

--- a/app/libs/globals.php
+++ b/app/libs/globals.php
@@ -22,20 +22,19 @@ if (!defined('LEAF_DOMAIN')) define('LEAF_DOMAIN', getenv('APP_URL_NEXUS'));
 
 preg_match('(\/.+\/)', $_SERVER['SCRIPT_FILENAME'], $match);
 
-$path = str_replace('/var/www/html', '', $match[0]);
-$path = str_replace('/admin/', '/', $path);
-$path = str_replace('/api/', '/', $path);
-$path = str_replace('/auth_cookie/', '/', $path);
-$path = str_replace('/auth_domain/', '/', $path);
-$path = str_replace('/auth_token/', '/', $path);
-$path = str_replace('/dynicons/', '/', $path);
-$path = str_replace('/login/', '/', $path);
-$path = str_replace('/qrcode/', '/', $path);
-$path = str_replace('/scripts/', '/', $path);
-$path = str_replace('sources/../mailer', '', $path);
-$path = str_replace('/utils/', '/', $path);
+$folders = array('admin', 'api', 'auth.cookie', 'auth_domain', 'auth_token', 'dynicons', 'login', 'qrcode', 'scripts', 'utils', 'sources', '..', 'mailer', 'var', 'www', 'html', '');
+
+$path = '';
+
+$path_array = explode('/', $match[0]);
+
+foreach ($path_array as $value) {
+    if (!in_array($value, $folders)) {
+        $path .= '/' . $value;
+    }
+}
+
 $l_path = trim($path, '/');
-$path = rtrim($path, '/');
 
 if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $path);
 if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS') . $l_path . '/');

--- a/app/libs/globals.php
+++ b/app/libs/globals.php
@@ -20,21 +20,27 @@ if (!defined('APP_CSS_PATH')) define('APP_CSS_PATH', getenv('APP_CSS_PATH'));
 if (!defined('APP_JS_PATH')) define('APP_JS_PATH', getenv('APP_JS_PATH'));
 if (!defined('LEAF_DOMAIN')) define('LEAF_DOMAIN', getenv('APP_URL_NEXUS'));
 
-preg_match('(\/.+\/)', $_SERVER['SCRIPT_FILENAME'], $match);
+/*
+    We need to extract the portal url from the SCRIPT_FILENAME so we can get the data from the sites table.
+    There are times where there is another folder tacked on to the end of the url, in those cases that folder
+    needs to be striped from the url
 
-$folders = array('admin', 'api', 'auth.cookie', 'auth_domain', 'auth_token', 'dynicons', 'login', 'qrcode', 'scripts', 'utils', 'sources', '..', 'mailer', 'var', 'www', 'html', '');
+    i.e. /Academy/Demo1/admin
+    I decided it best to put this into a class and have the class deal with it to keep this file clean
+*/
 
-$path = '';
+require_once getenv('APP_PATH') . '/Leaf/Db.php';
+require_once getenv('APP_PATH') . '/Leaf/Site.php';
 
-$path_array = explode('/', $match[0]);
+$file_paths_db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
 
-foreach ($path_array as $value) {
-    if (!in_array($value, $folders)) {
-        $path .= '/' . $value;
-    }
+$site = new App\Leaf\Site($file_paths_db, $_SERVER['SCRIPT_FILENAME']);
+
+if ($site->error) {
+    // redirect to 404 not found
+} else {
+    $my_path = $site->getPortalPath();
+    if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $my_path);
+    if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS') . trim($my_path) . '/');
+    $site_paths = $site->getSitePath();
 }
-
-$l_path = trim($path, '/');
-
-if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $path);
-if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS') . $l_path . '/');

--- a/app/libs/globals_plus.php
+++ b/app/libs/globals_plus.php
@@ -21,7 +21,7 @@ $file_paths_db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS,
 $site = new App\Leaf\Site($file_paths_db, $_SERVER['SCRIPT_FILENAME']);
 
 if ($site->error) {
-    // redirect to 404 not found
+    throw new Exception("Sorry the page you are looking for could not be found, please check the url and try again.");
 } else {
     $my_path = $site->getPortalPath();
     if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $my_path);

--- a/app/libs/globals_plus.php
+++ b/app/libs/globals_plus.php
@@ -1,0 +1,30 @@
+
+<?php
+
+/*
+    This file is needed because there are instances where one of the defined global variables is needed but the
+    autoloader isn't loaded on that particular page. So this will be loaded on those pages only.
+
+    We need to extract the portal url from the SCRIPT_FILENAME so we can get the data from the sites table.
+    There are times where there is another folder tacked on to the end of the url, in those cases that folder
+    needs to be striped from the url
+
+    i.e. /Academy/Demo1/admin
+    I decided it best to put this into a class and have the class deal with it to keep this file clean
+*/
+
+require_once getenv('APP_PATH') . '/Leaf/Db.php';
+require_once getenv('APP_PATH') . '/Leaf/Site.php';
+
+$file_paths_db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+
+$site = new App\Leaf\Site($file_paths_db, $_SERVER['SCRIPT_FILENAME']);
+
+if ($site->error) {
+    // redirect to 404 not found
+} else {
+    $my_path = $site->getPortalPath();
+    if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $my_path);
+    if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS') . trim($my_path) . '/');
+    $site_paths = $site->getSitePath();
+}

--- a/app/libs/loaders/Leaf_autoloader.php
+++ b/app/libs/loaders/Leaf_autoloader.php
@@ -9,7 +9,7 @@ $app_dir = '/var/www/html/app';
 
 require_once $app_dir . '/libs/globals.php';
 require_once $app_dir . '/Leaf/Psr4AutoloaderClass.php';
-require_once $curr_dir . '/libs/smarty/bootstrap.php';
+require_once $app_dir . '/libs/smarty/bootstrap.php';
 
 $loader = new Psr4AutoloaderClass;
 $loader->register();
@@ -35,30 +35,29 @@ $site_paths = $file_paths_db->pdo_select_query($sql, $vars);
 //error_log(print_r($site_paths, true));
 $site_paths = $site_paths['data'][0];
 
-if (is_dir($curr_dir . '/libs/php-commons')) {
-    //Commenting this out for testing purposes, this will be uncommented before going to prod.
+/** Here down is old loader stuff, will be deprecated as we go along getting everything into a single source of code. */
+$working_dir = $curr_dir;
 
-    $loader->addNamespace('Leaf', $curr_dir . '/libs/logger');
-    $loader->addNamespace('Leaf', $curr_dir . '/libs/php-commons');
-    $loader->addNamespace('Leaf', $curr_dir . '/libs/logger/formatters');
+$loader->addNamespace('Leaf', $curr_dir . '/libs/logger');
+$loader->addNamespace('Leaf', $curr_dir . '/libs/php-commons');
+$loader->addNamespace('Leaf', $curr_dir . '/libs/logger/formatters');
 
-    $working_dir = $curr_dir;
+$working_dir = $curr_dir;
 
-    if (is_dir($working_dir . $site_paths['site_path'])) {
-        $loader->addNamespace('Portal', $working_dir . $site_paths['site_path']);
-        $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/api');
-        $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/api/controllers');
-        $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/sources');
-        $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/scripts/events');
-    }
+if (is_dir($working_dir . $site_paths['site_path'])) {
+    $loader->addNamespace('Portal', $working_dir . $site_paths['site_path']);
+    $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/api');
+    $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/api/controllers');
+    $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/sources');
+    $loader->addNamespace('Portal', $working_dir . $site_paths['site_path'] . '/scripts/events');
+}
 
-    if (is_dir($working_dir . $site_paths['orgchart_path'])) {
+if (is_dir($working_dir . $site_paths['orgchart_path'])) {
 
-        $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path']);
-        $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/api');
-        $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/api/controllers');
-        $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/sources');
-    }
+    $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path']);
+    $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/api');
+    $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/api/controllers');
+    $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/sources');
 }
 
 if (!empty($site_paths['portal_database'])){

--- a/app/libs/loaders/Leaf_autoloader.php
+++ b/app/libs/loaders/Leaf_autoloader.php
@@ -18,6 +18,18 @@ $loader->addNamespace('App\Leaf', $app_dir . '/Leaf');
 $loader->addNamespace('App\Leaf\Logger', $app_dir . '/Leaf/Logger');
 $loader->addNamespace('App\Leaf\Logger\Formatters', $app_dir . '/Leaf/Logger/Formatters');
 
+$file_paths_db = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+
+$site = new App\Leaf\Site($file_paths_db, $_SERVER['SCRIPT_FILENAME']);
+
+if ($site->error) {
+    // redirect to 404 not found
+} else {
+    $my_path = $site->getPortalPath();
+    if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $my_path);
+    if (!defined('LEAF_NEXUS_URL')) define('LEAF_NEXUS_URL', getenv('APP_URL_NEXUS') . trim($my_path) . '/');
+    $site_paths = $site->getSitePath();
+}
 
 /** Here down is old loader stuff, will be deprecated once we can verify that they are no longer being used. */
 $working_dir = $curr_dir;

--- a/app/libs/loaders/Leaf_autoloader.php
+++ b/app/libs/loaders/Leaf_autoloader.php
@@ -23,7 +23,7 @@ $file_paths_db = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'nationa
 $site = new App\Leaf\Site($file_paths_db, $_SERVER['SCRIPT_FILENAME']);
 
 if ($site->error) {
-    // redirect to 404 not found
+    throw new Exception("Sorry the page you are looking for could not be found, please check the url and try again.");
 } else {
     $my_path = $site->getPortalPath();
     if (!defined('PORTAL_PATH')) define('PORTAL_PATH', $my_path);

--- a/app/libs/loaders/Leaf_autoloader.php
+++ b/app/libs/loaders/Leaf_autoloader.php
@@ -18,24 +18,8 @@ $loader->addNamespace('App\Leaf', $app_dir . '/Leaf');
 $loader->addNamespace('App\Leaf\Logger', $app_dir . '/Leaf/Logger');
 $loader->addNamespace('App\Leaf\Logger\Formatters', $app_dir . '/Leaf/Logger/Formatters');
 
-$file_paths_db = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
 
-if (substr(PORTAL_PATH, 0, 1) !== '/') {
-    $my_path = '/' . PORTAL_PATH;
-} else {
-    $my_path = PORTAL_PATH;
-}
-$vars = array(':site_path' => $my_path);
-$sql = 'SELECT `site_path`, `site_uploads`, `portal_database`, `orgchart_path`,
-            `orgchart_database`
-        FROM `sites`
-        WHERE `site_path` = BINARY :site_path';
-//error_log(print_r($vars, true));
-$site_paths = $file_paths_db->pdo_select_query($sql, $vars);
-//error_log(print_r($site_paths, true));
-$site_paths = $site_paths['data'][0];
-
-/** Here down is old loader stuff, will be deprecated as we go along getting everything into a single source of code. */
+/** Here down is old loader stuff, will be deprecated once we can verify that they are no longer being used. */
 $working_dir = $curr_dir;
 
 $loader->addNamespace('Leaf', $curr_dir . '/libs/logger');
@@ -60,6 +44,12 @@ if (is_dir($working_dir . $site_paths['orgchart_path'])) {
     $loader->addNamespace('Orgchart', $working_dir . $site_paths['orgchart_path'] . '/sources');
 }
 
+/* This ends the deprecation area
+
+    below this point can be refactored once the code above is removed.
+    just needs to be cleaned up as much as possible.
+*/
+
 if (!empty($site_paths['portal_database'])){
     $db = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, $site_paths['portal_database']);
 } else {
@@ -77,6 +67,9 @@ if (class_exists('Portal\Config')) {
     if (!defined('PORTAL_CONFIG')) define('PORTAL_CONFIG', $config);
 }
 
+/*
+    TODO: move this to the Site class
+*/
 $vars = array(':site_path' => $site_paths['orgchart_path']);
 $sql = 'SELECT site_uploads
         FROM sites

--- a/app/libs/smarty/plugins/modifier.sanitize.php
+++ b/app/libs/smarty/plugins/modifier.sanitize.php
@@ -6,7 +6,7 @@
  * @subpackage PluginsModifier
  */
 
-use Leaf\XSSHelpers;
+use App\Leaf\XSSHelpers;
 
 /**
  * Smarty HTML sanitation modifier plugin
@@ -23,8 +23,8 @@ use Leaf\XSSHelpers;
  *
  * @return string
  */
-if(!class_exists('Leaf\XSSHelpers')){
-    include_once __DIR__ . '/../../php-commons/XSSHelpers.php';
+if(!class_exists('App\Leaf\XSSHelpers')){
+    include_once __DIR__ . '/../../../Leaf/XSSHelpers.php';
 }
 
 function smarty_modifier_sanitize($in)

--- a/app/libs/smarty/plugins/modifier.sanitizeRichtext.php
+++ b/app/libs/smarty/plugins/modifier.sanitizeRichtext.php
@@ -6,7 +6,7 @@
  * @subpackage PluginsModifier
  */
 
-use Leaf\XSSHelpers;
+use App\Leaf\XSSHelpers;
 
 /**
  * Smarty HTML sanitation modifier plugin
@@ -24,7 +24,9 @@ use Leaf\XSSHelpers;
  * @return string
  */
 
- require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
+ if(!class_exists('App\Leaf\XSSHelpers')){
+    include_once __DIR__ . '/../../../Leaf/XSSHelpers.php';
+}
 
 function smarty_modifier_sanitizeRichtext($in)
 {


### PR DESCRIPTION
**Summary:**
This is a follow up to Leaf 4010.1. It updates any references to the old location to the new location. It also refactors the globals file to construct the PORTAL_PATH. 

**Potential impact:**
If a reference to the original was completely missed and it is still referring to the old location nothing should happen, the old files are still in their original location and accessible. However, if a reference were changed and it isn't quite right we could end up with broken references and 404 errors.

Where the globals are concerned, if a portal has the exact name as any of the folders we have it will break the site. A different way to construct the portal path would need to be figured out.

**Testing:**
A full regression testing is needed for this release. We are looking for broken references where files could not be found and therefore not loaded.

Special note, on local and staging the html/libs file can be removed/renamed to ensure that all references have been changed and are working. DO NOT do this on prod as doing so will break every site until the full push is complete.

Pay special attention to the following pages as they have references to the old img and jsapi (all of which should be changed to the new location):
Portal/report.php
Portal/index.php - import_data, reports, printview
Portal/admin/index.php - workflow, form, import_data
coach_roster.tpl

loading spinner on the Access User Groups