### PR TITLE
Inbox v2 - Catch shortened report links

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -675,6 +675,9 @@
                     else if(site.url.indexOf('/report.php?') != -1) {
                         site.url = site.url.substring(0, site.url.indexOf('/report.php?') + 1);
                     }
+                    else if(site.url.indexOf('/api/open/form/query/') != -1) {
+                        site.url = site.url.substring(0, site.url.indexOf('/api/open/form/query/') + 1);
+                    }
                 });
 
                 // Remove duplicate URLs


### PR DESCRIPTION
This lets the Inbox parse shortened report links correctly.

## Potential Impact
No known impact because the change extends an existing filter list, isolated on the Inbox page

## Testing
- [ ] Inbox doesn't show a "not all records have been loaded" error when a shortened report link is provided in the site map
