### PR TITLE
LEAF 4061 - Optimize form/query and getCustomData's read access check (2 of 3)

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2798,7 +2798,14 @@ class Form
         return 1;
     }
 
-    public function query($inQuery)
+    /**
+     * query parses a JSON formatted user query defined in formQuery.js.
+     * 
+     * Returns an array on success, and string/int for malformed queries
+     * 
+     * @return mixed
+     */
+    public function query(string $inQuery): mixed
     {
         $query = json_decode(html_entity_decode(html_entity_decode($inQuery)), true);
         if ($query == null)
@@ -3636,7 +3643,7 @@ class Form
                 $indicatorIDs .= $indicatorID . ',';
             }
 
-            return $this->getCustomData($data, $indicatorIDs, $alreadyCheckedReadAccess);
+            $data = $this->getCustomData($data, $indicatorIDs, $alreadyCheckedReadAccess);
         }
 
         return $data;

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2309,9 +2309,9 @@ class Form
      * @param array $recordID_list
      * @param array $indicatorID_list
      * @param bool (optional) $alreadyCheckedReadAccess
-     * @return array on success | false on malformed input
+     * @return array on success | boolean false on malformed input
      */
-    public function getCustomData(array $recordID_list, string|null $indicatorID_list, bool $alreadyCheckedReadAccess = false)
+    public function getCustomData(array $recordID_list, string|null $indicatorID_list, bool $alreadyCheckedReadAccess = false): array|bool
     {
         if (count($recordID_list) == 0) {
             return $recordID_list;

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2803,6 +2803,7 @@ class Form
      * 
      * Returns an array on success, and string/int for malformed queries
      * 
+     * @param string JSON formatted string of the query
      * @return mixed
      */
     public function query(string $inQuery): mixed


### PR DESCRIPTION
Note the PR merge base. This series of optimizations have been split into multiple PRs to simplify review.

This modifies getCustomData() to avoid duplicate checkReadAccess() queries. If checkReadAccess() was already run, then it's not necessary for getCustomData() to call checkReadAccess() again because it could only check a subset of the already checked records.

### Potential Impact
Read access to records

### Testing
Preconditions:
- A record that the current user doesn't have access to read
- The record doesn't show up in the Report Builder
- [x] After this patch, the current user still cannot open the record, and cannot see it in the Report Builder