### PR TITLE
LEAF 4062 - Optimize Form.php person designated access check (3 of 3)

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1955,7 +1955,7 @@ class Form
      */
     private function batchUpdateDependencyAccess(array $accessList, array $records): array
     {
-        // get santized lists for DB query
+        // get sanitized lists for DB query
         $indicatorIDs = [];
         $recordIDs = [];
         foreach($records as $dep) {

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2302,10 +2302,16 @@ class Form
 
     /* getCustomData iterates through an array of $recordID_list and incorporates any associated data
      * specified by $indicatorID_list (string of ID#'s delimited by ',')
+     * 
+     * WARNING: $alreadyCheckedReadAccess can only be set to true if $recordID_list has been
+     *          processed by checkReadAccess().
      *
+     * @param array $recordID_list
+     * @param array $indicatorID_list
+     * @param bool (optional) $alreadyCheckedReadAccess
      * @return array on success | false on malformed input
      */
-    public function getCustomData(array $recordID_list, string|null $indicatorID_list)
+    public function getCustomData(array $recordID_list, string|null $indicatorID_list, bool $alreadyCheckedReadAccess = false)
     {
         if (count($recordID_list) == 0) {
             return $recordID_list;
@@ -2534,7 +2540,7 @@ class Form
             }
         }
 
-        if ($this->isNeedToKnow())
+        if (!$alreadyCheckedReadAccess && $this->isNeedToKnow())
         {
             $out = $this->checkReadAccess($out);
         }
@@ -3589,9 +3595,11 @@ class Form
         }
 
         // check needToKnow mode
+        $alreadyCheckedReadAccess = false;
         if ($this->isNeedToKnow())
         {
             $data = $this->checkReadAccess($data);
+            $alreadyCheckedReadAccess = true;
         }
 
         // check actionable
@@ -3628,7 +3636,7 @@ class Form
                 $indicatorIDs .= $indicatorID . ',';
             }
 
-            return $this->getCustomData($data, $indicatorIDs);
+            return $this->getCustomData($data, $indicatorIDs, $alreadyCheckedReadAccess);
         }
 
         return $data;

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1965,6 +1965,7 @@ class Form
             }
         }
 
+        // get the list of records related to dependencyID -1 (person designated by requestor)
         if(count($recordIDs) > 0) {
             $indicators = implode(',', $indicatorIDs);
             $records = implode(',', $recordIDs);
@@ -1975,9 +1976,11 @@ class Form
             $res = $this->db->prepared_query($query, []);
 
             foreach($res as $record) {
+                // check if the current user is the designated person
                 if($record['data'] == $this->login->getEmpUID()) {
                     $accessList[$record['recordID']] = 1;
                 }
+                // check if the current user is a backup of the designated person
                 else if($this->checkIfBackup($record['data'])) {
                     $accessList[$record['recordID']] = 1;
                 }

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1990,11 +1990,23 @@ class Form
         return $accessList;
     }
 
-    public function getEmpUID($userName){
+    /**
+     * getEmpUID translates a userName to empUID
+     *
+     * @param string $userName
+     * @return int
+     */
+    public function getEmpUID($userName): int
+    {
+        if(isset($this->cache['getEmpUID_'. $userName])) {
+            return $this->cache['getEmpUID_'. $userName];
+        }
         $nexusDB = $this->login->getNexusDB();
         $vars = array(':userName' => $userName);
-        $response = $nexusDB->prepared_query('SELECT * FROM employee WHERE userName =:userName', $vars);
-        return $response[0]["empUID"];
+        $response = $nexusDB->prepared_query('SELECT empUID FROM employee WHERE userName =:userName', $vars);
+        $this->cache['getEmpUID_'. $userName] = (int)$response[0]["empUID"];
+
+        return $this->cache['getEmpUID_'. $userName];
     }
 
     /**
@@ -2025,7 +2037,7 @@ class Form
             $this->cache['checkIfBackup'][$row['empUID']] = true;
         }
 
-        return isset($this->cache['checkEmployeeAccess'][$empUID]);
+        return isset($this->cache['checkIfBackup'][$empUID]);
     }
 
     /**
@@ -2170,7 +2182,7 @@ class Form
                         }
 
                         // backup of the request initiator
-                        if($temp[$dep['recordID']] == 0 && $this->checkIfBackup($dep['userID'])) {
+                        if($temp[$dep['recordID']] == 0 && $this->checkIfBackup($this->getEmpUID($dep['userID']))) {
                             $temp[$dep['recordID']] = 1;
                         }
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1947,7 +1947,7 @@ class Form
 
     /**
      * batchUpdateDependencyAccess amends $accessList for specific dependencyIDs to optimize
-     * performance for dependencyIDs related to dynamic assignments, such as "person designated by requestor"
+     * performance related to dynamic assignments, such as "person designated by requestor"
      *
      * @param array $accessList Map of recordID->int of the current user's access. 1 = has access
      * @param array $records List of records to process

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1951,9 +1951,9 @@ class Form
      *
      * @param array $accessList Map of recordID->int of the current user's access. 1 = has access
      * @param array $records List of records to process
-     * @return boolean
+     * @return array Amended $accessList
      */
-    private function batchUpdateDependencyAccess(array $accessList, array $records)
+    private function batchUpdateDependencyAccess(array $accessList, array $records): array
     {
         // get santized lists for DB query
         $indicatorIDs = [];


### PR DESCRIPTION
Note the PR merge base. This series of optimizations have been split into multiple PRs to simplify review.

Similar to PR#2155, this continues to optimize hotspots where "person designated" records are involved. This is important for usability in the Inbox and Report Builder. The reduction of DB round trips dramatically improves performance, measuring around 100% faster response time in the Inbox and 40% in the Report Builder.

### Potential Impact
Areas that depend on access checks related to "person designated" and employee backups

### Testing
- [x] You can access records assigned to you via "person designated" and if you're a backup of the designated person
- [x] You cannot access records (as non-admin) for records assigned as "person designated", and you're not the designated person or their backup