### PR TITLE
LeAF-4076 - Optimize employee search

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -35,11 +35,7 @@ class Employee extends Data
 
     private $tableName = 'employee';    // Table of employee contact info
 
-    private $groupTableName = 'relation_group_employee';
-
     private $limit = 'LIMIT 3';       // Limit number of returned results "TOP 100"
-
-    private $sortBy = 'lastName';          // Sort by... ?
 
     private $sortDir = 'ASC';           // Sort ascending/descending?
 
@@ -958,7 +954,7 @@ class Employee extends Data
                 FROM {$this->tableName}
                 WHERE lastName LIKE :lastName
                 AND deleted = 0
-                ORDER BY {$this->sortBy} {$this->sortDir}
+                ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
 
         $vars = array(':lastName' => $lastName);
@@ -969,7 +965,7 @@ class Employee extends Data
                     FROM {$this->tableName}
                     WHERE phoneticLastName LIKE :lastName
                     AND deleted = 0
-                    ORDER BY {$this->sortBy} {$this->sortDir}
+                    ORDER BY phoneticLastName {$this->sortDir}
                     {$this->limit}";
 
             $vars = array(':lastName' => metaphone($lastName));
@@ -1006,7 +1002,7 @@ class Employee extends Data
                 FROM {$this->tableName}
                 WHERE firstName LIKE :firstName
                 AND deleted = 0
-                ORDER BY {$this->sortBy} {$this->sortDir}
+                ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
 
         $vars = array(':firstName' => $firstName);
@@ -1017,7 +1013,7 @@ class Employee extends Data
                     FROM {$this->tableName}
                     WHERE phoneticFirstName LIKE :firstName
                     AND deleted = 0
-                    ORDER BY {$this->sortBy} {$this->sortDir}
+                    ORDER BY lastName {$this->sortDir}
                     {$this->limit}";
 
             $vars = array(':firstName' => metaphone($firstName));
@@ -1053,7 +1049,7 @@ class Employee extends Data
                 AND lastName LIKE :lastName
                 AND middleName LIKE :middleName
                 AND deleted = 0
-                ORDER BY {$this->sortBy} {$this->sortDir}
+                ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
         }
         else
@@ -1063,7 +1059,7 @@ class Employee extends Data
                 WHERE firstName LIKE :firstName
                 AND lastName LIKE :lastName
                 AND deleted = 0
-                ORDER BY {$this->sortBy} {$this->sortDir}
+                ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
         }
         $result = $this->db->prepared_query($sql, $vars);
@@ -1074,7 +1070,7 @@ class Employee extends Data
                         WHERE phoneticFirstName LIKE :firstName
                         AND phoneticLastName LIKE :lastName
                         AND deleted = 0
-                        ORDER BY {$this->sortBy} {$this->sortDir}
+                        ORDER BY phoneticLastName {$this->sortDir}
                         {$this->limit}";
 
             $vars = array(':firstName' => $this->metaphone_query($firstName), ':lastName' => $this->metaphone_query($lastName));

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1070,7 +1070,7 @@ class Employee extends Data
                         WHERE phoneticFirstName LIKE :firstName
                         AND phoneticLastName LIKE :lastName
                         AND deleted = 0
-                        ORDER BY phoneticLastName {$this->sortDir}
+                        ORDER BY lastName, phoneticLastName {$this->sortDir}
                         {$this->limit}";
 
             $vars = array(':firstName' => $this->metaphone_query($firstName), ':lastName' => $this->metaphone_query($lastName));

--- a/LEAF_Nexus/sources/NationalEmployee.php
+++ b/LEAF_Nexus/sources/NationalEmployee.php
@@ -274,7 +274,7 @@ class NationalEmployee extends NationalData
                         AND phoneticLastName LIKE :lastName
                         AND deleted = 0
                         {$domain}
-                        ORDER BY phoneticLastName {$this->sortDir}
+                        ORDER BY lastName, phoneticLastName {$this->sortDir}
                         {$this->limit}";
 
             $result = $this->db->prepared_query($sql, $vars);

--- a/LEAF_Nexus/sources/NationalEmployee.php
+++ b/LEAF_Nexus/sources/NationalEmployee.php
@@ -31,9 +31,9 @@ class NationalEmployee extends NationalData
 
     private $tableName = 'employee';    // Table of employee contact info
 
-    private $limit = 'LIMIT 3';       // Limit number of returned results "TOP 100"
+    private $cache = array();
 
-    private $sortBy = 'lastName';          // Sort by... ?
+    private $limit = 'LIMIT 3';       // Limit number of returned results "TOP 100"
 
     private $sortDir = 'ASC';           // Sort ascending/descending?
 
@@ -155,7 +155,7 @@ class NationalEmployee extends NationalData
         $sql = "SELECT * FROM {$this->tableName}
                 WHERE lastName LIKE :lastName {$domain}"
                 . $disabled_clause .
-                "ORDER BY {$this->sortBy} {$this->sortDir}
+                "ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
 
 
@@ -167,7 +167,7 @@ class NationalEmployee extends NationalData
             $sql = "SELECT * FROM {$this->tableName}
                     WHERE phoneticLastName LIKE :lastName {$domain}"
                     . $disabled_clause .
-                    "ORDER BY {$this->sortBy} {$this->sortDir}
+                    "ORDER BY phoneticLastName {$this->sortDir}
                     {$this->limit}";
 
             if ($vars[':lastName'] != '')
@@ -207,7 +207,7 @@ class NationalEmployee extends NationalData
         $sql = "SELECT * FROM {$this->tableName}
                 WHERE firstName LIKE :firstName {$domain}"
                 . $disabled_clause .
-                "ORDER BY {$this->sortBy} {$this->sortDir}
+                "ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
 
         $result = $this->db->prepared_query($sql, $vars);
@@ -218,7 +218,7 @@ class NationalEmployee extends NationalData
             $sql = "SELECT * FROM {$this->tableName}
                     WHERE phoneticFirstName LIKE :firstName {$domain}"
                     . $disabled_clause .
-                    "ORDER BY {$this->sortBy} {$this->sortDir}
+                    "ORDER BY lastName {$this->sortDir}
                     {$this->limit}";
 
             if ($vars[':firstName'] != '')
@@ -248,7 +248,7 @@ class NationalEmployee extends NationalData
                 AND middleName LIKE :middleName
                 AND deleted = 0
                 {$domain}
-                ORDER BY {$this->sortBy} {$this->sortDir}
+                ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
         }
         else
@@ -260,7 +260,7 @@ class NationalEmployee extends NationalData
                 AND lastName LIKE :lastName
                 AND deleted = 0
                 {$domain}
-                ORDER BY {$this->sortBy} {$this->sortDir}
+                ORDER BY lastName {$this->sortDir}
                 {$this->limit}";
         }
         $result = $this->db->prepared_query($sql, $vars);
@@ -274,7 +274,7 @@ class NationalEmployee extends NationalData
                         AND phoneticLastName LIKE :lastName
                         AND deleted = 0
                         {$domain}
-                        ORDER BY {$this->sortBy} {$this->sortDir}
+                        ORDER BY phoneticLastName {$this->sortDir}
                         {$this->limit}";
 
             $result = $this->db->prepared_query($sql, $vars);


### PR DESCRIPTION
This improves employee search performance by providing better hints to the SQL query planner.

In a large database such as the national orgchart:

Example Before:
0.45s
```sql
SELECT * from employee
    WHERE phoneticFirstName LIKE "RY%"
        AND phoneticLastName LIKE "F%"
        AND deleted = 0
    ORDER BY lastName ASC
    LIMIT 5
```

Example After:
0.01s
```sql
SELECT * from employee
    WHERE phoneticFirstName LIKE "RY%"
        AND phoneticLastName LIKE "F%"
        AND deleted = 0
    ORDER BY lastName, phoneticLastName ASC
    LIMIT 5
```

### Potential Impact
- Nexus Employee Search
- Employee search field within forms

### Testing
- [x] Nexus employee search works
- [x] Employee search for orgchart_employee fields work
