### PR TITLE
Hotfix remove invalid comparison

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -175,7 +175,7 @@ class FormWorkflow
                         AND `disabled`=0";
         $res = $this->db->prepared_query($query, []);
 
-        // create map
+        // create map of recordIDs with "person designated"
         $dRecords = [];
         foreach($res as $record) {
             $dRecords[$record['recordID']]['data'] = $record['data'];
@@ -183,9 +183,10 @@ class FormWorkflow
         }
 
         $dir = $this->getDirectory();
-        // merge approver data
+        // loop through all srcRecords
         foreach($srcRecords as $i => $v) {
-            if($v['dependencyID'] == -1 && isset($dRecords[$v['recordID']])) {
+            // only process "person designated" records
+            if(isset($dRecords[$v['recordID']])) {
                 if($srcRecords[$i]['isActionable'] == 0) {
                     $srcRecords[$i]['isActionable'] = $this->checkEmployeeAccess($dRecords[$v['recordID']]['data']);
                 }


### PR DESCRIPTION
This resolves an issue where a comparison is made on a non-existent property "dependencyID". It's not necessary to check the dependencyID in this function because the information is already provided in the second function argument (pdRecords).

### Potential Impact
Access rules that involve Person Designated records

### Testing
1. Create a record that routes to a designated person
2. As the designated person AND non-admin, the record should be visible in the Inbox