### PR TITLE
LEAF-4016 - Cache control for JS and CSS files

### DIFF
--- a/docker/nginx/leaf_nginx.conf.template
+++ b/docker/nginx/leaf_nginx.conf.template
@@ -48,7 +48,7 @@ server {
     }
 
     # static files browser caching
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+    location ~* \.(jpg|jpeg|png|gif|ico)$ {
         #how long a browser should wait on checking for new cache
         expires 1m;
         #leave these out of the access log, who cares if someone access the leaf logo at 1245 pm
@@ -64,6 +64,24 @@ server {
         #open_file_cache_errors off;
         #the magic sauce to bust a cache
         etag on;
+    }
+
+    # static files browser caching that impact client runtime
+    location ~* \.(css|js)$ {
+        #leave these out of the access log, who cares if someone access the leaf logo at 1245 pm
+        access_log off;
+        add_header Vary Accept-Encoding;
+        #send the whole file
+        #tcp_nodelay off;
+        #If many changes to the file it can cause the file not to load, waiting the 45s between file changes keeps it
+        #from failing. This should not be too much of an issue on live and helps perf
+        #open_file_cache max=3000 inactive=120s;
+        #open_file_cache_valid 45s;
+        #open_file_cache_min_uses 2;
+        #open_file_cache_errors off;
+        #the magic sauce to bust a cache
+        etag on;
+        add_header Cache-Control "max-age=0, must-revalidate";
     }
 
     location ~ /api/v2/(.*?)$ {


### PR DESCRIPTION
OldTitle: Dev env: Add cache control for css/js files
This implements similar cache control rules developed for Prod, in order to avoid having to clear cache in the dev environment while working on css/js files.

### Potential Impact
Dev environment CSS/JS file delivery

### Testing
1. Load the portal homepage in the Dev environment
2. Open the browser's network debugger and click refresh
3. Note that form.js should have a 304 "Not modified" status code
4. Open the file ./LEAF_Request_Portal/js/form.js, add a * to the end of line 1, and save the file
5. In the browser, click refresh
6. form.js should have a 200 "OK" status code
7. Remove the * from the form.js file, save
8. In the browser, click refresh
9. form.js should have a 200 "OK" status code
10. Click refresh again
11. form.js should have a 304 status code