### PR TITLE
Leaf 4020 - allow admins access to tools

### DIFF
--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -16,6 +16,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
     var actionPreconditionFunc;
     var actionSuccessCallback;
     var rootURL = "";
+    let extraParams;
 
     /**
      * @memberOf LeafWorkflow
@@ -265,16 +266,17 @@ var LeafWorkflow = function (containerID, CSRFToken) {
             padding: "4px",
             resize: "vertical",
         });
-        $("#comment_dep" + step.dependencyID).on('input', function() {
-            let lines = $("#comment_dep" + step.dependencyID).val()?.match(/\n/g);
-            if(lines != null && lines.length > 0) {
+        $("#comment_dep" + step.dependencyID).on("input", function () {
+            let lines = $("#comment_dep" + step.dependencyID)
+                .val()
+                ?.match(/\n/g);
+            if (lines != null && lines.length > 0) {
                 $("#comment_dep" + step.dependencyID).css({
-                    height: (40 + (lines.length - 1) * 16) + "px"
+                    height: 40 + (lines.length - 1) * 16 + "px",
                 });
-            }
-            else {
+            } else {
                 $("#comment_dep" + step.dependencyID).css({
-                    height: "40px"
+                    height: "40px",
                 });
             }
         });
@@ -285,13 +287,13 @@ var LeafWorkflow = function (containerID, CSRFToken) {
         <div class="actions_alignment_left" style="display:flex; flex-wrap:wrap;"></div>
         <div class="actions_alignment_right" style="display:flex; flex-wrap:wrap; justify-content:flex-end"></div>
       </div>`
-    );
-    
-    // draw buttons
-    for (let i in step.dependencyActions) {
-      const icon =
-        step.dependencyActions[i].actionIcon != ""
-          ? `<img src="${rootURL}dynicons/?img=${step.dependencyActions[i].actionIcon}&amp;w=22"
+        );
+
+        // draw buttons
+        for (let i in step.dependencyActions) {
+            const icon =
+                step.dependencyActions[i].actionIcon != ""
+                    ? `<img src="${rootURL}dynicons/?img=${step.dependencyActions[i].actionIcon}&amp;w=22"
             alt="${step.dependencyActions[i].actionText}" style="vertical-align: middle" />`
                     : "";
             const alignment =
@@ -389,7 +391,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         applyAction(data);
                     }
                 };
-              
+
                 if (actionPreconditionFunc !== undefined) {
                     actionPreconditionFunc(e.data, completeAction);
                 } else {
@@ -584,6 +586,14 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                 color: step.stepFontColor,
             });
         }
+    }
+
+    /**
+     * Add extra parameters to the end of the query API URL
+     * @param {string} params
+     */
+    function setExtraParams(params = "") {
+        extraParams = params;
     }
 
     /**
@@ -794,7 +804,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
         currRecordID = recordID;
 
         let masquerade = "";
-        if (window.location.href.indexOf("masquerade=nonAdmin") != -1) {
+        if (extraParams === "masquerade=nonAdmin") {
             masquerade = "?masquerade=nonAdmin";
         }
 
@@ -852,5 +862,6 @@ var LeafWorkflow = function (containerID, CSRFToken) {
         setRootURL: function (url) {
             rootURL = url;
         },
+        setExtraParams,
     };
 };

--- a/LEAF_Request_Portal/templates/form.tpl
+++ b/LEAF_Request_Portal/templates/form.tpl
@@ -29,7 +29,7 @@
     </div>
     <div class="col span_1_of_5" style="float: left">
         <div id="tools" class="tools"><h1 style="font-size: 12px; text-align: center; margin: 0; padding: 2px">Tools</h1>
-            <div id="showSinglePage" role="button" onclick="window.location='?a=printview&amp;recordID=<!--{$recordID}-->&masquerade=nonAdmin'" title="View full form"><img src="dynicons/?img=edit-find-replace.svg&amp;w=32" alt="View full form"  /> Show single page</div>
+            <div id="showSinglePage" role="button" onclick="window.location='?a=printview&amp;recordID=<!--{$recordID}-->'" title="View full form"><img src="dynicons/?img=edit-find-replace.svg&amp;w=32" alt="View full form"  /> Show single page</div>
             <br /><br />
             <button tabindex="0" class="tools" aria-label="Cancel request" onclick="cancelRequest()"><img src="dynicons/?img=process-stop.svg&amp;w=16" alt="Cancel Request" title="Cancel Request" style="vertical-align: middle"/> Cancel Request</button>
         </div>
@@ -85,7 +85,7 @@ function getNext() {
     	if(<!--{$isIframe}-->) {
     		iframeURL = '&iframe=1';
     	}
-        window.location.href="index.php?a=printview&recordID=<!--{$recordID}-->&masquerade=nonAdmin" + iframeURL;
+        window.location.href="index.php?a=printview&recordID=<!--{$recordID}-->" + iframeURL;
     }
 
     return true;

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -227,6 +227,7 @@ function doSubmit(recordID) {
                 $('#submitContent').hide('blind', 500);
                 $('#comments').css({'display': "block"});
                 $('#notes').css({'display': "block"});
+                workflow.setExtraParams('masquerade=nonAdmin');
                 workflow.getWorkflow(recordID);
             } else {
                 let errors = '';


### PR DESCRIPTION
Summary:
Admins entering requests on someone else's behave need to be able to change the initiator without having to update the url or going back to the main page and clicking back into the request. But we also need to retain the masquerade of the workflow so that admins can't very easily just click through when they are not the approver of a step.

Potential Impact:
This should have minimal impact. Most notably an admin user should be able to use the Administrative Tools.

Testing:
Being an admin submit a new request.
Just after submission you should not be able to approve or advance through the workflow, but you should see and be able to use the Administrative Tools.