### PR TITLE
LEAF 4065 update endpoint url

### DIFF
--- a/LEAF_Request_Portal/js/LeafPreview.js
+++ b/LEAF_Request_Portal/js/LeafPreview.js
@@ -86,7 +86,7 @@ var LeafPreview = function(domID) {
     function load(recordID, indicatorID, fileID, callback) {
     	$.ajax({
         	type: 'GET',
-            url: LEAF_NEXUS_URL + 'LEAF/library/file.php?form='+ recordID +'&id='+ indicatorID +'&series=1&file=' + fileID,
+            url: '/' + LEAF_NEXUS_URL + 'LEAF/library/file.php?form='+ recordID +'&id='+ indicatorID +'&series=1&file=' + fileID,
             dataType: 'json',
             xhrFields: {withCredentials: true},
             success: function(res) {


### PR DESCRIPTION
This seems to resolve issues getting details for forms on the portal admin LEAF library page.

Testing
On portal admin LEAF library page:
-'Preview' button should show the first page of the form.
-'Get a Copy' should import the form to the Form Editor.

We currently have limited ability to test this locally, as it requires a library portal with specific form and indicator IDs.  It would more easily be tested once staged.