### PR TITLE
LEAF-4093 - Inbox v2 - Add endpoint check

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -678,6 +678,9 @@
                     else if(site.url.indexOf('/api/open/form/query/') != -1) {
                         site.url = site.url.substring(0, site.url.indexOf('/api/open/form/query/') + 1);
                     }
+                    else if(site.url.indexOf('/open.php?') != -1) {
+                        site.url = site.url.substring(0, site.url.indexOf('/open.php?') + 1);
+                    }
                 });
 
                 // Remove duplicate URLs


### PR DESCRIPTION
This resolves an issue when an admin has added a shortened report URL into the sitemap.

### Potential Impact
Limited to the Inbox's "combined" mode

### Testing
To reproduce the issue:
1. Create a report using the Report Builder
2. Click "Share Report", and copy the shortened URL
3. Go to the Sitemap Editor, add a button with the short URL as a target
4. Load the Combined Inbox. It should have a red error message on the top of the screen.

After this patch, there should not be an error message.
