### PR TITLE
LEAF 4088 - add isDisabled to indicator list x-dataFilter

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -423,7 +423,7 @@ function loadSearchPrereqs() {
     searchPrereqsLoaded = true;
     $.ajax({
         type: 'GET',
-        url: './api/form/indicator/list?x-filterData=name,indicatorID,categoryID,categoryName,parentCategoryID,parentStaples',
+        url: './api/form/indicator/list?x-filterData=name,indicatorID,categoryID,categoryName,parentCategoryID,parentStaples,isDisabled',
         dataType: 'text json',
         success: function(res) {
             var buffer = '';


### PR DESCRIPTION
Adds the string 'isDisabled' to the key names passed to the new x-filterData parameter value so that information about indicator archived status is received.  This information was used to present archived status in the Report Builder Step 2.

Testing:
In the Report Builder, questions that are archived should once again display with a grayed-out background and also have '(Archived)' next to their name/label.

Possible Impact:
None expected.  This value is only used in the Report Builder Step 2 question display, and this change corrects for it currently being undefined.