### PR TITLE
LEAF-4019 - refresh orgchart employees disable

### DIFF
--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -200,6 +200,12 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
 
         $nationalEmpUIDs[] = (int) $orgEmployee['empUID'];
 
+        $weekOld = $orgEmployee['lastUpdated'] + 604800;
+
+        if(time() > $weekOld){
+            $orgEmployee['deleted'] = time();
+        }
+
         $localEmployeeArray[] = [
             'empUID' => (empty($localEmpArray[$orgEmployee['userName']]) ? null : $localEmpArray[$orgEmployee['userName']]),
             'userName' => $orgEmployee['userName'],
@@ -213,6 +219,7 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
             'lastUpdated' => $orgEmployee['lastUpdated']
         ];
     }
+
 
     $localDeletedEmployees = array_diff(array_column($localEmpUIDs, 'userName'), array_column($orgEmployeeRes, 'userName'));
     $deletedEmployeesSql = "UPDATE employee SET deleted=UNIX_TIMESTAMP(NOW()) WHERE userName IN (" . implode(",", array_fill(1, count($localDeletedEmployees), '?')) . ")";

--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -200,12 +200,6 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
 
         $nationalEmpUIDs[] = (int) $orgEmployee['empUID'];
 
-        $weekOld = $orgEmployee['lastUpdated'] + 604800;
-
-        if(time() > $weekOld){
-            $orgEmployee['deleted'] = time();
-        }
-
         $localEmployeeArray[] = [
             'empUID' => (empty($localEmpArray[$orgEmployee['userName']]) ? null : $localEmpArray[$orgEmployee['userName']]),
             'userName' => $orgEmployee['userName'],
@@ -219,7 +213,6 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
             'lastUpdated' => $orgEmployee['lastUpdated']
         ];
     }
-
 
     $localDeletedEmployees = array_diff(array_column($localEmpUIDs, 'userName'), array_column($orgEmployeeRes, 'userName'));
     $deletedEmployeesSql = "UPDATE employee SET deleted=UNIX_TIMESTAMP(NOW()) WHERE userName IN (" . implode(",", array_fill(1, count($localDeletedEmployees), '?')) . ")";

--- a/scripts/disableOldUsers.php
+++ b/scripts/disableOldUsers.php
@@ -1,0 +1,21 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+require_once('timebracketcmd.php');
+echo date('Y-m-d g:i:s a') . "\r\n";
+
+try {
+
+    // in the future stuff like this will be spun off through a different program.
+    // Until then to keep thinks straight forward this could be done in individual files to be called.
+    $test = new TimeBracketCmd('disableOldUsers.php');
+
+    $test->setRunAtExactTime('1 am');
+    $test->run();
+    echo 'end';
+    echo date('Y-m-d g:i:s a') . "\r\n";
+
+} catch (Exception $e) {
+    echo sprintf("Message: %s \r\nFile: %s \r\nLine: %s \r\nTrace: %s\r\n", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString());
+}

--- a/scripts/scheduled-task-commands/disableOldUsers.php
+++ b/scripts/scheduled-task-commands/disableOldUsers.php
@@ -5,25 +5,9 @@ require_once LIB_PATH . '/php-commons/Db.php';
 // national_orgchart for stage/live leaf_user for dev
 $db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_orgchart');
 
-$vars = [
-    ':lastUpdated' => strtotime('-2 weeks')
-    //':lastUpdated' => 1623606681
+$employeeVars = [
+    ':lastUpdated' => strtotime('-1 week'),
+    ':deleted' => time()
 ];
-
-$sql = "SELECT empUID, userName, lastUpdated FROM `employee` Where `lastUpdated` > 0 and `lastUpdated` < :lastUpdated and `deleted` = 0";
-
-$employees = $db->prepared_query($sql,$vars);
-
-// set this all to the same to help with when things were deleted.
-$deletedTime = time();
-foreach( $employees as $employee ){
-
-    // we could use a bit of the logic from checkLastLogin.php to see if the user has been logged in recently. 
-
-    $employeeVars = [
-        ':empUID' => $employee['empUID'],
-        ':deleted' => $deletedTime
-    ];
-    $employeeSql = 'UPDATE `employee` SET `deleted`=:deleted WHERE empUID=:empUID';
-    $db->prepared_query($employeeSql, $employeeVars);
-}
+$employeeSql = 'UPDATE `employee` SET `deleted`=:deleted WHERE `lastUpdated` > 0 and `lastUpdated` < :lastUpdated and `deleted` = 0';
+$db->prepared_query($employeeSql, $employeeVars);

--- a/scripts/scheduled-task-commands/disableOldUsers.php
+++ b/scripts/scheduled-task-commands/disableOldUsers.php
@@ -1,0 +1,29 @@
+<?php
+require_once 'globals.php';
+require_once LIB_PATH . '/php-commons/Db.php';
+
+// national_orgchart for stage/live leaf_user for dev
+$db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_orgchart');
+
+$vars = [
+    ':lastUpdated' => strtotime('-2 weeks')
+    //':lastUpdated' => 1623606681
+];
+
+$sql = "SELECT empUID, userName, lastUpdated FROM `employee` Where `lastUpdated` > 0 and `lastUpdated` < :lastUpdated and `deleted` = 0";
+
+$employees = $db->prepared_query($sql,$vars);
+
+// set this all to the same to help with when things were deleted.
+$deletedTime = time();
+foreach( $employees as $employee ){
+
+    // we could use a bit of the logic from checkLastLogin.php to see if the user has been logged in recently. 
+
+    $employeeVars = [
+        ':empUID' => $employee['empUID'],
+        ':deleted' => $deletedTime
+    ];
+    $employeeSql = 'UPDATE `employee` SET `deleted`=:deleted WHERE empUID=:empUID';
+    $db->prepared_query($employeeSql, $employeeVars);
+}


### PR DESCRIPTION
The auto updater isn’t working correctly, as the national directory might not be updating. When I looked, their account was only marked as “disabled” after manually refreshing. This is a script that does not get sent out the the portals but gets setup in the scripts folder and run.

Issue:

The employee was not found in the ad. The script that runs nightly does not check to see when the last time that user was updated. With the refresh employee button on the orgchart side looks at the last updated time, if it has not been updated within a week it will disable the account.

Testing:
Users who have not been updated in over a set time will be deleted. Right now We have it set for 2 weeks but that time will be reduced to 1 before the final run.

Query to use in testing is below, the < unixtimestamp can be setup usingthe unix timestamp website.
`select * from employee where lastUpdated > 0 and lastUpdated < 1697057318 and deleted = 0`