### PR TITLE
LEAF-4015 - Resolve actionable query issue

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -388,7 +388,7 @@ class FormWorkflow
             if ($res[$i]['isActionable']) {
                 switch($res[$i]['dependencyID']) {
                     case -1: // dependencyID -1 is for a person designated by the requestor
-                        $personDesignatedRecords[$res[$i]['recordID']] = 1;
+                        $personDesignatedRecords[$res[$i]['recordID']][$res[$i]['indicatorID_for_assigned_empUID']] = 1;
                         $personDesignatedIndicators[$res[$i]['indicatorID_for_assigned_empUID']] = 1;
                         break;
                     case -2: // dependencyID -2 is for requestor followup

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -151,12 +151,12 @@ class FormWorkflow
      *          that are related to a "person designated" field AND workflow that utilizes the "person 
      *          designated" feature.
      * @param array $srcRecords list of records
-     * @param array $pdRecords list of record IDs that utilize "person designated"
+     * @param array $pdRecordsMap map of record IDs => indicatorID that utilize "person designated"
      * @param array $pdIndicator list of indicator IDs mapped to "person designated" fields
      * @param bool $skipNames set true to exclude employee lookups
      * @return array Amended records
      */
-    private function includePersonDesignatedData(array $srcRecords, array $pdRecords, array $pdIndicators, bool $skipNames = false): array
+    private function includePersonDesignatedData(array $srcRecords, array $pdRecordsMap, array $pdIndicators, bool $skipNames = false): array
     {
         // sanitize for use in query
         $pdIndicators = array_map(function($x) {
@@ -164,15 +164,17 @@ class FormWorkflow
                         }, $pdIndicators);
         $pdIndicators = implode(',', $pdIndicators);
 
-        $pdRecords = array_map(function($x) {
+        $pdRecordIDs = array_keys($pdRecordsMap);
+        $pdRecordIDs = array_map(function($x) {
                         return (int)$x;
-                    }, $pdRecords);
-        $pdRecords = implode(',', $pdRecords);
+                    }, $pdRecordIDs);
 
-        $query = "SELECT recordID, `data`, `name` FROM `data`
+        $pdRecordIDs = implode(',', $pdRecordIDs);
+
+        $query = "SELECT recordID, `data`, `name`, indicatorID FROM `data`
                     LEFT JOIN indicators USING (indicatorID)
                     WHERE indicatorID IN ({$pdIndicators}) 
-                        AND recordID IN ({$pdRecords})
+                        AND recordID IN ({$pdRecordIDs})
                         AND series=1
                         AND `disabled`=0";
         $res = $this->db->prepared_query($query, []);
@@ -180,8 +182,10 @@ class FormWorkflow
         // create map of recordIDs with "person designated"
         $dRecords = [];
         foreach($res as $record) {
-            $dRecords[$record['recordID']]['data'] = $record['data'];
-            $dRecords[$record['recordID']]['name'] = $record['name'];
+            if(isset($pdRecordsMap[$record['recordID']][$record['indicatorID']])) {
+                $dRecords[$record['recordID']]['data'] = $record['data'];
+                $dRecords[$record['recordID']]['name'] = $record['name'];
+            }
         }
 
         $dir = $this->getDirectory();
@@ -254,7 +258,7 @@ class FormWorkflow
             $res = $this->db->prepared_query($strSQL, []);
         }
 
-        $personDesignatedRecords = []; // map of records using "person designated"
+        $personDesignatedRecords = []; // map of records using "person designated" => associated indicatorID
         $personDesignatedIndicators = []; // map of indicators using "person designated"
         foreach ($res as $depRecord) {
             $depRecordID = $depRecord['recordID'];
@@ -279,7 +283,7 @@ class FormWorkflow
                     break;
 
                 case -1: // dependencyID -1 is for a person designated by the requestor
-                    $personDesignatedRecords[$depRecord['recordID']] = 1;
+                    $personDesignatedRecords[$depRecord['recordID']][$depRecord['indicatorID_for_assigned_empUID']] = 1;
                     $personDesignatedIndicators[$depRecord['indicatorID_for_assigned_empUID']] = 1;
                     break;
 
@@ -318,7 +322,7 @@ class FormWorkflow
         }
 
         if(count($personDesignatedRecords) > 0) {
-            $records = $this->includePersonDesignatedData($records, array_keys($personDesignatedRecords), array_keys($personDesignatedIndicators), true);
+            $records = $this->includePersonDesignatedData($records, $personDesignatedRecords, array_keys($personDesignatedIndicators), true);
         }
 
         return $records;
@@ -429,7 +433,7 @@ class FormWorkflow
                     break;
 
                 case -1: // dependencyID -1 is for a person designated by the requestor
-                    $personDesignatedRecords[$res[$i]['recordID']] = 1;
+                    $personDesignatedRecords[$res[$i]['recordID']][$res[$i]['indicatorID_for_assigned_empUID']] = 1;
                     $personDesignatedIndicators[$res[$i]['indicatorID_for_assigned_empUID']] = 1;
                     break;
 
@@ -486,7 +490,7 @@ class FormWorkflow
         }
 
         if(count($personDesignatedRecords) > 0) {
-            $res = $this->includePersonDesignatedData($res, array_keys($personDesignatedRecords), array_keys($personDesignatedIndicators));
+            $res = $this->includePersonDesignatedData($res, $personDesignatedRecords, array_keys($personDesignatedIndicators));
         }
 
         return $res;


### PR DESCRIPTION
This resolves an issue where a query for actionable records skips certain records in a specific condition.

To reproduce the issue:
1. Create a workflow with two sequential "person designated" steps
2. Create a form with two orgchart_employee fields
3. Map the workflow steps to the form
4. Create request A with the first designated person as the current user, and the second designated person as anyone else
5. Advance request A to the first step
6. Create request B with the first designated person as the current user, and the second designated person as anyone else
7. Advance request B to the second step
8. View the Inbox, we should expect to see request A

### Potential Impact
form/query for actionable records where a "person designated" assignment is involved

### Testing
- [ ] The issue is no longer reproducible with the steps described earlier
- [Experimental automated test added](https://github.com/mgaoVA/LEAF_test_experiments/commit/c4450f008a072a8e16155c7236f059edcded596e#diff-b7b1922b928b6c4ca9f0342a10188972bc7aa07897032f05faff1cb2b96f5234)