### PR TITLE
LEAF 2122 dialog modal and button related issues

### DIFF
--- a/LEAF_Nexus/js/dialogController.js
+++ b/LEAF_Nexus/js/dialogController.js
@@ -34,6 +34,15 @@ function dialogController(containerID, contentID, indicatorID, btnSaveID, btnCan
     $('#' + this.btnCancelID).on('click', function() {
     	t.hide();
     });
+    $('button.ui-dialog-titlebar-close').on('click', function() {
+        t.hide();
+    });
+    const preventCloseOnEnter = (e) => {
+        if(e?.keyCode === 13 && (e?.target?.nodeName || '').toLowerCase() === "input" && e?.target?.type !== 'color') {
+            e.preventDefault();
+        }
+    }
+    $(`#${t.contentID}`).on('keydown', preventCloseOnEnter);
 }
 
 dialogController.prototype.clearDialog = function() {
@@ -52,12 +61,14 @@ dialogController.prototype.hide = function() {
 };
 
 dialogController.prototype.show = function() {
-	if($('#' + this.contentID).html() == '') {
-		$('#' + this.indicatorID).css('visibility', 'visible');
-	}
-	$('#' + this.containerID).dialog('open');
-	$('#' + this.containerID).css('visibility', 'visible');
-	$('input:visible:first, select:visible:first').focus();
+    //Stack clear for some events.  This helps ensure modal content is mounted before trying to set styles.
+    setTimeout(() => {
+        if($('#' + this.contentID).html() == '') {
+            $('#' + this.loadIndicatorID).css('visibility', 'visible');
+        }
+        $('#' + this.containerID).dialog('open');
+        $('#' + this.containerID).css('visibility', 'visible');
+    });
 };
 
 dialogController.prototype.setContent = function(content) {

--- a/LEAF_Nexus/templates/permission_iframe.tpl
+++ b/LEAF_Nexus/templates/permission_iframe.tpl
@@ -31,7 +31,7 @@
         <!--{/if}-->
     <!--{else}-->
 <div style="padding: 4px; color: green">
-    <div onkeypress="triggerClick(event, this.id)" tabindex="0" id="editpermissions" class="buttonNorm" onclick="window.open('index.php?a=view_permissions&amp;indicatorID=<!--{$indicatorID|strip_tags|escape}-->&amp;UID=<!--{$UID|strip_tags|escape}-->','Orgchart','width=840,resizable=yes,scrollbars=yes,menubar=yes').focus();">
+    <div onkeydown="triggerClick(event, this.id)" tabindex="0" id="editpermissions" class="buttonNorm" onclick="window.open('index.php?a=view_permissions&amp;indicatorID=<!--{$indicatorID|strip_tags|escape}-->&amp;UID=<!--{$UID|strip_tags|escape}-->','Orgchart','width=840,resizable=yes,scrollbars=yes,menubar=yes').focus();">
     <img src="dynicons/?img=emblem-system.svg&amp;w=32" alt="Icon" style="vertical-align: middle" />
     You have access to <u>Edit Permissions</u> for this field.</div>
     <!--{/if}-->

--- a/LEAF_Nexus/templates/print_subindicators.tpl
+++ b/LEAF_Nexus/templates/print_subindicators.tpl
@@ -21,9 +21,9 @@
       <div id="mainblock_<!--{$indicator.indicatorID|strip_tags|escape}-->_<!--{$uid}-->" class="printmainblock<!--{if ($indicator.required == 0 && $indicator.data == '') || $indicator.format == 'json'}--> notrequired<!--{/if}-->">
         <div class="printmainlabel">
             <!--{if $indicator.required == 1 && $indicator.isEmpty == true}-->
-                <div role="button" tabindex="0" id="PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->" class="printheading_missing" style="cursor: pointer" onkeypress="triggerClick(event, 'PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->')" onclick="orgchartForm.getForm(<!--{$uid|strip_tags|escape}-->, <!--{$categoryID|strip_tags|escape}-->, <!--{$indicator.indicatorID|strip_tags|escape}-->);">
+                <div role="button" tabindex="0" id="PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->" class="printheading_missing" style="cursor: pointer" onkeydown="triggerClick(event, 'PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->')" onclick="orgchartForm.getForm(<!--{$uid|strip_tags|escape}-->, <!--{$categoryID|strip_tags|escape}-->, <!--{$indicator.indicatorID|strip_tags|escape}-->);">
             <!--{else}-->
-                <div role="button" tabindex="0" id="PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->" class="printheading" style="cursor: pointer" onkeypress="triggerClick(event, 'PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->')" onclick="orgchartForm.getForm(<!--{$uid|strip_tags|escape}-->, <!--{$categoryID|strip_tags|escape}-->, <!--{$indicator.indicatorID|strip_tags|escape}-->);">
+                <div role="button" tabindex="0" id="PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->" class="printheading" style="cursor: pointer" onkeydown="triggerClick(event, 'PHindicator_<!--{$indicator.indicatorID|strip_tags|escape}-->')" onclick="orgchartForm.getForm(<!--{$uid|strip_tags|escape}-->, <!--{$categoryID|strip_tags|escape}-->, <!--{$indicator.indicatorID|strip_tags|escape}-->);">
             <!--{/if}-->
             <div style="float: left">
             <!--{if $date < $indicator.timestamp && $date > 0}-->
@@ -68,7 +68,7 @@
     <!--{/foreach}-->
     </div>
 
-    <span role="button" tabindex="0" class="tempText" id="showallfields" style="float: right; text-decoration: underline; font-size: 80%; cursor: pointer" onkeypress="triggerClick(event, 'showallfields')" onclick="showAllFields(); announceAction('showing all fields');">Show_all_fields</span>
+    <span role="button" tabindex="0" class="tempText" id="showallfields" style="float: right; text-decoration: underline; font-size: 80%; cursor: pointer" onkeydown="triggerClick(event, 'showallfields')" onclick="showAllFields(); announceAction('showing all fields');">Show_all_fields</span>
     <br />
     <!--{/if}-->
 <!--{/strip}-->

--- a/LEAF_Nexus/templates/view_group.tpl
+++ b/LEAF_Nexus/templates/view_group.tpl
@@ -37,7 +37,7 @@
 <div id="toolbar" class="toolbar_right toolbar noprint">
     <div id="tools"><h1 role="heading" tabindex="0">Options</h1>
         <!--{if array_search('service', $tags) !== false}-->
-        <div onkeypress="triggerClickViewOrgchart(event)" role="button" id="view_orgchart"><a id="view_orgchart_link" href="?a=navigator&amp;rootID=<!--{$groupLeader|sanitize}-->"></a><img src="dynicons/?img=preferences-system-windows.svg&amp;w=32" style="vertical-align: middle" alt="View Org Chart" title="View Org Chart" /> View in Org Chart</div>
+        <div onkeydown="triggerClickViewOrgchart(event)" role="button" id="view_orgchart"><a id="view_orgchart_link" href="?a=navigator&amp;rootID=<!--{$groupLeader|sanitize}-->"></a><img src="dynicons/?img=preferences-system-windows.svg&amp;w=32" style="vertical-align: middle" alt="View Org Chart" title="View Org Chart" /> View in Org Chart</div>
         <br />
         <!--{/if}-->
         <button class="options" onclick="editGroupName()" style="width: 100%"><img src="dynicons/?img=edit-select-all.svg&amp;w=32" style="vertical-align: middle" alt="Edit" title="Edit" /> Edit Group Name</button>
@@ -51,7 +51,7 @@
     <div class="toolbar_tags"><h1 role="heading" tabindex="0">Tags</h1>
         <div class="tags">
             <!--{foreach $tags as $tag}-->
-            <button class="buttonNorm" style="width: 100%" aria-label="<!--{$tag}-->. Click to delete tag" tabindex="0" onkeypress="triggerClick(event, this.id)" onclick="confirmDeleteTag('<!--{$tag}-->')"><!--{$tag}--></button>
+            <button class="buttonNorm" style="width: 100%" aria-label="<!--{$tag}-->. Click to delete tag" tabindex="0" onkeydown="triggerClick(event, this.id)" onclick="confirmDeleteTag('<!--{$tag}-->')"><!--{$tag}--></button>
             <!--{/foreach}-->
             <!--{if $groupPrivileges[$groupID].write == 1}-->
             <br /><br />

--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -14,6 +14,10 @@ let vueData = {
     indicatorID: 0,
     updateIndicatorList: false
 }
+function updateVueData(indicatorID) {
+    vueData.indicatorID = parseInt(indicatorID);
+    document.getElementById('btn-vue-update-trigger').dispatchEvent(new Event("click"));
+}
 
 //variables used within this scope, type, and approx. locations of def/redef (if applicable)
 const CSRFToken = '<!--{$CSRFToken}-->';
@@ -115,8 +119,8 @@ function editProperties(isSubForm) {
     if(isSubForm) {
         $('.isSubForm').css('display', 'none');
     }
-    //ie11 fix
-    setTimeout(function () {dialog.show();}, 0);
+
+    dialog.show();
 
     // load workflow data
     dialog.indicateBusy();
@@ -305,7 +309,7 @@ function openContent(url) {
         workflow = '<span style="color: red">No workflow. Users will not be able to select this form.</span>';
     }
     $("#formEditor_content").html('<div style="padding: 8px; border: 1px solid black; background-color: white">' +
-    		                      '<div style="float: right"><div id="editFormData" tabindex="0" onkeypress="onKeyPressClick(event)" class="buttonNorm">Edit Properties</div><br /><div tabindex="0" id="editFormPermissions" onkeypress="onKeyPressClick(event)" onclick="editPermissions();" class="buttonNorm">Edit Collaborators</div></div>' +
+    		                      '<div style="float: right"><div id="editFormData" tabindex="0" onkeydown="onKeyPressClick(event)" class="buttonNorm">Edit Properties</div><br /><div tabindex="0" id="editFormPermissions" onkeydown="onKeyPressClick(event)" onclick="editPermissions();" class="buttonNorm">Edit Collaborators</div></div>' +
     		                      '<div style="padding: 8px">' +
     		                          '<b aria-label="'+ formTitle +'" tabindex="0" title="categoryID: '+ currCategoryID +'">' + formTitle + '</b><br /><span tabindex="0">' +
     		                          categories[currCategoryID].categoryDescription +
@@ -381,10 +385,8 @@ function addPermission(categoryID) {
             cache: false
         });
     });
-    //ie11 fix
-    setTimeout(function () {
-        dialog.show();
-    }, 0);
+
+    dialog.show();
 }
 
 /**
@@ -422,19 +424,17 @@ function editPermissions() {
 		success: function(res) {
 			let buffer = '<ul>';
 			for(let i in res) {
-				buffer += '<li>' + res[i].name + ' [ <a href="#" tabindex="0" onkeypress="onKeyPressClick(event);" onclick="removePermission(\''+ res[i].groupID +'\');">Remove</a> ]</li>';
+				buffer += '<li>' + res[i].name + ' [ <a href="#" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="removePermission(\''+ res[i].groupID +'\');">Remove</a> ]</li>';
 			}
 			buffer += '</ul>';
-			buffer += '<span tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="addPermission(currCategoryID);" role="button">Add Group</span>';
+			buffer += '<span tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="addPermission(currCategoryID);" role="button">Add Group</span>';
 			$('#formPrivs').html(buffer);
 			dialog_simple.indicateIdle();
 		},
 		cache: false
 	});
-	//ie11 fix
-	setTimeout(function () {
-		dialog_simple.show();
-	}, 0);
+
+	dialog_simple.show();
 
 }
 
@@ -527,12 +527,12 @@ function editIndicatorPrivileges(indicatorID) {
                     let count = 0;
                     for (let group in groups) {
                         if (groups[group].id !== undefined) {
-                            buffer += '<li>' + groups[group].name + ' [ <a href="#" tabindex="0" onkeypress="onKeyPressClick(event);" onclick="removeIndicatorPrivilege(' + indicatorID + ',' + groups[group].id + ');">Remove</a> ]</li>';
+                            buffer += '<li>' + groups[group].name + ' [ <a href="#" tabindex="0" onkeydown="onKeyPressClick(event);" onclick="removeIndicatorPrivilege(' + indicatorID + ',' + groups[group].id + ');">Remove</a> ]</li>';
                             count++;
                         }
                     }
                     buffer += '</ul>';
-                    buffer += `<span tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="addIndicatorPrivilege(${indicatorID},'${indicatorName}');">Add Group</span>`;
+                    buffer += `<span tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="addIndicatorPrivilege(${indicatorID},'${indicatorName}');">Add Group</span>`;
                     let statusMessage = "Special access restrictions are not enabled. Normal access rules apply.";
                     if(count > 0) {
                         statusMessage = "Special access restrictions are enabled!";
@@ -564,11 +564,6 @@ function makeColumnID(){
 /**
  * Purpose: common listener methods
  */
-function preventEnterDefault(event) {
-    if(event.keyCode === 13) {
-        event.preventDefault();
-    }
-}
 function onKeyPressClick(event){
     if(event.keyCode === 13) {
         $(event.target).trigger('click');
@@ -587,7 +582,7 @@ function getIndicatorModalTemplate(isEditingModal = false) {
         </tr>
         <tr>
             <td>Archive</td>
-            <td colspan="1"><input id="archived" name="disable_or_delete" type="checkbox" value="archived" onkeypress="onKeyPressClick(event)" /></td>
+            <td colspan="1"><input id="archived" name="disable_or_delete" type="checkbox" value="archived" onkeydown="onKeyPressClick(event)" /></td>
             <td style="width: 275px;">
                 <span id="archived-warning" style="color: red; visibility: hidden;">
                 This field will be archived.  It can be<br/>re-enabled by using <a href="?a=disabled_fields" target="_blank">Restore Fields</a>.
@@ -596,14 +591,14 @@ function getIndicatorModalTemplate(isEditingModal = false) {
         </tr>
         <tr>
             <td>Delete</td>
-            <td colspan="1"><input id="deleted" name="disable_or_delete" type="checkbox" value="deleted" onkeypress="onKeyPressClick(event)" /></td>
+            <td colspan="1"><input id="deleted" name="disable_or_delete" type="checkbox" value="deleted" onkeydown="onKeyPressClick(event)" /></td>
             <td style="width: 275px;">
                 <span id="deletion-warning" style="color: red; visibility: hidden;">
                 Deleted items can only be re-enabled<br/>within 30 days by using <a href="?a=disabled_fields" target="_blank">Restore Fields</a>.
                 </span>
             </td>
         </tr>`;
-    const advancedOptions = `<span id="button_advanced" class="buttonNorm" tabindex="0" onkeypress="onKeyPressClick(event)">Advanced Options</span>
+    const advancedOptions = `<span id="button_advanced" class="buttonNorm" tabindex="0" onkeydown="onKeyPressClick(event)">Advanced Options</span>
         <div>
             <fieldset id="advanced" style="visibility: collapse; height: 0;"><legend>Advanced Options</legend>
                 Template Variables:<br />
@@ -686,11 +681,11 @@ function getIndicatorModalTemplate(isEditingModal = false) {
             <table>
                 <tr>
                     <td>Required</td>
-                    <td colspan="2" style="width: 300px;"><input id="required" name="required" type="checkbox" onkeypress="onKeyPressClick(event)" /></td>
+                    <td colspan="2" style="width: 300px;"><input id="required" name="required" type="checkbox" onkeydown="onKeyPressClick(event)" /></td>
                 </tr>
                 </tr>
                     <td>Sensitive Data (PHI/PII)</td>
-                    <td colspan="2"><input id="sensitive" name="sensitive" type="checkbox" onkeypress="onKeyPressClick(event)" /></td>
+                    <td colspan="2"><input id="sensitive" name="sensitive" type="checkbox" onkeydown="onKeyPressClick(event)" /></td>
                 </tr>
                 <tr>
                     <td>Sort Priority</td>
@@ -798,15 +793,12 @@ function renderFormatEntryUI(indFormat, formatOptionsStr = '', gridCols = 0) {
 function addIndicatorModalListeners(isEditingModal = false) {
     //all indicator modals have format render, description, required, sensitive and raw/adv (text formatter)
     $('#indicatorType').on('change', event => renderFormatEntryUI(event.target.value));
-    $('#description').on('keypress', preventEnterDefault);
-    $('#required').on('keypress', preventEnterDefault);
     $('#required').on('click', function() {
         if($('#indicatorType').val() == '') {
             $('#required').prop('checked', false);
             alert('You can\'t mark a field as required if the Input Format is "None".');
         }
     });
-    $('#sensitive').on('keypress', preventEnterDefault);
     $('#sensitive').on('click', function() {
         if($('#indicatorType').val() == '') {
             $('#sensitive').prop('checked', false);
@@ -838,7 +830,6 @@ function addIndicatorModalListeners(isEditingModal = false) {
         });
     });
     if (isEditingModal === true) {  //archive, delete, advanced options
-        $('#archived').on('keypress', preventEnterDefault);
         $('#archived').on('change', function(event) {
             if($(this).is(':checked')) {
                 $('#deleted').prop('checked', false);
@@ -849,7 +840,6 @@ function addIndicatorModalListeners(isEditingModal = false) {
                 $('#archived-warning').css('visibility','hidden');
             }
         });
-        $('#deleted').keypress(preventEnterDefault);
         $('#deleted').on("change", function(event) {
             if($(this).is(':checked')) {
                 $('#archived').prop('checked', false);
@@ -937,10 +927,7 @@ function newQuestion(parentIndicatorID = null) {
     dialog.setTitle(title);
     dialog.setContent(getIndicatorModalTemplate(false));
     addIndicatorModalListeners(false);
-    //ie11 fix
-    setTimeout(function () {
-        dialog.show();
-    }, 0);
+    dialog.show();
     dialog.setSaveHandler(function() {
     	let isRequired = $('#required').is(':checked') ? 1 : 0;
         let isSensitive = $('#sensitive').is(':checked') ? 1 : 0;
@@ -1241,7 +1228,7 @@ function deleteColumn(event){
     columns = columns - 1;
     $('#tableStatus').attr('aria-label', 'Row ' + columnDeleted + ' removed, ' + $(tbody).children().length + ' total.');
 
-    //ie11 fix
+    //stack clear
     setTimeout(function () {
         focus.focus();
     }, 0);
@@ -1807,10 +1794,7 @@ function mergeForm(categoryID) {
         });
     });
 
-		//ie11 fix
-		setTimeout(function () {
-			dialog.show();
-		}, 0);
+	dialog.show();
 
 }
 
@@ -1845,20 +1829,17 @@ function mergeFormDialog(categoryID) {
         success: function(res) {
             let buffer = '<ul>';
             for(let i in res) {
-                buffer += '<li>' + res[i].categoryName + ' [ <a href="#" onkeypress="onKeyPressClick(event)" onclick="unmergeForm(\''+ categoryID +'\', \''+ res[i].stapledCategoryID +'\');">Remove</a> ]</li>';
+                buffer += '<li>' + res[i].categoryName + ' [ <a href="#" onkeydown="onKeyPressClick(event)" onclick="unmergeForm(\''+ categoryID +'\', \''+ res[i].stapledCategoryID +'\');">Remove</a> ]</li>';
             }
             buffer += '</ul>';
-            buffer += '<span class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="mergeForm(\''+ categoryID +'\');" tabindex="0" role="button">Select a form to merge</span>';
+            buffer += '<span class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="mergeForm(\''+ categoryID +'\');" tabindex="0" role="button">Select a form to merge</span>';
             $('#mergedForms').html(buffer);
             dialog_simple.indicateIdle();
         },
         cache: false
     });
-		//ie11 fix
-		setTimeout(function () {
-				dialog_simple.show();
-		}, 0);
 
+	dialog_simple.show();
 }
 
 /**
@@ -1947,10 +1928,7 @@ function deleteForm() {
 		});
 	});
 
-	//ie11 fix
-	setTimeout(function () {
-		dialog_confirm.show();
-	}, 0);
+	dialog_confirm.show();
 
 }
 
@@ -1959,8 +1937,8 @@ function deleteForm() {
  * @param categoryID
  */
 function buildMenu(categoryID) {
-	$('#menu').html('<div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="postRenderFormBrowser = null; showFormBrowser(); fetchFormSecureInfo();" role="button"><img src="../dynicons/?img=system-file-manager.svg&w=32" alt="View All Forms" /> View All Forms</div><br />');
-	$('#menu').append('<div tabindex="0" id="'+ categoryID +'" class="buttonNorm" onkeypress="onKeyPressClick(event)" role="button"><img src="../dynicons/?img=document-open.svg&w=32" alt="Open Form" />'+ categories[categoryID].categoryName +'</div>');
+	$('#menu').html('<div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="postRenderFormBrowser = null; showFormBrowser(); fetchFormSecureInfo();" role="button"><img src="../dynicons/?img=system-file-manager.svg&w=32" alt="View All Forms" /> View All Forms</div><br />');
+	$('#menu').append('<div tabindex="0" id="'+ categoryID +'" class="buttonNorm" onkeydown="onKeyPressClick(event)" role="button"><img src="../dynicons/?img=document-open.svg&w=32" alt="Open Form" />'+ categories[categoryID].categoryName +'</div>');
     $('#' + categoryID).on('click', function(categoryID) {
         return function() {
             $('#menu>div').removeClass('buttonNormSelected');
@@ -1972,7 +1950,7 @@ function buildMenu(categoryID) {
 
 	for(let i in categories) {
 		if(categories[i].parentID == categoryID) {
-			$('#menu').append('<div tabindex="0" id="'+ categories[i].categoryID +'" onkeypress="onKeyPressClick(event)" class="buttonNorm" role="button"><img src="../dynicons/?img=text-x-generic.svg&w=32" alt="Open Form" /> '+ categories[i].categoryName +'</div>');
+			$('#menu').append('<div tabindex="0" id="'+ categories[i].categoryID +'" onkeydown="onKeyPressClick(event)" class="buttonNorm" role="button"><img src="../dynicons/?img=text-x-generic.svg&w=32" alt="Open Form" /> '+ categories[i].categoryName +'</div>');
             $('#' + categories[i].categoryID).on('click', function(categoryID) {
                 return function() {
                     $('#menu>div').removeClass('buttonNormSelected');
@@ -1984,12 +1962,12 @@ function buildMenu(categoryID) {
 		}
 	}
 
-	$('#menu').append('<div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event);" onclick="createForm(\''+ categoryID +'\');" role="button"><img src="../dynicons/?img=list-add.svg&w=32" alt="Create Form" /> Add Internal-Use</div><br />');
+	$('#menu').append('<div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event);" onclick="createForm(\''+ categoryID +'\');" role="button"><img src="../dynicons/?img=list-add.svg&w=32" alt="Create Form" /> Add Internal-Use</div><br />');
 
-    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event);" onclick="mergeFormDialog(\''+ categoryID +'\');" role="button"><img src="../dynicons/?img=tab-new.svg&w=32" alt="Staple Form" /> Staple other form</div>\
+    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event);" onclick="mergeFormDialog(\''+ categoryID +'\');" role="button"><img src="../dynicons/?img=tab-new.svg&w=32" alt="Staple Form" /> Staple other form</div>\
                           <div id="stapledArea"></div><br />');
 
-    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event);" onclick="viewHistory(\''+ categoryID +'\');" role="button"><img src="../dynicons/?img=appointment.svg&amp;w=32" alt="View History" /> View History</div>\
+    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event);" onclick="viewHistory(\''+ categoryID +'\');" role="button"><img src="../dynicons/?img=appointment.svg&amp;w=32" alt="View History" /> View History</div>\
                         <div id="viewHistory"></div><br />');
 
 
@@ -2010,9 +1988,9 @@ function buildMenu(categoryID) {
     });
 
 
-	$('#menu').append('<br /><div tabindex="0"class="buttonNorm" onkeypress="onKeyPressClick(event)"onclick="exportForm(\''+ categoryID +'\');"role="button"><img src="../dynicons/?img=network-wireless.svg&w=32" alt="Export Form" /> Export Form</div><br />');
-    $('#menu').append('<br /><div class="buttonNorm" onclick="deleteForm();"><img src="../dynicons/?img=user-trash.svg&w=32" alt="Delete Form" /> Delete this form</div>');
-    $('#menu').append('<br /><br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="window.location = \'?a=disabled_fields\';" role="button"><img src="../dynicons/?img=user-trash-full.svg&w=32" alt="Restore fields" /> Restore Fields</div>');
+	$('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="exportForm(\''+ categoryID +'\');"role="button"><img src="../dynicons/?img=network-wireless.svg&w=32" alt="Export Form" /> Export Form</div><br />');
+    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="deleteForm();"><img src="../dynicons/?img=user-trash.svg&w=32" alt="Delete Form" /> Delete this form</div>');
+    $('#menu').append('<br /><br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="window.location = \'?a=disabled_fields\';" role="button"><img src="../dynicons/?img=user-trash-full.svg&w=32" alt="Restore fields" /> Restore Fields</div>');
 	$('#' + categoryID).addClass('buttonNormSelected');
 }
 
@@ -2031,10 +2009,10 @@ function selectForm(categoryID) {
  */
 function showFormBrowser() {
     window.location = '#';
-    $('#menu').html('<div tabindex="0" role="button" class="buttonNorm" onkeypress="onKeyPressClick(event)" id="createFormButton" onclick="createForm();"><img src="../dynicons/?img=document-new.svg&w=32" alt="Create Form" /> Create Form</div><br />');
-    $('#menu').append('<div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="formLibrary();" role="button"><img src="../dynicons/?img=system-file-manager.svg&w=32" alt="Import Form" /> LEAF Library</div><br />');
-    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="importForm();" role="button"><img src="../dynicons/?img=package-x-generic.svg&w=32" alt="Import Form" /> Import Form</div><br />');
-    $('#menu').append('<br /><br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="window.location = \'?a=disabled_fields\';" role="button"><img src="../dynicons/?img=user-trash-full.svg&w=32" alt="Restore fields" /> Restore Fields</div>');
+    $('#menu').html('<div tabindex="0" role="button" class="buttonNorm" onkeydown="onKeyPressClick(event)" id="createFormButton" onclick="createForm();"><img src="../dynicons/?img=document-new.svg&w=32" alt="Create Form" /> Create Form</div><br />');
+    $('#menu').append('<div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="formLibrary();" role="button"><img src="../dynicons/?img=system-file-manager.svg&w=32" alt="Import Form" /> LEAF Library</div><br />');
+    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="importForm();" role="button"><img src="../dynicons/?img=package-x-generic.svg&w=32" alt="Import Form" /> Import Form</div><br />');
+    $('#menu').append('<br /><br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="window.location = \'?a=disabled_fields\';" role="button"><img src="../dynicons/?img=user-trash-full.svg&w=32" alt="Restore fields" /> Restore Fields</div>');
     $.ajax({
         type: 'GET',
         url: '../api/formStack/categoryList/all',
@@ -2058,7 +2036,7 @@ function showFormBrowser() {
                         formActiveID = '#forms_inactive';
                     }
                     const workflow = res[i].description != null ? 'Workflow: ' + res[i].description : '';
-                    $(formActiveID).append('<div tabindex="0"  onkeypress="onKeyPressClick(event)" class="formPreview formLibraryID_'+ res[i].formLibraryID +'" id="'+ res[i].categoryID +'" title="'+ res[i].categoryID +'">\
+                    $(formActiveID).append('<div tabindex="0"  onkeydown="onKeyPressClick(event)" class="formPreview formLibraryID_'+ res[i].formLibraryID +'" id="'+ res[i].categoryID +'" title="'+ res[i].categoryID +'">\
                             <div class="formPreviewTitle">'+ formTitle + needToKnow + '</div>\
                             <div class="formPreviewDescription">'+ res[i].categoryDescription +'</div>\
                             <div class="formPreviewStatus">'+ availability +'</div>\
@@ -2264,11 +2242,8 @@ function createForm(parentID) {
                                 <td><textarea tabindex="0" id="description" maxlength="255"></textarea></td>\
                             </tr>\
                         </table>');
-            //ie11 fix
-        setTimeout(function () {
-            dialog.show();
-        }, 0);
 
+    dialog.show();
 
     dialog.setSaveHandler(function() {
         let categoryName = $('#name').val();

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -803,10 +803,7 @@ function getGroupList() {
                                 }(res[i].userName));
                                 counter++;
                             }
-
-                            setTimeout(function () {
-                                dialog.show();
-                            }, 0);
+                            dialog.show();
                         } else {
                             displayDialogOk(response.status['message']);
                         }
@@ -873,10 +870,7 @@ function getGroupList() {
 
                                 dialog.hide();
                             });
-
-                            setTimeout(function () {
-                                dialog.show();
-                            }, 0);
+                            dialog.show();
                         } else {
                             displayDialogOk(response.status['message']);
                         }

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -1,27 +1,27 @@
 <div id="sideBar" style="float: left; width: 180px">
-    <div id="btn_createStep" class="buttonNorm" onclick="createStep();" style="font-size: 120%; display: none"
+    <div id="btn_createStep" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="createStep();" style="font-size: 120%; display: none"
         role="button" tabindex="0"><img src="../dynicons/?img=list-add.svg&w=32" alt="Add Step" /> Add Step</div><br />
     Workflows: <br />
     <div id="workflowList"></div>
     <br />
-    <div id="btn_newWorkflow" class="buttonNorm" onclick="newWorkflow();" style="font-size: 120%" role="button"
+    <div id="btn_newWorkflow" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="newWorkflow();" style="font-size: 120%" role="button"
         tabindex="0"><img src="../dynicons/?img=list-add.svg&w=32" alt="New Workflow" /> New Workflow</div><br />
     <br />
-    <div id="btn_deleteWorkflow" class="buttonNorm" onclick="deleteWorkflow();" style="font-size: 120%; display: none"
+    <div id="btn_deleteWorkflow" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="deleteWorkflow();" style="font-size: 120%; display: none"
         role="button" tabindex="0"><img src="../dynicons/?img=list-remove.svg&w=16" alt="Delete workflow" /> Delete
         workflow</div><br />
-    <div id="btn_listActionType" class="buttonNorm" onclick="listActionType();" style="font-size: 120%; display: none"
+    <div id="btn_listActionType" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="listActionType();" style="font-size: 120%; display: none"
         role="button" tabindex="0">Edit Actions</div><br />
-    <div id="btn_listEvents" class="buttonNorm" onclick="listEvents();" style="font-size: 120%; display: none"
+    <div id="btn_listEvents" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="listEvents();" style="font-size: 120%; display: none"
         role="button" tabindex="0">Edit Events</div><br />
-    <div id="btn_viewHistory" class="buttonNorm" onclick="viewHistory();" style="font-size: 120%; display: none;"
+    <div id="btn_viewHistory" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="viewHistory();" style="font-size: 120%; display: none;"
         role="button" tabindex="0"><img src="../dynicons/?img=appointment.svg&amp;w=32" alt="View History" /> View
         History</div><br />
-    <div id="btn_renameWorkflow" class="buttonNorm" onclick="renameWorkflow();" style="font-size: 120%; display: none;"
+    <div id="btn_renameWorkflow" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="renameWorkflow();" style="font-size: 120%; display: none;"
         role="button" tabindex="0"><img src="../dynicons/?img=accessories-text-editor.svg&amp;w=32"
             alt="Rename Workflow" /> Rename
         Workflow</div>
-    <div id="btn_duplicateWorkflow" class="buttonNorm" onclick="duplicateWorkflow();" style="font-size: 100%; display: none; margin-top: 10px;"
+    <div id="btn_duplicateWorkflow" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="duplicateWorkflow();" style="font-size: 100%; display: none; margin-top: 10px;"
         role="button" tabindex="0"><img src="../dynicons/?img=edit-copy.svg&amp;w=32"
             alt="Duplicate Workflow" /> Duplicate
         Workflow</div>
@@ -38,12 +38,6 @@
 <script type="text/javascript">
     var CSRFToken = '<!--{$CSRFToken}-->';
 
-    //508
-    $("#btn_newWorkflow").on('keypress', function(event) {
-        if (event.keyCode == 13) {
-            newWorkflow();
-        }
-    });
     function isJSON(input = '') {
         try {
             JSON.parse(input);
@@ -51,6 +45,12 @@
             return false;
         }
         return true;
+    }
+    /* mediate keydown listeners on this page for enter key */
+    function onKeyPressClick(event) {
+        if(event.keyCode === 13) {
+            $(event.target).trigger('click');
+        }
     }
 
     function newWorkflow() {
@@ -956,8 +956,7 @@
 
                 buffer += '</select></div>';
                 buffer +=
-                    '<br /><br /><br /><br /><div>If a requirement does not exist: <span tabindex=0 class="buttonNorm" onkeydown="if (event.which === 13) { newDependency(' +
-                    stepID + '); }" onclick="newDependency(' + stepID +
+                    '<br /><br /><br /><br /><div>If a requirement does not exist: <span tabindex=0 class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="newDependency(' + stepID +
                     ')">Create a new requirement</span></div>';
                 $('#dependencyList').html(buffer);
                 $('#dependencyID').chosen({disable_search_threshold: 5});
@@ -1344,7 +1343,7 @@
 
                 buffer += '</select>';
                 buffer +=
-                    '<br />- OR -<br /><br /><span class="buttonNorm" onclick="newAction();">Create a new Action Type</span>';
+                    '<br />- OR -<br /><br /><span class="buttonNorm" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="newAction();">Create a new Action Type</span>';
 
                 dialog.indicateIdle();
                 dialog.setContent(buffer);
@@ -1435,15 +1434,15 @@
             for (let i in res) {
                 output += '<li><b title="' + res[i].eventID + '">' + res[i].eventType + ' - ' + res[i]
                     .eventDescription +
-                    '</b> <img src="../dynicons/?img=dialog-error.svg&w=16" style="cursor: pointer" onclick="unlinkEvent(' +
+                    '</b> <img tabindex=0 onkeydown="onKeyPressClick(event)" src="../dynicons/?img=dialog-error.svg&w=16" style="cursor: pointer" onclick="unlinkEvent(' +
                     currentWorkflow + ', ' + stepID + ', \'' + params.action + '\', \'' + res[i]
                     .eventID + '\')" alt="Remove Action" title="Remove Action" /></li>';
             }
-            output += '<li style="padding-top: 8px"><span class="buttonNorm" id="event_' +
-                currentWorkflow + '_' + stepID + '_' + params.action + '">Add Event</span>';
+            output += '<li style="padding-top: 8px"><span tabindex=0 class="buttonNorm" id="event_' +
+                currentWorkflow + '_' + stepID + '_' + params.action + '" onkeydown="onKeyPressClick(event)">Add Event</span>';
             output += '</ul></div>';
             output +=
-                '<hr /><div style="padding: 4px"><span class="buttonNorm" onclick="removeAction(' +
+                '<hr /><div style="padding: 4px"><span class="buttonNorm" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="removeAction(' +
                 currentWorkflow + ', ' + stepID + ', ' + params.nextStepID + ', \'' + params.action +
                 '\')">Remove Action</span></div>';
             $('#stepInfo_' + stepID).html(output);
@@ -1667,21 +1666,21 @@
                     url: '../api/workflow/step/' + stepID + '/dependencies',
                     success: function(res) {
                         var control_removeStep =
-                            '<img style="cursor: pointer" src="../dynicons/?img=dialog-error.svg&w=16" onclick="removeStep(' +
+                            '<img style="cursor: pointer" src="../dynicons/?img=dialog-error.svg&w=16" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="removeStep(' +
                             stepID + ')" alt="Remove" />';
                         let output = '<h2>stepID: #' + stepID + ' ' + control_removeStep +
                             '</h2><br />Step: <b>' + steps[stepID].stepTitle +
-                            '</b> <img style="cursor: pointer" src="../dynicons/?img=accessories-text-editor.svg&w=16" onclick="editStep(' +
+                            '</b> <img style="cursor: pointer" src="../dynicons/?img=accessories-text-editor.svg&w=16" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="editStep(' +
                             stepID + ')" alt="Edit Step" /><br />';
 
                         output += '<br /><br /><div>Requirements:<ul>';
                         var tDeps = {};
                         for (let i in res) {
                             control_editDependency =
-                                '<img style="cursor: pointer" src="../dynicons/?img=accessories-text-editor.svg&w=16" onclick="editRequirement(' +
+                                '<img style="cursor: pointer" src="../dynicons/?img=accessories-text-editor.svg&w=16" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="editRequirement(' +
                                 res[i].dependencyID + ')" alt="Edit Requirement" />';
                             control_unlinkDependency =
-                                '<img style="cursor: pointer" src="../dynicons/?img=dialog-error.svg&w=16" onclick="unlinkDependency(' +
+                                '<img style="cursor: pointer" src="../dynicons/?img=dialog-error.svg&w=16" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="unlinkDependency(' +
                                 stepID + ', ' + res[i].dependencyID + ')" alt="Remove" />';
                             if (res[i].dependencyID == 1) { // special case for service chief and quadrad
                                 output += '<li><b style="color: green">' + res[i].description + '</b> ' +
@@ -1705,7 +1704,7 @@
                                     control_unlinkDependency + ' (depID: ' + res[i].dependencyID + ')<ul>' +
                                     indicatorWarning + '<li>indicatorID: ' + res[i]
                                     .indicatorID_for_assigned_empUID +
-                                    '<br /><div class="buttonNorm" onclick="setDynamicApprover(' + res[i]
+                                    '<br /><div class="buttonNorm" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="setDynamicApprover(' + res[i]
                                     .stepID + ')">Set Data Field</div></li></ul></li>';
                             } else if (res[i].dependencyID == -2) { // dependencyID -2 : requestor followup
                                 output += '<li><b style="color: green">' + res[i].description + '</b> ' +
@@ -1722,17 +1721,17 @@
                                     control_unlinkDependency + ' (depID: ' + res[i].dependencyID + ')<ul>' +
                                     indicatorWarning + '<li>indicatorID: ' + res[i]
                                     .indicatorID_for_assigned_groupID +
-                                    '<br /><div class="buttonNorm" onclick="setDynamicGroupApprover(' + res[
+                                    '<br /><div class="buttonNorm" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="setDynamicGroupApprover(' + res[
                                         i].stepID + ')">Set Data Field</div></li></ul></li>';
                             } else {
                                 if (tDeps[res[i].dependencyID] == undefined) { //
                                     tDeps[res[i].dependencyID] = 1;
                                     output += '<li style="padding-bottom: 8px"><b title="depID: ' + res[i]
-                                        .dependencyID + '" onclick="dependencyGrantAccess(' + res[i]
+                                        .dependencyID + '" tabindex=0 onkeydown="onKeyPressClick(event)" onclick="dependencyGrantAccess(' + res[i]
                                         .dependencyID + ')">' + res[i].description + '</b> ' +
                                         control_editDependency + ' ' + control_unlinkDependency +
                                         '<ul id="step_' + stepID + '_dep' + res[i].dependencyID +
-                                        '"><li style="padding-top: 8px"><span class="buttonNorm" onclick="dependencyGrantAccess(' +
+                                        '"><li style="padding-top: 8px"><span tabindex=0 onkeydown="onKeyPressClick(event)" class="buttonNorm" onclick="dependencyGrantAccess(' +
                                         res[i].dependencyID + ')"><img src="../dynicons/?img=list-add.svg&w=16" alt="Add" /> Add Group</span></li>\
                                 </ul></li>';
                                 }
@@ -1772,11 +1771,10 @@
                             }
                         }
                         output +=
-                            '<hr /><div style="padding: 4px; display:flex;"><span tabindex=0 class="buttonNorm" onkeydown="if (event.which == 13) { linkDependencyDialog(' +
-                            stepID + '); }" onclick="linkDependencyDialog(' + stepID +
+                            '<hr /><div style="padding: 4px; display:flex;"><span tabindex=0 class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="linkDependencyDialog(' + stepID +
                             ')">Add Requirement</span>';
                         output +=
-                            '<span class="buttonNorm" style="margin-left: auto;" onclick="addEmailReminderDialog(' +
+                            '<span tabindex=0 class="buttonNorm" style="margin-left: auto;" onkeydown="onKeyPressClick(event)" onclick="addEmailReminderDialog(' +
                             stepID + ')">Email Reminder</span></div>';
 
                         $('#stepInfo_' + stepID).html(output);
@@ -1792,7 +1790,7 @@
                                 $('#step_' + stepID + '_dep' + res[i].dependencyID).prepend(
                                     '<li><span style="white-space: nowrap"><b title="groupID: ' + res[i]
                                     .groupID + '">' + res[i].name +
-                                    '</b> <img style="cursor: pointer" src="../dynicons/?img=dialog-error.svg&w=16" onclick="dependencyRevokeAccess(' +
+                                    '</b> <img tabindex=0 onkeydown="onKeyPressClick(event)" style="cursor: pointer" src="../dynicons/?img=dialog-error.svg&w=16" onclick="dependencyRevokeAccess(' +
                                     res[i].dependencyID + ', ' + res[i].groupID +
                                     ')" alt="Remove" /></span></li>');
                                 counter++;
@@ -1968,19 +1966,6 @@
         $('#btn_viewHistory').css('display', 'block');
         $('#btn_renameWorkflow').css('display', 'block');
         $('#btn_duplicateWorkflow').css('display', 'block');
-
-        //508
-        $('#btn_createStep').on('keypress', function(event) {
-            if (event.keyCode == 13) {
-                createStep();
-            }
-        });
-
-        $('#btn_deleteWorkflow').on('keypress', function(event) {
-            if (event.keyCode == 13) {
-                deleteWorkflow();
-            }
-        });
 
         currentWorkflow = workflowID;
         jsPlumb.reset();

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2081,7 +2081,7 @@
             type: 'GET',
             url: '../api/workflow',
             success: function(res) {
-                let output = '<select id="workflows" style="width: 100%">';
+                let output = '<select tabindex=0 id="workflows" style="width: 100%">';
                 var count = 0;
                 var firstWorkflowID = 0;
                 let firstWorkflowDescription = '';

--- a/LEAF_Request_Portal/admin/templates/print_form_ajax.tpl
+++ b/LEAF_Request_Portal/admin/templates/print_form_ajax.tpl
@@ -2,5 +2,5 @@
 
 <div class="printmainform">
     <!--{include file="print_subindicators.tpl" form=$form orgchartPath=$orgchartPath}-->
-    <div class="buttonNorm" role="button" tabindex="0" onkeypress="onKeyPressClick(event)" onclick="newQuestion(null);"><img src="../dynicons/?img=list-add.svg&amp;w=16" alt="Add Section Heading" title="Add Section Heading"/> Add Section Heading</div>
+    <div class="buttonNorm" role="button" tabindex="0" onkeydown="onKeyPressClick(event)" onclick="newQuestion(null);"><img src="../dynicons/?img=list-add.svg&amp;w=16" alt="Add Section Heading" title="Add Section Heading"/> Add Section Heading</div>
 </div>

--- a/LEAF_Request_Portal/admin/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/admin/templates/print_subindicators.tpl
@@ -35,7 +35,7 @@
             <!--{if $indicator.is_sensitive == 1}-->
                 &nbsp;<img src="../dynicons/?img=eye_invisible.svg&amp;w=16" alt="This field is sensitive" title="This field is sensitive" />&nbsp;
             <!--{/if}-->
-                <span onkeypress="keyPressGetForm(event, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" tabindex="0" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)">
+                <span onkeydown="onKeyPressClick(event)" tabindex="0" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)">
             <!--{if trim($indicator.name) != ''}-->
                 <!--{$indicator.name|sanitizeRichtext|strip_tags}-->
             <!--{else}-->
@@ -43,8 +43,8 @@
             <!--{/if}-->
                 </span>
 
-            &nbsp;<img src="../dynicons/?img=accessories-text-editor.svg&amp;w=16" tabindex="0" onkeypress="keyPressGetForm(event, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" alt="Edit this field" title="Edit this field" style="cursor: pointer" />
-            &nbsp;<img src="../dynicons/?img=emblem-readonly.svg&amp;w=16" tabindex="0" onkeypress="keyPressEditIndicatorPrivileges(event, <!--{$indicator.indicatorID}-->)" onclick="editIndicatorPrivileges(<!--{$indicator.indicatorID}-->);" alt="Edit indicator privileges" title="Edit indicator privileges" style="cursor: pointer" />
+            &nbsp;<img src="../dynicons/?img=accessories-text-editor.svg&amp;w=16" tabindex="0" onkeydown="onKeyPressClick(event)" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" alt="Edit this field" title="Edit this field" style="cursor: pointer" />
+            &nbsp;<img src="../dynicons/?img=emblem-readonly.svg&amp;w=16" tabindex="0" onkeydown="onKeyPressClick(event)" onclick="editIndicatorPrivileges(<!--{$indicator.indicatorID}-->);" alt="Edit indicator privileges" title="Edit indicator privileges" style="cursor: pointer" />
             <!--{if $indicator.has_code}-->
                 &nbsp;<img src="../dynicons/?img=document-properties.svg&amp;w=16" tabindex="0" alt="Advanced Options present" title="Advanced Options present" style="cursor: pointer" />
             <!--{/if}-->
@@ -61,7 +61,7 @@
                     <!--{if $indicator.is_sensitive == 1}-->
                         &nbsp;<img src="../dynicons/?img=eye_invisible.svg&amp;w=16" alt="This field is sensitive" title="This field is sensitive" />&nbsp;
                     <!--{/if}-->
-                    <span onkeypress="keyPressGetForm(event, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" tabindex="0" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)">
+                    <span onkeydown="onKeyPressClick(event)" tabindex="0" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)">
                     <!--{if trim($indicator.name) != ''}-->
                         <!--{$indicator.name|sanitizeRichtext|strip_tags|indent:$depth:""}-->
                     <!--{else}-->
@@ -69,15 +69,15 @@
                     <!--{/if}-->
                     </span>
 
-                    &nbsp;<img src="../dynicons/?img=accessories-text-editor.svg&amp;w=16" tabindex="0" onkeypress="keyPressGetForm(event, <!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" alt="Edit this field" title="Edit this field" style="cursor: pointer" />
-                    &nbsp;<img src="../dynicons/?img=emblem-readonly.svg&amp;w=16" tabindex="0" onkeypress="keyPressEditIndicatorPrivileges(event, <!--{$indicator.indicatorID}-->)" onclick="editIndicatorPrivileges(<!--{$indicator.indicatorID}-->);" alt="Edit indicator privileges" title="Edit indicator privileges" style="cursor: pointer" />
+                    &nbsp;<img src="../dynicons/?img=accessories-text-editor.svg&amp;w=16" tabindex="0" onkeydown="onKeyPressClick(event)" onclick="getForm(<!--{$indicator.indicatorID}-->, <!--{$indicator.series}-->)" alt="Edit this field" title="Edit this field" style="cursor: pointer" />
+                    &nbsp;<img src="../dynicons/?img=emblem-readonly.svg&amp;w=16" tabindex="0" onkeydown="onKeyPressClick(event)" onclick="editIndicatorPrivileges(<!--{$indicator.indicatorID}-->);" alt="Edit indicator privileges" title="Edit indicator privileges" style="cursor: pointer" />
                     <!--{if $indicator.format|in_array:['text','dropdown','multiselect','radio', 'checkboxes', '', 'fileupload', 'image', 'textarea', 'orgchart_employee', 'orgchart_group', 'orgchart_position']}-->
-                        &nbsp;<img id="edit_conditions_<!--{$indicator.indicatorID}-->" src="../dynicons/?img=preferences-system.svg&amp;w=16" tabindex="0" onkeypress="updateVueData(<!--{$indicator.indicatorID}-->)" onclick="updateVueData(<!--{$indicator.indicatorID}-->,<!--{$indicator.required}-->);" alt="Edit Conditions" title="Edit conditions" style="cursor: pointer" />
+                        &nbsp;<img id="edit_conditions_<!--{$indicator.indicatorID}-->" src="../dynicons/?img=preferences-system.svg&amp;w=16" tabindex="0" onkeydown="onKeyPressClick(event)" onclick="updateVueData(<!--{$indicator.indicatorID}-->,<!--{$indicator.required}-->);" alt="Edit Conditions" title="Edit conditions" style="cursor: pointer" />
                     <!--{/if}-->
                     <!--{if $indicator.has_code}-->
                         &nbsp;<img src="../dynicons/?img=document-properties.svg&amp;w=16" tabindex="0" alt="Advanced Options present" title="Advanced Options present" style="cursor: pointer" />
                     <!--{/if}-->
-                <br /><br /><span tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" onclick="newQuestion(<!--{$indicator.indicatorID}-->);"><img src="../dynicons/?img=list-add.svg&amp;w=16" alt="Add Sub-question" title="Add Sub-question"/> Add Sub-question</span>
+                <br /><br /><span tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="newQuestion(<!--{$indicator.indicatorID}-->);"><img src="../dynicons/?img=list-add.svg&amp;w=16" alt="Add Sub-question" title="Add Sub-question"/> Add Sub-question</span>
                 </span>
         <!--{/if}-->
             </div>
@@ -123,26 +123,3 @@
     <br />
     <!--{/if}-->
 <!--{/strip}-->
-<script>
-function keyPressGetForm(evt, indicatorID, series) {
-    if(evt.keyCode == 13) {
-        getForm(indicatorID, series);
-    }
-}
-
-function onKeyPressClick(e){
-    if((e.keyCode ? e.keyCode : e.which) === 13){
-        $(e.target).trigger('click');
-    }
-}
-function updateVueData(indicatorID) {
-    vueData.indicatorID = parseInt(indicatorID);
-    document.getElementById('btn-vue-update-trigger').dispatchEvent(new Event("click"));
-}
-
-function keyPressEditIndicatorPrivileges(evt, indicatorID) {
-    if(evt.keyCode == 13) {
-        editIndicatorPrivileges(<!--{$indicator.indicatorID}-->);
-    }
-}
-</script>

--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -39,6 +39,15 @@ function dialogController(containerID, contentID, loadIndicatorID, btnSaveID, bt
     $('#' + this.btnCancelID).on('click', function() {
     	t.hide();
     });
+    $('button.ui-dialog-titlebar-close').on('click', function() {
+        t.hide();
+    });
+    const preventCloseOnEnter = (e) => {
+        if(e?.keyCode === 13 && (e?.target?.nodeName || '').toLowerCase() === "input" && e?.target?.type !== 'color') {
+            e.preventDefault();
+        }
+    }
+    $(`#${t.contentID}`).on('keydown', preventCloseOnEnter);
 }
 
 dialogController.prototype.clear = function() {
@@ -62,11 +71,14 @@ dialogController.prototype.hide = function() {
 };
 
 dialogController.prototype.show = function() {
-	if($('#' + this.contentID).html() == '') {
-		$('#' + this.loadIndicatorID).css('visibility', 'visible');
-	}
-	$('#' + this.containerID).dialog('open');
-	$('#' + this.containerID).css('visibility', 'visible');
+    //Stack clear for some events.  This helps ensure modal content is mounted before trying to set styles.
+    setTimeout(() => {
+        if($('#' + this.contentID).html() == '') {
+            $('#' + this.loadIndicatorID).css('visibility', 'visible');
+        }
+        $('#' + this.containerID).dialog('open');
+        $('#' + this.containerID).css('visibility', 'visible');
+    });
 };
 
 dialogController.prototype.setContent = function(content) {
@@ -77,11 +89,13 @@ dialogController.prototype.setContent = function(content) {
 
 dialogController.prototype.indicateBusy = function() {
     $('#' + this.loadIndicatorID).css('visibility', 'visible');
+    $('#' + this.loadIndicatorID).css('height', 'auto');
     $('#' + this.btnSaveID).css('visibility', 'hidden');
 };
 
 dialogController.prototype.indicateIdle = function() {
     $('#' + this.loadIndicatorID).css('visibility', 'hidden');
+    $('#' + this.loadIndicatorID).css('height', '1px');
     $('#' + this.btnSaveID).css('visibility', 'visible');
 };
 

--- a/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
+++ b/LEAF_Request_Portal/js/vue_conditions_editor/LEAF_conditions_editor.js
@@ -85,6 +85,7 @@ const ConditionsEditor = Vue.createApp({
     clearSelections(resetAll = false) {
       //cleared when either the form or child indicator changes
       if (resetAll) {
+        this.childIndID = 0;
         this.vueData.indicatorID = 0;
         this.showConditionEditor = false;
       }
@@ -750,6 +751,16 @@ const ConditionsEditor = Vue.createApp({
         prefill: this.savedConditions.filter(i => i.selectedOutcome.toLowerCase() === "pre-fill"),
         crosswalk: this.savedConditions.filter(i => i.selectedOutcome.toLowerCase() === "crosswalk"),
       };
+    }
+  },
+  watch: {
+    childIndID(newVal, oldVal) {
+      setTimeout(() => {
+        const elNew = document.querySelector('#condition_editor_inputs .btnNewCondition');
+        if(+newVal > 0 && elNew !== null) {
+          elNew.focus();
+        }
+      });
     }
   },
   template: `<div id="condition_editor_content" :style="{display: vueData.indicatorID===0 ? 'none' : 'block'}">

--- a/LEAF_Request_Portal/templates/form.tpl
+++ b/LEAF_Request_Portal/templates/form.tpl
@@ -125,7 +125,7 @@ function updateProgress(focusNext=false) {
                 $('#progressLabel').text(response + '%');
             }
             else {
-                savechange = '<div tabindex="0" class="buttonNorm" onkeypress="if(event.keyCode === 13){ manualSaveChange(); }" onclick="manualSaveChange();"><div id="save_indicator"><img src="dynicons/?img=media-floppy.svg&amp;w=22" alt="save" style="vertical-align: middle" /> Save Change</div></button>';
+                savechange = '<div tabindex="0" class="buttonNorm" onkeydown="if(event.keyCode === 13){ manualSaveChange(); }" onclick="manualSaveChange();"><div id="save_indicator"><img src="dynicons/?img=media-floppy.svg&amp;w=22" alt="save" style="vertical-align: middle" /> Save Change</div></button>';
                 $('#progressControl').html(savechange);
             }
             window.scrollTo(0,0);
@@ -236,7 +236,7 @@ $(function() {
                 else {
                     description = formStructure[i].desc;
                 }
-                buffer += '<div tabindex="0" id="q'+ i +'" class="buttonNorm question" style="border: 0px" onclick="currFormPosition='+i+';treeClick('+ formStructure[i].indicatorID +', '+ formStructure[i].series +');" onkeypress="onKeyPressClick(event)">' + counter + '. ' + description + '</div>';
+                buffer += '<div tabindex="0" id="q'+ i +'" class="buttonNorm question" style="border: 0px" onclick="currFormPosition='+i+';treeClick('+ formStructure[i].indicatorID +', '+ formStructure[i].series +');" onkeydown="onKeyPressClick(event)">' + counter + '. ' + description + '</div>';
                 counter++;
             }
             $('#navtree').html(buffer);

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -309,10 +309,7 @@ function doSubmit(recordID) {
     }
 
     function getForm(indicatorID, series) {
-        //ie11 fix
-        setTimeout(function() {
-            form.dialog().show();
-        }, 0);
+        form.dialog().show();
         form.setPostModifyCallback(function() {
             getIndicator(indicatorID, series);
             updateProgress();
@@ -326,10 +323,7 @@ function doSubmit(recordID) {
             'Modifications made to this field:<table class="agenda" style="background-color: white"><thead><tr><th>Date/Author</th><th>Data</th></tr></thead><tbody id="history_' +
             indicatorID + '"></tbody></table>');
         dialog_message.indicateBusy();
-        //ie11 fix
-        setTimeout(function() {
-            dialog_message.show();
-        }, 0);
+        dialog_message.show();
 
         $.ajax({
             type: 'GET',

--- a/LEAF_Request_Portal/templates/print_form_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_form_ajax.tpl
@@ -3,7 +3,7 @@
 <div class="printmainform" style="border-bottom: 0px; min-height: 64px">
     <div id="requestTitle"><!--{$title|sanitize}--> <!--{$subtype|sanitize}-->
     <!--{if $submitted == 0 || $is_admin}-->
-        <img src="dynicons/?img=accessories-text-editor.svg&amp;w=16" style="cursor: pointer" alt="Edit Title" title="Edit Title" onclick="changeTitle()" tabindex="0" role="button" onkeypress="if (event.keyCode==13){ changeTitle(); }" />
+        <img src="dynicons/?img=accessories-text-editor.svg&amp;w=16" style="cursor: pointer" alt="Edit Title" title="Edit Title" onclick="changeTitle()" tabindex="0" role="button" onkeydown="if (event.keyCode==13){ changeTitle(); }" />
     <!--{/if}-->
 
     <br /><span style="font-weight: normal; color: #686868; font-style: italic"><!--{$categoryText|sanitize}--></span>
@@ -15,7 +15,7 @@
                 </td>
                 <td><b><!--{$service|sanitize}--></b>
                     <!--{if $submitted == 0}-->
-                        <img src="dynicons/?img=accessories-text-editor.svg&amp;w=16" style="cursor: pointer" alt="Edit Service" title="Edit Service" onclick="changeService()" role="button" tabindex="0" onkeypress="if (event.keyCode==13){ changeService(); }"/>
+                        <img src="dynicons/?img=accessories-text-editor.svg&amp;w=16" style="cursor: pointer" alt="Edit Service" title="Edit Service" onclick="changeService()" role="button" tabindex="0" onkeydown="if (event.keyCode==13){ changeService(); }"/>
                     <!--{/if}-->
                 </td>
             </tr>

--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -36,7 +36,7 @@
             <!--{/if}-->
             <div style="float: right">
             <!--{if $date < $indicator.timestamp && $date > 0}-->
-                <img src="dynicons/?img=appointment.svg&amp;w=16" alt="View History" title="View History" style="cursor: pointer" onclick="getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->)" tabindex="0" role="button" onkeypress="if (event.keyCode==13){ getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->); }"/>&nbsp;
+                <img src="dynicons/?img=appointment.svg&amp;w=16" alt="View History" title="View History" style="cursor: pointer" onclick="getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->)" tabindex="0" role="button" onkeydown="if (event.keyCode==13){ getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->); }"/>&nbsp;
             <!--{/if}-->
             <!--{if $indicator.isWritable == 0}-->
                 <img src="dynicons/?img=emblem-readonly.svg&amp;w=16" alt="Read-only" title="Read-only" tabindex="0" role="button" />
@@ -63,7 +63,7 @@
                 <span class="printsubheading" title="indicatorID: <!--{$indicator.indicatorID|strip_tags}-->"><!--{$indicator.name|sanitizeRichtext|strip_tags|indent:$depth:""}--></span>
             <!--{/if}-->
             <!--{if $date < $indicator.timestamp && $date > 0}-->
-                &nbsp;<img src="dynicons/?img=appointment.svg&amp;w=16" alt="View History" title="View History" style="cursor: pointer" onclick="getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->)" tabindex="0" role="button" onkeypress="if (event.keyCode==13){ getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->); }"/>
+                &nbsp;<img src="dynicons/?img=appointment.svg&amp;w=16" alt="View History" title="View History" style="cursor: pointer" onclick="getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->)" tabindex="0" role="button" onkeydown="if (event.keyCode==13){ getIndicatorLog(<!--{$indicator.indicatorID|strip_tags}-->, <!--{$indicator.series|strip_tags}-->); }"/>
             <!--{/if}-->
         <!--{/if}-->
             </div>

--- a/LEAF_Request_Portal/templates/reports/LEAF_Sitemap_Search.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Sitemap_Search.tpl
@@ -831,10 +831,7 @@ function showJSONendpoint() {
 
  function changeTitle(form_data, current_title) {
     dialog.setContent('<label for="recordTitle"><b>Report Title</b></label><br/><input type="text" id="recordTitle" style="width: 250px" name="recordTitle" value="' + current_title + '" /><input type="hidden" id="CSRFToken" name="CSRFToken" value="<!--{$CSRFToken}-->" />');
-  //ie11 fix
-  setTimeout(function () {
     dialog.show();
-  }, 0);
     dialog.setSaveHandler(function() {
         $.ajax({
             type: 'POST',

--- a/LEAF_Request_Portal/templates/view_inbox.tpl
+++ b/LEAF_Request_Portal/templates/view_inbox.tpl
@@ -17,7 +17,7 @@ The following is a list of requests that are pending your action:
 <!--{if count($errors) == 0}-->
 <!--{foreach from=$inbox item=dep}-->
 <br /><br />
-<table onKeypress="toggleDepVisibilityKeypress(event, '<!--{$dep.dependencyID|strip_tags}-->', '<!--{$CSRFToken}-->')" tabindex="0" id="depTitle_<!--{$dep.dependencyID}-->" class="agenda" style="width: 100%; margin: 0px auto">
+<table onkeydown="toggleDepVisibilityKeypress(event, '<!--{$dep.dependencyID|strip_tags}-->', '<!--{$CSRFToken}-->')" tabindex="0" id="depTitle_<!--{$dep.dependencyID}-->" class="agenda" style="width: 100%; margin: 0px auto">
     <div aria-live="assertive" id="depTitle_<!--{$dep.dependencyID}-->_announce"></div>
     <tr style="background-color: <!--{$dep.dependencyBgColor|strip_tags}-->; cursor: pointer"  onclick="toggleDepVisibility('<!--{$dep.dependencyID|strip_tags}-->', '<!--{$CSRFToken}-->')">
       <th colspan="3">

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -939,10 +939,7 @@ function showJSONendpoint() {
 
  function changeTitle(form_data, current_title) {
     dialog.setContent('<label for="recordTitle"><b>Report Title</b></label><br/><input type="text" id="recordTitle" style="width: 250px" name="recordTitle" value="' + current_title + '" /><input type="hidden" id="CSRFToken" name="CSRFToken" value="<!--{$CSRFToken}-->" />');
-  //ie11 fix
-  setTimeout(function () {
     dialog.show();
-  }, 0);
     dialog.setSaveHandler(function() {
         $.ajax({
             type: 'POST',


### PR DESCRIPTION
***Summary of changes***

-Delegated a listener to dialogController content to prevent default behavior for input elements if the enter key is pressed.

-Added listener to dialogController X(close) button so that it behaves the same way as the Cancel button.

-Wrapped dialogController show() method's content with a setTimeout 0 to consistently clear JS stack before trying to apply styles.  Added comment for clarification (there were prior comments suggesting this was related to older browsers when it is not) and removed some repetitive setTimeout wrappers around this modal show call.

-Deprecated onkeypress listener was replaced with onkeydown.


other:
The dialogController js file is currently in two places (one nexus, and one portal), and seem to have diverged somewhat - this is better addressed during other upcoming JS moves.
Multiple methods had been used to mediate keypress events in form and workflow editor.  These were updated to use the same method where possible.  Added tabindex and keydown events where missing (mostly Workflow Editor).
Added a focus fix for the ifthen dialog modal.



***Impact / testing ***
Effects should be limited to keypress events.

Pressing Enter within a dialog modal input element field should not close the modal or cause other unexpected behavior.

The 'enter' key (in some cases spacebar) should continue to activate elements that have keydown events (eg edit forms questions, menu divs/spans with button roles etc).  Activation should be limited to these keys.