### PR TITLE
LEAF-4119: Prevent invalid query

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3943,12 +3943,15 @@ class Form
         }
         $indicatorList = trim($indicatorList, ',');
 
-        $res = $this->db->query(
-            'SELECT indicatorID, name, format
-                FROM indicators
-                WHERE indicatorID IN ('. $indicatorList .')'
-            );
-        return $res;
+        $return = [];
+        if($indicatorList != '') {
+            $return = $this->db->query(
+                'SELECT indicatorID, name, format
+                    FROM indicators
+                    WHERE indicatorID IN ('. $indicatorList .')'
+                );
+        }
+        return $return;
     }
 
     /**


### PR DESCRIPTION
This patch prevents an invalid query and Error 500 due to an unchecked variable. It's a rare and low-impact issue because the user would have to be testing an incomplete configuration of the Parallel Workflow feature in order to trigger the error.

### Potential Impact
API endpoint: ./api/form/[RECORD_ID]/workflow/indicator/assigned

### Testing
- [Experimental automated test added](https://github.com/mgaoVA/LEAF_test_experiments/commit/0429b7c777e2c2c60457c8d2f6c1d7fc0083e0d7)

Procedures:
- Precondition: Request's workflow only has a single "requestor followup" step
1. In dev env: Attempt to access https://localhost/LEAF_Request_Portal/api/form/RECORD_ID/workflow/indicator/assigned , where RECORD_ID is the ID of the request
2. You should expect to see this output in the Raw Data:
```
[]
```