### PR TITLE
LEAF-4120: Update filter

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3424,7 +3424,7 @@ class Form
 
         if(isset($_GET['debugQuery'])) {
             if($this->login->checkGroup(1)) {
-                $debugQuery = str_replace(["\r", "\n","\t", "%0d","%0a","%09","%20", ":", ";", "="], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
+                $debugQuery = str_replace(["\r", "\n","\t", "%0d","%0a","%09","%20", ";"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
                 $debugVars = [];
                 foreach($vars as $key => $value) {
                     if(strpos($key, ':data') !== false


### PR DESCRIPTION
This amends a filter used in the form/query when the debugQuery URL argument is present. The filter is meant to scrub unsafe characters in a HTTP header, however the characters ":" and "=" should be safe to use in this context.

### Potential Impact
Partially reverses commit c4f8dfc relating to HTTP header injection

### Testing
Security: It should not be possible to overwrite previously defined headers.