### PR TITLE
LEAF-4121: Fulltext search

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -223,6 +223,13 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   }
 
   /**
+   * encodeReadableURI provides minimal character URI encoding, prioritizing readible URLs
+   */
+  function encodeReadableURI(url) {
+      return url.replace('+', '%2b');
+  }
+
+  /**
    * Execute search query in chunks
    * @param {number} limitOffset Used in subsequent recursive calls to track current offset
    * @returns Promise resolving to query response
@@ -244,7 +251,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
     const urlParamJSONP = useJSONP ? "&format=jsonp" : "";
     return $.ajax({
       type: "GET",
-      url: `${rootURL}api/form/query?q=${queryUrl + extraParams + urlParamJSONP}`,
+      url: `${rootURL}api/form/query?q=${encodeReadableURI(queryUrl + extraParams + urlParamJSONP)}`,
       dataType: dataType,
       error: (err) => console.log(err)
     }).then((res, resStatus, resJqXHR) => {
@@ -288,7 +295,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
     const urlParamJSONP = useJSONP ? "&format=jsonp" : "";
     return $.ajax({
       type: "GET",
-      url: `${rootURL}api/form/query?q=${queryUrl + extraParams + urlParamJSONP}`,
+      url: `${rootURL}api/form/query?q=${encodeReadableURI(queryUrl + extraParams + urlParamJSONP)}`,
       dataType: dataType,
       success: successCallback,
       error: (err) => console.log(err)

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -271,9 +271,7 @@ var LeafFormSearch = function (containerID) {
                                 $(
                                     "#" + prefixID + "widgetCod_" + widgetID
                                 ).trigger("chosen:updated");
-                                $("#" + prefixID + "widgetMat_" + widgetID).val(
-                                    match.replace(/\*/g, "")
-                                );
+                                $("#" + prefixID + "widgetMat_" + widgetID).val(match);
                                 $(
                                     "#" + prefixID + "widgetMat_" + widgetID
                                 ).trigger("chosen:updated");
@@ -290,7 +288,7 @@ var LeafFormSearch = function (containerID) {
                     renderWidget(i);
                 }
                 $("#" + prefixID + "widgetCod_" + i).val(advSearch[i].operator);
-                if (typeof advSearch[i].match == "string") {
+                if (typeof advSearch[i].match == "string" && advSearch[i].operator.indexOf('MATCH') == -1) {
                     $("#" + prefixID + "widgetMat_" + i).val(
                         advSearch[i].match.replace(/\*/g, "")
                     );
@@ -1010,7 +1008,8 @@ var LeafFormSearch = function (containerID) {
                                             "widgetCod_" +
                                             widgetID +
                                             '" class="chosen" aria-label="condition" style="width: 120px">\
-										<option value="LIKE">CONTAINS</option>\
+                                        <option value="MATCH ALL">CONTAINS</option>\
+										<option value="LIKE">CONTAINS FRAGMENT</option>\
 										<option value="NOT LIKE">DOES NOT CONTAIN</option>\
 					            		<option value="=">=</option>\
 										<option value="!=">!=</option>\
@@ -1366,6 +1365,7 @@ var LeafFormSearch = function (containerID) {
                                 }
                             }
                         );
+                        $("#" + prefixID + "widgetIndicator_" + widgetID).trigger("chosen:updated"); // trigger render on first load
                         $(
                             "#" +
                                 prefixID +

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -1037,12 +1037,10 @@ var LeafFormSearch = function (containerID) {
                                             widgetID +
                                             '" class="chosen" aria-label="condition" style="width: 120px">\
                                         <option value="MATCH ALL">CONTAINS</option>\
-                                        <option value="NOT MATCH">DOES NOT CONTAIN</option>\
                                         <option value="MATCH">CONTAINS EITHER</option>\
 					            		<option value="=">=</option>\
 										<option value="!=">!=</option>\
 										<option value="LIKE">HAS FRAGMENT</option>\
-                                        <option value="NOT LIKE">DOES NOT HAVE FRAGMENT</option>\
 					            	</select>'
                                     );
                                     $(

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -271,7 +271,14 @@ var LeafFormSearch = function (containerID) {
                                 $(
                                     "#" + prefixID + "widgetCod_" + widgetID
                                 ).trigger("chosen:updated");
-                                $("#" + prefixID + "widgetMat_" + widgetID).val(match);
+
+                                if(operator.indexOf('MATCH') == -1) {
+                                    $("#" + prefixID + "widgetMat_" + widgetID).val(match.replace(/\*/g, ""));
+                                }
+                                else {
+                                    $("#" + prefixID + "widgetMat_" + widgetID).val(match);
+                                }
+
                                 $(
                                     "#" + prefixID + "widgetMat_" + widgetID
                                 ).trigger("chosen:updated");

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -634,6 +634,9 @@ var LeafFormSearch = function (containerID) {
      */
     function renderSingleSelectInputType(widgetID, options) {
         switch ($("#" + prefixID + "widgetCod_" + widgetID).val()) {
+            case "MATCH ALL":
+            case "NOT MATCH":
+            case "MATCH":
             case "LIKE":
             case "NOT LIKE":
                 $("#" + prefixID + "widgetMatch_" + widgetID).html(
@@ -1016,10 +1019,12 @@ var LeafFormSearch = function (containerID) {
                                             widgetID +
                                             '" class="chosen" aria-label="condition" style="width: 120px">\
                                         <option value="MATCH ALL">CONTAINS</option>\
-										<option value="LIKE">CONTAINS FRAGMENT</option>\
-										<option value="NOT LIKE">DOES NOT CONTAIN</option>\
+                                        <option value="NOT MATCH">DOES NOT CONTAIN</option>\
+                                        <option value="MATCH">CONTAINS EITHER</option>\
 					            		<option value="=">=</option>\
 										<option value="!=">!=</option>\
+										<option value="LIKE">HAS FRAGMENT</option>\
+                                        <option value="NOT LIKE">DOES NOT HAVE FRAGMENT</option>\
 					            	</select>'
                                     );
                                     $(
@@ -1284,12 +1289,15 @@ var LeafFormSearch = function (containerID) {
                                                         '" class="chosen" aria-label="condition" style="width: 120px">\
                                                     <option value="=">IS</option>\
                                                     <option value="!=">IS NOT</option>\
-													<option value="LIKE">CONTAINS</option>\
-													<option value="NOT LIKE">DOES NOT CONTAIN</option>\
+                                                    <option value="MATCH ALL">CONTAINS</option>\
+                                                    <option value="NOT MATCH">DOES NOT CONTAIN</option>\
+                                                    <option value="MATCH">CONTAINS EITHER</option>\
 								            		<option value=">">></option>\
 								            		<option value=">=">>=</option>\
 								            		<option value="<"><</option>\
 								            		<option value="<="><=</option>\
+                                                    <option value="LIKE">HAS FRAGMENT</option>\
+                                                    <option value="NOT LIKE">DOES NOT HAVE FRAGMENT</option>\
 								            	</select>'
                                                 );
                                                 var resOptions =
@@ -1347,10 +1355,13 @@ var LeafFormSearch = function (containerID) {
                                                         "widgetCod_" +
                                                         widgetID +
                                                         '" class="chosen" aria-label="condition" style="width: 120px">\
-													<option value="LIKE">CONTAINS</option>\
-													<option value="NOT LIKE">DOES NOT CONTAIN</option>\
-								            		<option value="=">=</option>\
-													<option value="!=">!=</option>\
+                                                        <option value="MATCH ALL">CONTAINS</option>\
+                                                        <option value="NOT MATCH">DOES NOT CONTAIN</option>\
+                                                        <option value="MATCH">CONTAINS EITHER</option>\
+                                                        <option value="=">=</option>\
+                                                        <option value="!=">!=</option>\
+                                                        <option value="LIKE">HAS FRAGMENT</option>\
+                                                        <option value="NOT LIKE">DOES NOT HAVE FRAGMENT</option>\
 								            	</select>'
                                                 );
                                                 $(

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -1023,7 +1023,10 @@ var LeafFormSearch = function (containerID) {
                                         widgetID
                                 ).val();
 
-                                // set default conditions for "any data field"
+                                /* Set default conditions for "any data field"
+                                 * Negative conditions are excluded because more extensive postprocessing
+                                 * is needed for logically valid results
+                                 */
                                 if (iID == ALL_DATA_FIELDS) {
                                     $(
                                         "#" +
@@ -1039,7 +1042,6 @@ var LeafFormSearch = function (containerID) {
                                         <option value="MATCH ALL">CONTAINS</option>\
                                         <option value="MATCH">CONTAINS EITHER</option>\
 					            		<option value="=">=</option>\
-										<option value="!=">!=</option>\
 										<option value="LIKE">HAS FRAGMENT</option>\
 					            	</select>'
                                     );

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -473,6 +473,15 @@ var LeafFormSearch = function (containerID) {
                         }
                     });
                     empSel.initialize();
+                    let previousSelectedEmp = $("#" + prefixID + "widgetMat_" + widgetID).val();
+                    if(previousSelectedEmp != '') {
+                        if(type == 'empUID') {
+                            empSel.forceSearch(`#${previousSelectedEmp}`);
+                        }
+                        else {
+                            empSel.forceSearch(previousSelectedEmp);
+                        }
+                    }
                 },
             });
         } else {
@@ -505,6 +514,15 @@ var LeafFormSearch = function (containerID) {
                 }
             });
             empSel.initialize();
+            let previousSelectedEmp = $("#" + prefixID + "widgetMat_" + widgetID).val();
+            if(previousSelectedEmp != '') {
+                if(type == 'empUID') {
+                    empSel.forceSearch(`#${previousSelectedEmp}`);
+                }
+                else {
+                    empSel.forceSearch(previousSelectedEmp);
+                }
+            }
         }
     }
 
@@ -901,7 +919,7 @@ var LeafFormSearch = function (containerID) {
                         widgetID +
                         '" style="width: 140px" class="chosen" aria-label="categoryID">\
 	            		<option value="=">IS</option>\
-	            		<option value="!=">IS NOT</option>\
+	            		<option value="!=" selected>IS NOT</option>\
 	            	</select>'
                 );
                 url =
@@ -925,7 +943,7 @@ var LeafFormSearch = function (containerID) {
                         categories +=
                             '<option value="deleted">Cancelled</option>';
                         categories +=
-                            '<option value="resolved">Resolved</option>';
+                            '<option value="resolved" selected>Resolved</option>';
                         categories +=
                             '<option value="actionable">Actionable by me</option>';
                         //categories += '<option value="destruction">Scheduled for Destruction</option>';
@@ -1397,6 +1415,28 @@ var LeafFormSearch = function (containerID) {
                     },
                 });
                 break;
+            case "recordID":
+                $("#" + prefixID + "widgetCondition_" + widgetID).html(
+                    '<select id="' +
+                        prefixID +
+                        "widgetCod_" +
+                        widgetID +
+                        '" class="chosen" aria-label="condition" style="width: 55px">\
+		            		<option value="=">=</option>\
+		            		<option value=">">></option>\
+		            		<option value=">=">>=</option>\
+		            		<option value="<"><</option>\
+		            		<option value="<="><=</option>\
+		            	</select>'
+                );
+                $("#" + prefixID + "widgetMatch_" + widgetID).html(
+                    '<input type="text" aria-label="text" id="' +
+                        prefixID +
+                        "widgetMat_" +
+                        widgetID +
+                        '" style="width: 200px" />'
+                );
+                break;
             default:
                 $("#" + prefixID + "widgetCondition_" + widgetID).html(
                     '<select id="' +
@@ -1458,14 +1498,15 @@ var LeafFormSearch = function (containerID) {
             "widgetTerm_" +
             widgetCounter +
             '" style="width: 150px" class="chosen" aria-label="condition">\
-            				<option value="title">Title</option>\
-            				<option value="serviceID">Service</option>\
-            				<option value="dateSubmitted">Date Submitted</option>\
-            				<option value="categoryID">Type</option>\
-            				<option value="userID">Initiator</option>\
-            				<option value="dependencyID">Requirement</option>\
-            				<option value="stepID">Current Status</option>\
+                            <option value="stepID">Current Status</option>\
             				<option value="data">Data Field</option>\
+            				<option value="dateSubmitted">Date Submitted</option>\
+                            <option value="userID">Initiator</option>\
+            				<option value="serviceID">Service</option>\
+            				<option value="title">Title</option>\
+            				<option value="categoryID">Type</option>\
+                            <option value="recordID">Record ID</option>\
+            				<option value="dependencyID">Requirement</option>\
             				</select></td>\
 			            <td id="' +
             prefixID +

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3517,6 +3517,10 @@ class Form
         $recordIDs = trim($recordIDs, ',');
         $recordIDs = $recordIDs ?: 0;
 
+        if(count($res) > count(array_keys($data))) {
+            header('LEAF-Query: continue'); // signal frontend there might be more data
+        }
+
         // These all require the recordIDs to be set
         if (!empty($recordIDs))
         {

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3298,10 +3298,8 @@ class Form
                                 $dataTermSql = $dataTerm;
                             }
                             // catch default data
-                            if ((isset($tResTypeHint[0]['default'])
+                            if (isset($tResTypeHint[0]['default'])
                                     && $tResTypeHint[0]['default'] == $vars[':data' . $count])
-                                || $q['operator'] == 'NOT LIKE'
-                                || $q['operator'] == 'NOT MATCH')
                             {
                                 $conditions .= "{$gate}({$dataTermSql} {$operator} $dataMatch OR {$dataTerm} IS NULL)";
                             }

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2881,6 +2881,7 @@ class Form
         $joinSearchAllData = false;
         $joinSearchOrgchartEmployeeData = false;
         $filterActionable = false;
+        $usingFulltextIndex = false;
         $vars = array();
         $conditions = '';
         $joins = '';
@@ -2931,12 +2932,15 @@ class Form
                     break;
                 case 'MATCH ALL': // Only usable when a fulltext index exists AND logic has been implemented
                     $operator = 'MATCH ALL';
+                    $usingFulltextIndex = true;
                     break;
                 case 'NOT MATCH': // Only usable when a fulltext index exists AND logic has been implemented
                     $operator = 'NOT MATCH';
+                    $usingFulltextIndex = true;
                     break;
                 case 'MATCH': // Only usable when a fulltext index exists AND logic has been implemented
                     $operator = 'MATCH';
+                    $usingFulltextIndex = true;
                     break;
                 case 'RIGHT JOIN':
                     break;
@@ -3441,6 +3445,11 @@ class Form
                 default:
                     break;
             }
+        }
+        
+        // avoid extra sort when using fulltext index
+        if($usingFulltextIndex) {
+            $sort = '';
         }
 
         // join tables for queries on data fields without filtering by indicatorID


### PR DESCRIPTION
This follows [PR#2127](https://github.com/department-of-veterans-affairs/LEAF/pull/2127) and implements fulltext search for data fields within the portal.data table, which provides a better overall search experience. Backward compatibility in ./api/form/query is not impacted because the change only adds new search terms: MATCH ALL, MATCH, and NOT MATCH.

Using the original implementation as a baseline: Although the worst case performance is significantly better, this comes at a cost in best case performance and minor change in initial sort order. Average case performance also seems to be better when using the fulltext index.

| Condition | Before (s) | After (s) |
| :-- | :---: | :---: |
| Worst case performance (obscure search term "sterile pants") | 22.363 | 0.007 |
| Best case performance (common word "clinic" in dataset) | 0.008 | 0.122 |
| Average case performance (popular search term "FY23") | 0.341 | 0.004 |

Other UX changes:
- Changed default "Advanced Options" search view, and dropdown order
- Resolved issue where a selected employee appears blank after refreshing the page
- Resolved issue where a query using a NOT LIKE term ignored null fields

### Opportunities
- Explore whether OPTIMIZE table has any benefit
- Explore [innodb_ft_max_token_size](https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_ft_max_token_size)
- Explore hybrid search UX using both LIKE and MATCH terms

### Potential Impact
- form/query and areas involving search
- The change in sort order could potentially cause confusion. This only impacts the homepage when an advanced search is applied, where the initial 50 results is sorted by relevance instead of the original date sort. Additionally this can be mitigated by simply clicking on "Show more records". Coordinate with the training team to prepare explanations for users.

### Testing
- [Experimental automated test added](https://github.com/mgaoVA/LEAF_test_experiments/commit/ac85fe53c3a1274d80a41748c94a7450a18397cd#diff-b7b1922b928b6c4ca9f0342a10188972bc7aa07897032f05faff1cb2b96f5234R56)
- Preprod: On a large site with at least 100,000 records, run a search for "Any standard data field CONTAINS FY23". The results should generally be the same as before.

### Deployment Prerequisites
- [ ] LEAF Infrastructure PR#109 must be merged and deployed
- [ ] Confirm that cache control is working properly for JS files