### PR TITLE
Enable easy file embeds

### DIFF
--- a/LEAF_Request_Portal/file.php
+++ b/LEAF_Request_Portal/file.php
@@ -14,7 +14,8 @@ $form = new Portal\Form($db, $login);
 $data = $form->getIndicator(
     XSSHelpers::xscrub($_GET['id']),
     XSSHelpers::xscrub($_GET['series']),
-    XSSHelpers::xscrub($_GET['form'])
+    XSSHelpers::xscrub($_GET['form']),
+    false // don't need to parse the template for file downloads
 );
 
 if (isset($data[$_GET['id']]['value'])){
@@ -42,8 +43,11 @@ $filename = $uploadDir . Portal\Form::getFileHash($_GET['form'], $_GET['id'], $_
 
 if (file_exists($filename))
 {
-    header('Content-Type: application/octet-stream');
-    header('Content-Disposition: attachment; filename="' . addslashes($value[$_GET['file']]) . '"');
+    $mimetype = mime_content_type($filename) ?: "application/octet-stream";
+    header('Content-Type: '. $mimetype);
+    if(!isset($_GET['inline'])) {
+        header('Content-Disposition: attachment; filename="' . addslashes($value[$_GET['file']]) . '"');
+    }
     header('Content-Length: ' . filesize($filename));
     header('Cache-Control: maxage=1'); //In seconds
     header('Pragma: public');

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -627,21 +627,16 @@ class Form
             }
 
             if($parseTemplate) {
-                /* putting this here to see what this value is
-                    the error is Array to string conversion and it gives the
-                    location, so I checked the database that it is pulling this
-                    from and I don't see any arrays in their data
-                */
-                if (is_array($data[0]['html'])) {
-                    error_log(print_r($data[0]['html'], true));
+                if($data[0]['html'] != null) {
+                    $form[$idx]['html'] = str_replace(['{{ iID }}', '{{ recordID }}', '{{ data }}'],
+                                            [$idx, $recordID, $form[$idx]['value']],
+                                            $data[0]['html']);
                 }
-
-                $form[$idx]['html'] = str_replace(['{{ iID }}', '{{ recordID }}', '{{ data }}'],
-                                                [$idx, $recordID, $form[$idx]['value']],
-                                                $data[0]['html']);
-                $form[$idx]['htmlPrint'] = str_replace(['{{ iID }}', '{{ recordID }}', '{{ data }}'],
+                if($data[0]['htmlPrint'] != null) {
+                    $form[$idx]['htmlPrint'] = str_replace(['{{ iID }}', '{{ recordID }}', '{{ data }}'],
                                                 [$idx, $recordID, $form[$idx]['value']],
                                                 $data[0]['htmlPrint']);
+                }
             }
 
             $form[$idx]['format'] = trim($inputType[0]);


### PR DESCRIPTION
This enables customizations to easily embed file uploads by adding the parameter *&inline* to the end of the file's URL.

For example, the following code in the LEAF Programmer would immediately display a PDF in compatible browsers.

*file.php?form=123...* is an example URL for an uploaded PDF document.
```html
<object data="file.php?form=123...&inline" width="800" height="600" type="application/pdf"></object>
```

A type checking issue was also identified and fixed.

### Potential Impact
Ability to download files

### Testing
- [ ] Files uploaded into records should also be downloadable