### PR TITLE
Use replaceAll function

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -226,7 +226,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
    * encodeReadableURI provides minimal character URI encoding, prioritizing readible URLs
    */
   function encodeReadableURI(url) {
-      return url.replace('+', '%2b');
+      return url.replaceAll('+', '%2b');
   }
 
   /**


### PR DESCRIPTION
This resolves an issue where only the first matching character would be replaced, instead of all matching characters.

The function updates the URL to replace "+" with its encoded format "%2b", since "+" would normally be interpreted as blank spaces.


### Potential Impact
Areas where formQuery.js is used, such as the homepage

### Testing
The homepage should load correctly