### PR TITLE
LEAF 4139 update keypress listeners in orgchartForm

### DIFF
--- a/LEAF_Nexus/js/orgchartForm.js
+++ b/LEAF_Nexus/js/orgchartForm.js
@@ -63,7 +63,7 @@ orgchartForm.prototype.getForm = function (UID, categoryID, indicatorID) {
         success: function (response) {
           dialog.setContent(response);
           $("input:visible:first, select:visible:first").focus();
-          $("input:visible:first, select:visible:first").keypress(function (
+          $("input:visible:first, select:visible:first").on("keydown", function (
             event
           ) {
             if (event.which == 13) {
@@ -100,11 +100,13 @@ orgchartForm.prototype.getForm = function (UID, categoryID, indicatorID) {
         success: function (response) {
           dialog.setContent(response);
           $("input:visible:first, select:visible:first").focus();
-          $("input:visible:first, select:visible:first").keypress(function (
+          $("input:visible:first, select:visible:first").on("keydown", function (
             event
           ) {
             if (event.which == 13) {
-              $("#" + dialog.btnSaveID).trigger("click");
+              setTimeout(() => { //timeout needed for ind 2 chosen dropdown
+                $("#" + dialog.btnSaveID).trigger("click");
+              }, 100);
             }
           });
         },
@@ -137,7 +139,7 @@ orgchartForm.prototype.getForm = function (UID, categoryID, indicatorID) {
         success: function (response) {
           dialog.setContent(response);
           $("input:visible:first, select:visible:first").focus();
-          $("input:visible:first, select:visible:first").keypress(function (
+          $("input:visible:first, select:visible:first").on("keydown", function (
             event
           ) {
             if (event.which == 13) {

--- a/LEAF_Nexus/js/orgchartForm.js
+++ b/LEAF_Nexus/js/orgchartForm.js
@@ -104,9 +104,13 @@ orgchartForm.prototype.getForm = function (UID, categoryID, indicatorID) {
             event
           ) {
             if (event.which == 13) {
-              setTimeout(() => { //timeout needed for ind 2 chosen dropdown
+              let elChosenDrop = null;
+              if(event.target.classList.contains('chosen-search-input')) {
+                elChosenDrop = document.querySelector('.chosen-with-drop');
+              }
+              if(elChosenDrop === null) { //if a chosen dropdown box is still open, the first enter will just close it.
                 $("#" + dialog.btnSaveID).trigger("click");
-              }, 100);
+              }
             }
           });
         },

--- a/LEAF_Nexus/templates/view_position.tpl
+++ b/LEAF_Nexus/templates/view_position.tpl
@@ -394,9 +394,9 @@ $(function() {
     orgchartForm = new orgchartForm('orgchartForm');
     orgchartForm.initialize();
     orgchartForm.addUpdateEvent(19, function(response) {
-    	if(($('.employee').size() - 1) < $('#data_19_2_<!--{$positionID}-->').html()) {
-    		window.location.reload();
-    	}
+        if(($('.employee').length - 1) < $('#data_19_2_<!--{$positionID}-->').html()) {
+            window.location.reload();
+        }
     });
     // include file="site_elements/orgchartForm_updateOutlook.js.tpl"
 


### PR DESCRIPTION
This updates the .keypress listeners in the Nexus orgchartForm js file to .on("keydown" listeners.

This should restore enter-save functionality of Nexus employee, position and group modals.  These were not changed in the recent update but seem to have been impacted by the addition of a dialogController modal keydown listener. 

The deprecated/removed jQuery size() method was also replaced by the .length property to fix a separate uncovered error.


Impact/Testing
Nexus side, editable (check write access) position, group and employee fields should save when enter is pressed in orgForm modals.  Confirm that these fields consistently save correctly (particularly the Position 'Pay Plan' field, which required a short timeout for the chosen dropdown). 
Confirm that updating a position Total Headcount field does not result in an error.