### PR TITLE
LEAF-2478 - Histogram for sizes of uploaded files

### DIFF
--- a/scripts/leaf-scripts/check_user_upload_sizes.php
+++ b/scripts/leaf-scripts/check_user_upload_sizes.php
@@ -16,12 +16,12 @@ $totalfilecount = 0;
 $totalfilesize = 0;
 $totalmaxfilesize = 0;
 $totalminfilesize = 999999999;
-$fp = fopen('filehistogram.csv', 'w');
-fputcsv($fp, ['path', 'max (KB)', 'min (KB)', 'average (KB)', 'count']);
+$fp = fopen('check_user_upload_sizes.csv', 'w');
+fputcsv($fp, ['path', 'min (KB)', 'max (KB)', 'average (KB)', 'count']);
 foreach ($portals as $portal) {
 
     // setup our initial array
-    $filesizes = ['path' => $portal['site_path'], 'max' => 0, 'min' => 999999999, 'average' => 0, 'count' => 0];
+    $filesizes = ['path' => $portal['site_path'], 'min' => 999999999, 'max' => 0, 'average' => 0, 'count' => 0];
 
     // look at the erm uploads, if looking at multiple dirs, will need to decouple filecounts, since we mainly want to look at erm I will just look at erm.
     $path = $portal['site_uploads'] . '*.*';
@@ -70,7 +70,7 @@ if ($totalminfilesize > $totalmaxfilesize) {
     $totalminfilesize = 0;
 }
 
-fputcsv($fp, ['total', $totalmaxfilesize, $totalminfilesize, $totalfilesize / $totalfilecount, $totalfilecount]);
+fputcsv($fp, ['total', $totalminfilesize, $totalmaxfilesize, $totalfilesize / $totalfilecount, $totalfilecount]);
 fclose($fp);
 $endTime = microtime(true);
 $timeInMinutes = round(($endTime - $startTime) / 60, 2);

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -11,6 +11,8 @@ $portals = $db->query("SELECT * FROM `sites` WHERE `site_type` = 'portal'");
 $directory = '/var/www/html';
 $totalfilecount = 0;
 $totalfilesize = 0;
+$totalmaxfilesize = 0;
+$totalminfilesize = 0;
 $fp = fopen('filehistogram.csv', 'w');
 fputcsv($fp, ['path', 'max (MB)', 'min (MB)', 'average (MB)', 'count']);
 foreach ($portals as $portal) {
@@ -20,7 +22,7 @@ foreach ($portals as $portal) {
 
     $glob_array = glob($directory . $portal['site_path'] . '/files/*.*');
     $filecount = count($glob_array);
-    $filzesize['count'] = $filecount;
+    $filzesizes['count'] = $filecount;
 
     foreach ($glob_array as $glob) {
         $filesize = filesize($glob);
@@ -31,8 +33,16 @@ foreach ($portals as $portal) {
             $filesizes['max'] = $filesize;
         }
 
-        if ($filesize < $filesizes['min']) {
+        if ($filesize < $filesizes['min'] && $filesize > 0) {
             $filesizes['min'] = $filesize;
+        }
+
+        if ($filesize > $totalmaxfilesize) {
+            $totalmaxfilesize = $filesize;
+        }
+
+        if ($filesize < $totalminfilesize && $filesize > 0) {
+            $totalminfilesize = $filesize;
         }
 
         $filesizes['average'] += $filesize;
@@ -45,7 +55,7 @@ foreach ($portals as $portal) {
         fputcsv($fp, $filesizes);
     }
 }
-fputcsv($fp, ['total', 0, 0, $totalfilesize / $totalfilecount, $totalfilecount]);
+fputcsv($fp, ['total', $totalmaxfilesize, $totalminfilesize, $totalfilesize / $totalfilecount, $totalfilecount]);
 fclose($fp);
 $endTime = microtime(true);
 $timeInMinutes = round(($endTime - $startTime) / 60, 2);

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -14,7 +14,7 @@ $totalfilesize = 0;
 $totalmaxfilesize = 0;
 $totalminfilesize = 999999999;
 $fp = fopen('filehistogram.csv', 'w');
-fputcsv($fp, ['path', 'max (MB)', 'min (MB)', 'average (MB)', 'count']);
+fputcsv($fp, ['path', 'max (KB)', 'min (KB)', 'average (KB)', 'count']);
 foreach ($portals as $portal) {
 
     $filesizes = ['path' => $portal['site_path'], 'max' => 0, 'min' => 999999999, 'average' => 0, 'count' => 0];

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -18,35 +18,37 @@ fputcsv($fp, ['path', 'max (KB)', 'min (KB)', 'average (KB)', 'count']);
 foreach ($portals as $portal) {
 
     $filesizes = ['path' => $portal['site_path'], 'max' => 0, 'min' => 999999999, 'average' => 0, 'count' => 0];
-    $header = array_keys($filesizes);
+    $paths = [$directory . $portal['site_path'] . '/files/*.*', $portal['site_uploads'] . '*.*'];
+    foreach ($paths as $path) {
+        $glob_array = glob($path);
+        $filecount = count($glob_array);
+        $filesizes['count'] += $filecount;
 
-    $glob_array = glob($directory . $portal['site_path'] . '/files/*.*');
-    $filecount = count($glob_array);
-    $filesizes['count'] = $filecount;
+        foreach ($glob_array as $glob) {
+            $filesize = filesize($glob);
+            if ($filesize > 0)
+                $filesize = $filesize / 1024;
 
-    foreach ($glob_array as $glob) {
-        $filesize = filesize($glob);
-        if ($filesize > 0)
-            $filesize = $filesize / 1024;
+            if ($filesize > $filesizes['max']) {
+                $filesizes['max'] = $filesize;
+            }
 
-        if ($filesize > $filesizes['max']) {
-            $filesizes['max'] = $filesize;
+            if ($filesize < $filesizes['min'] && $filesize > 0) {
+                $filesizes['min'] = $filesize;
+            }
+
+            if ($filesize > $totalmaxfilesize) {
+                $totalmaxfilesize = $filesize;
+            }
+
+            if ($filesize < $totalminfilesize && $filesize > 0) {
+                $totalminfilesize = $filesize;
+            }
+
+            $filesizes['average'] += $filesize;
         }
-
-        if ($filesize < $filesizes['min'] && $filesize > 0) {
-            $filesizes['min'] = $filesize;
-        }
-
-        if ($filesize > $totalmaxfilesize) {
-            $totalmaxfilesize = $filesize;
-        }
-
-        if ($filesize < $totalminfilesize && $filesize > 0) {
-            $totalminfilesize = $filesize;
-        }
-
-        $filesizes['average'] += $filesize;
     }
+
 
     if ($filesizes['min'] > $filesizes['max']) {
         $filesizes['min'] = 0;

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -1,0 +1,54 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+require_once 'globals.php';
+require_once LIB_PATH . '/php-commons/Db.php';
+
+$startTime = microtime(true);
+
+$db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+
+$portals = $db->query("SELECT * FROM `sites` WHERE `site_type` = 'portal'");
+$directory = '/var/www/html';
+$totalfilecount = 0;
+$totalfilesize = 0;
+$fp = fopen('filehistogram.csv', 'w');
+fputcsv($fp, ['path', 'max (MB)', 'min (MB)', 'average (MB)', 'count']);
+foreach ($portals as $portal) {
+
+    $filesizes = ['path' => $portal['site_path'], 'max' => 0, 'min' => 999999999, 'average' => 0, 'count' => 0];
+    $header = array_keys($filesizes);
+
+    $glob_array = glob($directory . $portal['site_path'] . '/files/*.*');
+    $filecount = count($glob_array);
+    $filzesize['count'] = $filecount;
+
+    foreach ($glob_array as $glob) {
+        $filesize = filesize($glob);
+        if ($filesize > 0)
+            $filesize = $filesize / 1024;
+
+        if ($filesize > $filesizes['max']) {
+            $filesizes['max'] = $filesize;
+        }
+
+        if ($filesize < $filesizes['min']) {
+            $filesizes['min'] = $filesize;
+        }
+
+        $filesizes['average'] += $filesize;
+    }
+
+    if (count($glob_array) > 0) {
+        $totalfilesize += $filesizes['average'];
+        $filesizes['average'] = $filesizes['average'] / $filecount;
+        $totalfilecount += $filecount;
+        fputcsv($fp, $filesizes);
+    }
+}
+fputcsv($fp, ['total', 0, 0, $totalfilesize / $totalfilecount, $totalfilecount]);
+fclose($fp);
+$endTime = microtime(true);
+$timeInMinutes = round(($endTime - $startTime) / 60, 2);
+echo "Destruction took {$timeInMinutes} minutes\r\n";
+echo date('Y-m-d g:i:s a') . "\r\n";

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once getenv('APP_LIBS_PATH') . '/globals.php';
-require_once getenv('APP_LIBS_PATH') . '../Leaf/Db.php';
+require_once getenv('APP_LIBS_PATH') . '/../Leaf/Db.php';
 
 $startTime = microtime(true);
 
@@ -12,7 +12,7 @@ $directory = '/var/www/html';
 $totalfilecount = 0;
 $totalfilesize = 0;
 $totalmaxfilesize = 0;
-$totalminfilesize = 0;
+$totalminfilesize = 999999999;
 $fp = fopen('filehistogram.csv', 'w');
 fputcsv($fp, ['path', 'max (MB)', 'min (MB)', 'average (MB)', 'count']);
 foreach ($portals as $portal) {
@@ -22,7 +22,7 @@ foreach ($portals as $portal) {
 
     $glob_array = glob($directory . $portal['site_path'] . '/files/*.*');
     $filecount = count($glob_array);
-    $filzesizes['count'] = $filecount;
+    $filesizes['count'] = $filecount;
 
     foreach ($glob_array as $glob) {
         $filesize = filesize($glob);
@@ -48,6 +48,10 @@ foreach ($portals as $portal) {
         $filesizes['average'] += $filesize;
     }
 
+    if ($filesizes['min'] > $filesizes['max']) {
+        $filesizes['min'] = 0;
+    }
+
     if (count($glob_array) > 0) {
         $totalfilesize += $filesizes['average'];
         $filesizes['average'] = $filesizes['average'] / $filecount;
@@ -55,6 +59,11 @@ foreach ($portals as $portal) {
         fputcsv($fp, $filesizes);
     }
 }
+
+if ($totalminfilesize > $totalmaxfilesize) {
+    $totalminfilesize = 0;
+}
+
 fputcsv($fp, ['total', $totalmaxfilesize, $totalminfilesize, $totalfilesize / $totalfilecount, $totalfilecount]);
 fclose($fp);
 $endTime = microtime(true);

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -17,38 +17,39 @@ $fp = fopen('filehistogram.csv', 'w');
 fputcsv($fp, ['path', 'max (KB)', 'min (KB)', 'average (KB)', 'count']);
 foreach ($portals as $portal) {
 
+    // setup our initial array
     $filesizes = ['path' => $portal['site_path'], 'max' => 0, 'min' => 999999999, 'average' => 0, 'count' => 0];
-    $paths = [$directory . $portal['site_path'] . '/files/*.*', $portal['site_uploads'] . '*.*'];
-    foreach ($paths as $path) {
-        $glob_array = glob($path);
-        $filecount = count($glob_array);
-        $filesizes['count'] += $filecount;
 
-        foreach ($glob_array as $glob) {
-            $filesize = filesize($glob);
-            if ($filesize > 0)
-                $filesize = $filesize / 1024;
+    // look at the erm uploads, if looking at multiple dirs, will need to decouple filecounts, since we mainly want to look at erm I will just look at erm.
+    $path = $portal['site_uploads'] . '*.*';
 
-            if ($filesize > $filesizes['max']) {
-                $filesizes['max'] = $filesize;
-            }
+    $glob_array = glob($path);
+    $filecount = count($glob_array);
+    $filesizes['count'] += $filecount;
 
-            if ($filesize < $filesizes['min'] && $filesize > 0) {
-                $filesizes['min'] = $filesize;
-            }
+    foreach ($glob_array as $glob) {
+        $filesize = filesize($glob);
+        if ($filesize > 0)
+            $filesize = $filesize / 1024;
 
-            if ($filesize > $totalmaxfilesize) {
-                $totalmaxfilesize = $filesize;
-            }
-
-            if ($filesize < $totalminfilesize && $filesize > 0) {
-                $totalminfilesize = $filesize;
-            }
-
-            $filesizes['average'] += $filesize;
+        if ($filesize > $filesizes['max']) {
+            $filesizes['max'] = $filesize;
         }
-    }
 
+        if ($filesize < $filesizes['min'] && $filesize > 0) {
+            $filesizes['min'] = $filesize;
+        }
+
+        if ($filesize > $totalmaxfilesize) {
+            $totalmaxfilesize = $filesize;
+        }
+
+        if ($filesize < $totalminfilesize && $filesize > 0) {
+            $totalminfilesize = $filesize;
+        }
+
+        $filesizes['average'] += $filesize;
+    }
 
     if ($filesizes['min'] > $filesizes['max']) {
         $filesizes['min'] = 0;

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * This file gets the amount of storage used for each portal in the ERM uploads directory.
+ */
 
 require_once getenv('APP_LIBS_PATH') . '/globals.php';
 require_once getenv('APP_LIBS_PATH') . '/../Leaf/Db.php';
@@ -71,5 +74,5 @@ fputcsv($fp, ['total', $totalmaxfilesize, $totalminfilesize, $totalfilesize / $t
 fclose($fp);
 $endTime = microtime(true);
 $timeInMinutes = round(($endTime - $startTime) / 60, 2);
-echo "Destruction took {$timeInMinutes} minutes\r\n";
+echo "Processing took {$timeInMinutes} minutes\r\n";
 echo date('Y-m-d g:i:s a') . "\r\n";

--- a/scripts/leaf-scripts/filehistorgram.php
+++ b/scripts/leaf-scripts/filehistorgram.php
@@ -1,12 +1,11 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-require_once 'globals.php';
-require_once LIB_PATH . '/php-commons/Db.php';
+
+require_once getenv('APP_LIBS_PATH') . '/globals.php';
+require_once getenv('APP_LIBS_PATH') . '../Leaf/Db.php';
 
 $startTime = microtime(true);
 
-$db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+$db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
 
 $portals = $db->query("SELECT * FROM `sites` WHERE `site_type` = 'portal'");
 $directory = '/var/www/html';

--- a/scripts/leaf-scripts/showdbvers.php
+++ b/scripts/leaf-scripts/showdbvers.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * This file is used to get the different db versions after a deploy to verify update. 
+ * You will need to update the db version manually in this file to do the search at this time however
+ */
 
 require_once getenv('APP_LIBS_PATH') . '/globals.php';
 require_once getenv('APP_LIBS_PATH') . '../Leaf/Db.php';

--- a/scripts/leaf-scripts/showdbvers.php
+++ b/scripts/leaf-scripts/showdbvers.php
@@ -1,0 +1,29 @@
+<?php
+
+require_once 'globals.php';
+require_once LIB_PATH . '/php-commons/Db.php';
+
+$startTime = microtime(true);
+
+$db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+
+$portals = $db->query("SELECT `portal_database` FROM `sites` WHERE `site_type` = 'portal'");
+
+foreach ($portals as $portal) {
+    // Initialize record destruction counter
+    $count = 0;
+
+    // Switch to portal in list
+    $db->query("USE `{$portal['portal_database']}`");
+
+    $results = $db->query("SELECT `data` from `settings` where setting = 'dbversion'");
+
+    if( (int)$results[0]['data'] < 2023100500){
+        var_dump($portal['portal_database'],$results[0]['data']);
+    }
+}
+
+$endTime = microtime(true);
+$timeInMinutes = round(($endTime - $startTime) / 60, 2);
+echo "Destruction took {$timeInMinutes} minutes\r\n";
+echo date('Y-m-d g:i:s a') . "\r\n";

--- a/scripts/leaf-scripts/showdbvers.php
+++ b/scripts/leaf-scripts/showdbvers.php
@@ -1,11 +1,11 @@
 <?php
 
-require_once 'globals.php';
-require_once LIB_PATH . '/php-commons/Db.php';
+require_once getenv('APP_LIBS_PATH') . '/globals.php';
+require_once getenv('APP_LIBS_PATH') . '../Leaf/Db.php';
 
 $startTime = microtime(true);
 
-$db = new Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+$db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
 
 $portals = $db->query("SELECT `portal_database` FROM `sites` WHERE `site_type` = 'portal'");
 

--- a/scripts/leaf-scripts/showdbvers.php
+++ b/scripts/leaf-scripts/showdbvers.php
@@ -29,5 +29,5 @@ foreach ($portals as $portal) {
 
 $endTime = microtime(true);
 $timeInMinutes = round(($endTime - $startTime) / 60, 2);
-echo "Destruction took {$timeInMinutes} minutes\r\n";
+echo "Processing took {$timeInMinutes} minutes\r\n";
 echo date('Y-m-d g:i:s a') . "\r\n";


### PR DESCRIPTION
This is a script that will export a csv with the max, min, average filesizes and count of files. It outputs in MB to make things a bit more useful. 

 I also have a copy of the db vers, this  is setup for looking at portal db versions. This had not been copied over and this has been useful for helping find and verify things are working.

These files should have no impact since they are scripts run by developers only.