### PR TITLE
Leaf 2973 - Subordinate sites limited

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -2009,10 +2009,10 @@ function selectForm(categoryID) {
  */
 function showFormBrowser() {
     window.location = '#';
-    $('#menu').html('<div tabindex="0" role="button" class="buttonNorm" onkeydown="onKeyPressClick(event)" id="createFormButton" onclick="createForm();"><img src="../dynicons/?img=document-new.svg&w=32" alt="Create Form" /> Create Form</div><br />');
-    $('#menu').append('<div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="formLibrary();" role="button"><img src="../dynicons/?img=system-file-manager.svg&w=32" alt="Import Form" /> LEAF Library</div><br />');
-    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="importForm();" role="button"><img src="../dynicons/?img=package-x-generic.svg&w=32" alt="Import Form" /> Import Form</div><br />');
-    $('#menu').append('<br /><br /><div tabindex="0" class="buttonNorm" onkeydown="onKeyPressClick(event)" onclick="window.location = \'?a=disabled_fields\';" role="button"><img src="../dynicons/?img=user-trash-full.svg&w=32" alt="Restore fields" /> Restore Fields</div>');
+    $('#menu').html('<div tabindex="0" role="button" class="buttonNorm" onkeypress="onKeyPressClick(event)" id="createFormButton" onclick="createForm();"><img src="../dynicons/?img=document-new.svg&w=32" alt="Create Form" /> Create Form</div><br />');
+    $('#menu').append('<div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" id="formLibrary" onclick="formLibrary();" role="button"><img src="../dynicons/?img=system-file-manager.svg&w=32" alt="Import Form" /> LEAF Library</div><br />');
+    $('#menu').append('<br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" id="importForm" onclick="importForm();" role="button"><img src="../dynicons/?img=package-x-generic.svg&w=32" alt="Import Form" /> Import Form</div><br />');
+    $('#menu').append('<br /><br /><div tabindex="0" class="buttonNorm" onkeypress="onKeyPressClick(event)" id="restoreFields" onclick="window.location = \'?a=disabled_fields\';" role="button"><img src="../dynicons/?img=user-trash-full.svg&w=32" alt="Restore fields" /> Restore Fields</div>');
     $.ajax({
         type: 'GET',
         url: '../api/formStack/categoryList/all',
@@ -2197,6 +2197,11 @@ function fetchFormSecureInfo() {
             warnContent += `<span>Do not make modifications! &nbsp;Synchronization problems will occur. &nbsp;`;
             warnContent += `Please contact your process POC if modifications need to be made.</span></div>`;
             $('#bodyarea').prepend(warnContent);
+
+            $('#createFormButton').css('display', 'none');
+            $('#formLibrary').css('display', 'none');
+            $('#importForm').css('display', 'none');
+            $('#restoreFields').css('display', 'none');
         }
         renderSecureFormsInfo(res)
     });
@@ -2225,74 +2230,85 @@ function fetchDropdownFiles() {
  * @param parentID
  */
 function createForm(parentID) {
-    if(parentID == undefined) {
-        parentID = '';
-        dialog.setTitle('New Form');
-    }
-    else {
-        dialog.setTitle('New Internal-Use Form');
-    }
-    dialog.setContent('<table>\
-                            <tr>\
-                                <td>Form Label</td>\
-                                <td><input tabindex="0" id="name" type="text" maxlength="50"></input></td>\
-                            </tr>\
-                            <tr>\
-                                <td>Form Description</td>\
-                                <td><textarea tabindex="0" id="description" maxlength="255"></textarea></td>\
-                            </tr>\
-                        </table>');
+    if ($('#subordinate_site_warning').length) {
+        alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+    } else {
+        if(parentID == undefined) {
+            parentID = '';
+            dialog.setTitle('New Form');
+        } else {
+            dialog.setTitle('New Internal-Use Form');
+        }
+        dialog.setContent('<table>\
+                                <tr>\
+                                    <td>Form Label</td>\
+                                    <td><input tabindex="0" id="name" type="text" maxlength="50"></input></td>\
+                                </tr>\
+                                <tr>\
+                                    <td>Form Description</td>\
+                                    <td><textarea tabindex="0" id="description" maxlength="255"></textarea></td>\
+                                </tr>\
+                            </table>');
 
-    dialog.show();
+        dialog.show();
 
-    dialog.setSaveHandler(function() {
-        let categoryName = $('#name').val();
-        let categoryDescription = $('#description').val();
-        $.ajax({
-            type: 'POST',
-            url: '../api/formEditor/new',
-            data: {name: $('#name').val(),
-                    description: $('#description').val(),
-                    parentID: parentID,
-                    CSRFToken: '<!--{$CSRFToken}-->'},
-            success: function(res) {
-                dialog.hide();
-                currCategoryID = res;
-                categories[res] = {};
-                categories[res].categoryID = res;
-                categories[res].categoryName = categoryName;
-                categories[res].categoryDescription = categoryDescription;
-                categories[res].workflowID = 0;
-                categories[res].parentID = '';
-                categories[res].needToKnow = 0;
-                categories[res].visible = 1;
-                categories[res].sort = 0;
-                if(parentID != '') {
-                    categories[res].parentID = parentID;
-                    buildMenu(parentID);
-                    // hightlight the newly created form in the menu
-                    $('#menu>div').removeClass('buttonNormSelected');
-                    $('#' + res).addClass('buttonNormSelected');
+        dialog.setSaveHandler(function() {
+            let categoryName = $('#name').val();
+            let categoryDescription = $('#description').val();
+            $.ajax({
+                type: 'POST',
+                url: '../api/formEditor/new',
+                data: {name: $('#name').val(),
+                        description: $('#description').val(),
+                        parentID: parentID,
+                        CSRFToken: '<!--{$CSRFToken}-->'},
+                success: function(res) {
+                    dialog.hide();
+                    currCategoryID = res;
+                    categories[res] = {};
+                    categories[res].categoryID = res;
+                    categories[res].categoryName = categoryName;
+                    categories[res].categoryDescription = categoryDescription;
+                    categories[res].workflowID = 0;
+                    categories[res].parentID = '';
+                    categories[res].needToKnow = 0;
+                    categories[res].visible = 1;
+                    categories[res].sort = 0;
+                    if(parentID != '') {
+                        categories[res].parentID = parentID;
+                        buildMenu(parentID);
+                        // hightlight the newly created form in the menu
+                        $('#menu>div').removeClass('buttonNormSelected');
+                        $('#' + res).addClass('buttonNormSelected');
+                    }
+                    buildMenu(res);
+                    openContent('ajaxIndex.php?a=printview&categoryID='+ res);
                 }
-                buildMenu(res);
-                openContent('ajaxIndex.php?a=printview&categoryID='+ res);
-            }
+            });
         });
-    });
+    }
 }
 
 /**
  * Purpose: Import Form
  */
 function importForm() {
-	window.location.href = './?a=importForm';
+    if ($('#subordinate_site_warning').length) {
+        alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+    } else {
+	    window.location.href = './?a=importForm';
+    }
 }
 
 /**
  * Purpose: Import Form from Library
  */
 function formLibrary() {
-    window.location.href = './?a=formLibrary';
+    if ($('#subordinate_site_warning').length) {
+        alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+    } else {
+        window.location.href = './?a=formLibrary';
+    }
 }
 
 

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -54,45 +54,53 @@
     }
 
     function newWorkflow() {
-        $('.workflowStepInfo').css('display', 'none');
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
 
-        dialog.setTitle('Create new workflow');
-        dialog.setContent('<br /><label for="description">Workflow Title:</label> <input type="text" id="description"/>');
-        dialog.setSaveHandler(function() {
-            let workflowID;
+            dialog.setTitle('Create new workflow');
+            dialog.setContent('<br /><label for="description">Workflow Title:</label> <input type="text" id="description"/>');
+            dialog.setSaveHandler(function() {
+                let workflowID;
 
-            postWorkflow(function(workflow_id) {
-                loadWorkflowList(workflow_id);
-                dialog.hide();
+                postWorkflow(function(workflow_id) {
+                    loadWorkflowList(workflow_id);
+                    dialog.hide();
+                });
             });
-        });
-        dialog.show();
+            dialog.show();
+        }
     }
 
     function deleteWorkflow() {
-        $('.workflowStepInfo').css('display', 'none');
-        if (currentWorkflow == 0) {
-            return;
-        }
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
+            if (currentWorkflow == 0) {
+                return;
+            }
 
-        dialog_confirm.setTitle('Confirmation required');
-        dialog_confirm.setContent('Are you sure you want to delete this workflow?');
-        dialog_confirm.setSaveHandler(function() {
-            $.ajax({
-                type: 'DELETE',
-                url: `../api/workflow/${currentWorkflow}?` + $.param({ 'CSRFToken': CSRFToken }),
-                success: (res) => {
-                    if (res != true) {
-                        alert("Prerequisite action needed:\n\n" + res);
-                        dialog_confirm.hide();
-                    } else {
-                        window.location.reload();
-                    }
-                },
-                error: (err) => console.log(err),
+            dialog_confirm.setTitle('Confirmation required');
+            dialog_confirm.setContent('Are you sure you want to delete this workflow?');
+            dialog_confirm.setSaveHandler(function() {
+                $.ajax({
+                    type: 'DELETE',
+                    url: `../api/workflow/${currentWorkflow}?` + $.param({ 'CSRFToken': CSRFToken }),
+                    success: (res) => {
+                        if (res != true) {
+                            alert("Prerequisite action needed:\n\n" + res);
+                            dialog_confirm.hide();
+                        } else {
+                            window.location.reload();
+                        }
+                    },
+                    error: (err) => console.log(err),
+                });
             });
-        });
-        dialog_confirm.show();
+            dialog_confirm.show();
+        }
     }
 
     function unlinkEvent(workflowID, stepID, actionType, eventID) {
@@ -166,31 +174,35 @@
      * Purpose: List all Custom Events
      */
     function listEvents() {
-        $('.workflowStepInfo').css('display', 'none');
-        dialog.hide();
-        $("#button_save").hide();
-        dialog.setTitle('List of Events');
-        dialog.show();
-        $.ajax({
-            type: 'GET',
-            url: '../api/workflow/customEvents',
-            cache: false
-        }).done(function(res) {
-            dialog.indicateIdle();
-            dialog.setContent(listEventsContent(res));
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
+            dialog.hide();
+            $("#button_save").hide();
+            dialog.setTitle('List of Events');
+            dialog.show();
+            $.ajax({
+                type: 'GET',
+                url: '../api/workflow/customEvents',
+                cache: false
+            }).done(function(res) {
+                dialog.indicateIdle();
+                dialog.setContent(listEventsContent(res));
 
-            $("#create-event").click(function() {
-                $("#button_save").show();
-                newEvent(res);
+                $("#create-event").click(function() {
+                    $("#button_save").show();
+                    newEvent(res);
+                });
+            }).fail(function(error) {
+                alert(error);
             });
-        }).fail(function(error) {
-            alert(error);
-        });
-        //shows the save button for other dialogs
-        $('div#xhrDialog').on('dialogclose', function() {
-            $("#button_save").show();
-            $('div#xhrDialog').off();
-        });
+            //shows the save button for other dialogs
+            $('div#xhrDialog').on('dialogclose', function() {
+                $("#button_save").show();
+                $('div#xhrDialog').off();
+            });
+        }
     }
 
     /**
@@ -971,27 +983,31 @@
     }
 
     function createStep() {
-        $('.workflowStepInfo').css('display', 'none');
-        if (currentWorkflow == 0) {
-            return;
-        }
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
+            if (currentWorkflow == 0) {
+                return;
+            }
 
-        dialog.setTitle('Create new Step');
-        dialog.setContent(
-            '<br /><label for="stepTitle">Step Title:</label> <input type="text" id="stepTitle"></input><br /><br />Example: "Service Chief"'
-        );
-        dialog.setSaveHandler(function() {
-            addStep(currentWorkflow, $('#stepTitle').val(), function(stepID) {
-                if (isNaN(stepID)) {
-                    console.log(stepID);
-                } else {
-                    loadWorkflow(currentWorkflow);
-                }
+            dialog.setTitle('Create new Step');
+            dialog.setContent(
+                '<br /><label for="stepTitle">Step Title:</label> <input type="text" id="stepTitle"></input><br /><br />Example: "Service Chief"'
+            );
+            dialog.setSaveHandler(function() {
+                addStep(currentWorkflow, $('#stepTitle').val(), function(stepID) {
+                    if (isNaN(stepID)) {
+                        console.log(stepID);
+                    } else {
+                        loadWorkflow(currentWorkflow);
+                    }
 
-                dialog.hide();
+                    dialog.hide();
+                });
             });
-        });
-        dialog.show();
+            dialog.show();
+        }
     }
 
     function setInitialStep(stepID) {
@@ -1021,61 +1037,65 @@
 
     //list all action type to edit/delete
     function listActionType() {
-        $('.workflowStepInfo').css('display', 'none');
-        dialog.hide();
-        $("#button_save").hide();
-        dialog.setTitle('List of Actions');
-        dialog.show();
-        $.ajax({
-            type: 'GET',
-            url: '../api/workflow/userActions',
-            success: function(res) {
-                let buffer = `<table id="actions" class="table" border="1">
-                    <caption><h2>List of Actions</h2></caption>
-                    <thead>
-                        <th scope="col">Action</th>
-                        <th scope="col">Action (Past Tense)</th>
-                        <th scope="col">Button Order</th>
-                        <th scope="col"></th>
-                    </thead>`;
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
+            dialog.hide();
+            $("#button_save").hide();
+            dialog.setTitle('List of Actions');
+            dialog.show();
+            $.ajax({
+                type: 'GET',
+                url: '../api/workflow/userActions',
+                success: function(res) {
+                    let buffer = `<table id="actions" class="table" border="1">
+                        <caption><h2>List of Actions</h2></caption>
+                        <thead>
+                            <th scope="col">Action</th>
+                            <th scope="col">Action (Past Tense)</th>
+                            <th scope="col">Button Order</th>
+                            <th scope="col"></th>
+                        </thead>`;
 
-                for (let i in res) {
-                    buffer += `<tr>
-                        <td width="300px" id="${res[i].actionType}">${res[i].actionText}</td>
-                        <td width="300px" id="${res[i].actionTextPasttense}">${res[i].actionTextPasttense}</td>
-                        <td width="100px">${res[i]?.sort || 0}</td>
-                        <td width="150px" id="editor_${res[i].actionType}">
-                            <button type="button" class="buttonNorm" onclick="editActionType('${res[i].actionType}')"
-                                style="background: #22b;color: #fff; padding: 2px 4px;">
-                                Edit
-                            </button>
-                            <button type="button" class="buttonNorm" onclick="deleteActionType('${res[i].actionType}')"
-                                style="background: #c00;color: #fff;margin-left: 10px; padding: 2px 4px;">
-                                Delete
-                            </button>
-                        </td>
-                    </tr>`;
-                }
+                    for (let i in res) {
+                        buffer += `<tr>
+                            <td width="300px" id="${res[i].actionType}">${res[i].actionText}</td>
+                            <td width="300px" id="${res[i].actionTextPasttense}">${res[i].actionTextPasttense}</td>
+                            <td width="100px">${res[i]?.sort || 0}</td>
+                            <td width="150px" id="editor_${res[i].actionType}">
+                                <button type="button" class="buttonNorm" onclick="editActionType('${res[i].actionType}')"
+                                    style="background: #22b;color: #fff; padding: 2px 4px;">
+                                    Edit
+                                </button>
+                                <button type="button" class="buttonNorm" onclick="deleteActionType('${res[i].actionType}')"
+                                    style="background: #c00;color: #fff;margin-left: 10px; padding: 2px 4px;">
+                                    Delete
+                                </button>
+                            </td>
+                        </tr>`;
+                    }
 
-                buffer += `</table><br /><br />
-                    <span class="buttonNorm" id="create-action-type" tabindex="0">Create a new Action</span>`;
+                    buffer += `</table><br /><br />
+                        <span class="buttonNorm" id="create-action-type" tabindex="0">Create a new Action</span>`;
 
-                dialog.indicateIdle();
-                dialog.setContent(buffer);
+                    dialog.indicateIdle();
+                    dialog.setContent(buffer);
 
-                $("#create-action-type").click(function() {
-                    $("#button_save").show();
-                    newAction();
-                });
-            },
-            error: (err) => console.log(err),
-            cache: false
-        });
-        //shows the save button for other dialogs
-        $('div#xhrDialog').on('dialogclose', function(event) {
-            $("#button_save").show();
-            $('div#xhrDialog').off();
-        });
+                    $("#create-action-type").click(function() {
+                        $("#button_save").show();
+                        newAction();
+                    });
+                },
+                error: (err) => console.log(err),
+                cache: false
+            });
+            //shows the save button for other dialogs
+            $('div#xhrDialog').on('dialogclose', function(event) {
+                $("#button_save").show();
+                $('div#xhrDialog').off();
+            });
+        }
     }
 
     /**
@@ -1959,13 +1979,24 @@
     var currentWorkflow = 0;
 
     function loadWorkflow(workflowID) {
-        $('#btn_createStep').css('display', 'block');
-        $('#btn_deleteWorkflow').css('display', 'block');
-        $('#btn_listActionType').css('display', 'block');
-        $('#btn_listEvents').css('display', 'block');
-        $('#btn_viewHistory').css('display', 'block');
-        $('#btn_renameWorkflow').css('display', 'block');
-        $('#btn_duplicateWorkflow').css('display', 'block');
+        if ($('#subordinate_site_warning').length) {
+            $('#btn_createStep').css('display', 'none');
+            $('#btn_deleteWorkflow').css('display', 'none');
+            $('#btn_newWorkflow').css('display', 'none');
+            $('#btn_listActionType').css('display', 'none');
+            $('#btn_listEvents').css('display', 'none');
+            $('#btn_viewHistory').css('display', 'none');
+            $('#btn_renameWorkflow').css('display', 'none');
+            $('#btn_duplicateWorkflow').css('display', 'none');
+        } else {
+            $('#btn_createStep').css('display', 'block');
+            $('#btn_deleteWorkflow').css('display', 'block');
+            $('#btn_listActionType').css('display', 'block');
+            $('#btn_listEvents').css('display', 'block');
+            $('#btn_viewHistory').css('display', 'block');
+            $('#btn_renameWorkflow').css('display', 'block');
+            $('#btn_duplicateWorkflow').css('display', 'block');
+        }
 
         currentWorkflow = workflowID;
         jsPlumb.reset();
@@ -2141,34 +2172,38 @@
     }
 
     function renameWorkflow() {
-        $('.workflowStepInfo').css('display', 'none');
-        dialog.setContent(
-            '<input type="text" id="workflow_rename" name="workflow_rename" value="' + workflowDescription +
-            '" tabindex="0">' +
-            '</input>');
-        dialog.setTitle('Rename Workflow');
-        dialog.setSaveHandler(function() {
-            $.ajax({
-                type: 'POST',
-                url: '../api/workflow/' + currentWorkflow,
-                data: {
-                    description: $('#workflow_rename').val(),
-                    CSRFToken: CSRFToken
-                },
-                success: function(res) {
-                    if (res != currentWorkflow) {
-                        alert("Prerequisite action needed:\n\n" + res);
-                        dialog.hide();
-                    } else {
-                        loadWorkflowList(res);
-                        workflowDescription = $('#workflow_rename').val();
-                        dialog.hide();
-                    }
-                },
-                error: (err) => console.log(err),
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
+            dialog.setContent(
+                '<input type="text" id="workflow_rename" name="workflow_rename" value="' + workflowDescription +
+                '" tabindex="0">' +
+                '</input>');
+            dialog.setTitle('Rename Workflow');
+            dialog.setSaveHandler(function() {
+                $.ajax({
+                    type: 'POST',
+                    url: '../api/workflow/' + currentWorkflow,
+                    data: {
+                        description: $('#workflow_rename').val(),
+                        CSRFToken: CSRFToken
+                    },
+                    success: function(res) {
+                        if (res != currentWorkflow) {
+                            alert("Prerequisite action needed:\n\n" + res);
+                            dialog.hide();
+                        } else {
+                            loadWorkflowList(res);
+                            workflowDescription = $('#workflow_rename').val();
+                            dialog.hide();
+                        }
+                    },
+                    error: (err) => console.log(err),
+                });
             });
-        });
-        dialog.show();
+            dialog.show();
+        }
     }
 
     /**
@@ -2177,85 +2212,89 @@
      * Created at: 7/26/2023, 1:08:10 PM (America/New_York)
      */
     function duplicateWorkflow() {
-        $('.workflowStepInfo').css('display', 'none');
+        if ($('#subordinate_site_warning').length) {
+            alert('To make changes, please contact the administrator for the Nationally Standardized Primary site.');
+        } else {
+            $('.workflowStepInfo').css('display', 'none');
 
-        dialog.setTitle('Duplicate current workflow');
-        dialog.setContent('<br /><label for="description">New Workflow Title:</label> <input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
-        dialog.setSaveHandler(function() {
-            let old_steps = {};
-            let workflowID;
-            let title = $('#description').val();
+            dialog.setTitle('Duplicate current workflow');
+            dialog.setContent('<br /><label for="description">New Workflow Title:</label> <input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
+            dialog.setSaveHandler(function() {
+                let old_steps = {};
+                let workflowID;
+                let title = $('#description').val();
 
-            postWorkflow(function(workflow_id) {
-                workflowID = workflow_id;
-                dialog.hide();
-            });
-
-            workflows[workflowID] = workflows[currentWorkflow];
-            workflows[workflowID]['workflowID'] = parseInt(workflowID);
-            workflows[workflowID]['description'] = title;
-            old_steps[-1] = -1;
-
-            for(let i in steps) {
-                // add step, if successful update that step
-                addStep(workflowID, steps[i].stepTitle, function(stepID) {
-
-                    if (isNaN(stepID)) {
-                        console.log(stepID);
-                    } else {
-                        old_steps[steps[i].stepID] = stepID;
-                        updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
-
-                        updateTitle(steps[i].stepTitle, stepID, function(res) {
-                            // Alls well that ends well.
-                        });
-
-                        if (steps[i].stepData != null) {
-                            let auto = JSON.parse(steps[i].stepData);
-
-                            let seriesData = {
-                                AutomatedEmailReminders: {
-                                    'Automate Email Group': auto.AutomatedEmailReminders.AutomateEmailGroup,
-                                    'Days Selected': auto.AutomatedEmailReminders.DaysSelected,
-                                    'Date Selected': auto.AutomatedEmailReminders?.DateSelected || '',
-                                    'Additional Days Selected': auto.AutomatedEmailReminders.AdditionalDaysSelected,
-                                }
-                            };
-
-                            updateStepData(seriesData, stepID, function (res) {
-                                // Alls well that ends well.
-                            });
-                        }
-
-                        updateApprover(steps[i].indicatorID_for_assigned_empUID, stepID, function (res) {
-                            // Alls well that ends well.
-                        });
-
-                        updateGroupApprover(steps[i].indicatorID_for_assigned_groupID, stepID, function (res) {
-                            // Alls well that ends well.
-                        });
-
-                        // set requireDigitalSignature
-                        // this endpoint does not exist in this file at this time.
-
-                        updateDependencies(steps[i].stepID, old_steps);
-                    }
+                postWorkflow(function(workflow_id) {
+                    workflowID = workflow_id;
+                    dialog.hide();
                 });
 
+                workflows[workflowID] = workflows[currentWorkflow];
+                workflows[workflowID]['workflowID'] = parseInt(workflowID);
+                workflows[workflowID]['description'] = title;
+                old_steps[-1] = -1;
 
-            }
+                for(let i in steps) {
+                    // add step, if successful update that step
+                    addStep(workflowID, steps[i].stepTitle, function(stepID) {
 
-            workflows[workflowID]['initialStepID'] = parseInt(old_steps[workflows[currentWorkflow].initialStepID]);
+                        if (isNaN(stepID)) {
+                            console.log(stepID);
+                        } else {
+                            old_steps[steps[i].stepID] = stepID;
+                            updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
 
-            updateInitialStep(workflowID, workflows[workflowID]['initialStepID'], function () {
-                // nothing to do here
+                            updateTitle(steps[i].stepTitle, stepID, function(res) {
+                                // Alls well that ends well.
+                            });
+
+                            if (steps[i].stepData != null) {
+                                let auto = JSON.parse(steps[i].stepData);
+
+                                let seriesData = {
+                                    AutomatedEmailReminders: {
+                                        'Automate Email Group': auto.AutomatedEmailReminders.AutomateEmailGroup,
+                                        'Days Selected': auto.AutomatedEmailReminders.DaysSelected,
+                                        'Date Selected': auto.AutomatedEmailReminders?.DateSelected || '',
+                                        'Additional Days Selected': auto.AutomatedEmailReminders.AdditionalDaysSelected,
+                                    }
+                                };
+
+                                updateStepData(seriesData, stepID, function (res) {
+                                    // Alls well that ends well.
+                                });
+                            }
+
+                            updateApprover(steps[i].indicatorID_for_assigned_empUID, stepID, function (res) {
+                                // Alls well that ends well.
+                            });
+
+                            updateGroupApprover(steps[i].indicatorID_for_assigned_groupID, stepID, function (res) {
+                                // Alls well that ends well.
+                            });
+
+                            // set requireDigitalSignature
+                            // this endpoint does not exist in this file at this time.
+
+                            updateDependencies(steps[i].stepID, old_steps);
+                        }
+                    });
+
+
+                }
+
+                workflows[workflowID]['initialStepID'] = parseInt(old_steps[workflows[currentWorkflow].initialStepID]);
+
+                updateInitialStep(workflowID, workflows[workflowID]['initialStepID'], function () {
+                    // nothing to do here
+                });
+
+                updateRoutes(workflowID, old_steps);
+                updateRouteEvents(currentWorkflow, workflowID, old_steps);
+                loadWorkflowList(workflowID);
             });
-
-            updateRoutes(workflowID, old_steps);
-            updateRouteEvents(currentWorkflow, workflowID, old_steps);
-            loadWorkflowList(workflowID);
-        });
-        dialog.show();
+            dialog.show();
+        }
     }
 
     /**
@@ -3004,6 +3043,15 @@
                     warnContent +=
                         `Please contact your process POC if modifications need to be made.</span></div>`;
                     $('#bodyarea').prepend(warnContent);
+
+                    $('#btn_createStep').css('display', 'none');
+                    $('#btn_deleteWorkflow').css('display', 'none');
+                    $('#btn_newWorkflow').css('display', 'none');
+                    $('#btn_listActionType').css('display', 'none');
+                    $('#btn_listEvents').css('display', 'none');
+                    $('#btn_viewHistory').css('display', 'none');
+                    $('#btn_renameWorkflow').css('display', 'none');
+                    $('#btn_duplicateWorkflow').css('display', 'none');
                 }
             },
             error: err => console.log(err),

--- a/LEAF_Request_Portal/api/controllers/FormEditorController.php
+++ b/LEAF_Request_Portal/api/controllers/FormEditorController.php
@@ -19,11 +19,14 @@ class FormEditorController extends RESTfulResponse
 
     private $login;
 
-    public function __construct($db, $login)
+    private $subordinate;
+
+    public function __construct($db, $login, $subordinate = false)
     {
         $this->form = new Form($db, $login);
         $this->formEditor = new FormEditor($db, $login);
         $this->login = $login;
+        $this->subordinate = $subordinate;
     }
 
     public function get($act)
@@ -69,6 +72,7 @@ class FormEditorController extends RESTfulResponse
     public function post($act)
     {
         $formEditor = $this->formEditor;
+        $subordinate = $this->subordinate;
 
         //        $this->verifyAdminReferrer();
         // The above line was commented out when I
@@ -88,7 +92,7 @@ class FormEditorController extends RESTfulResponse
             $this->index['POST']->register('formEditor', function ($args) {
             });
 
-            $this->index['POST']->register('formEditor/newIndicator', function ($args) use ($formEditor) {
+            $this->index['POST']->register('formEditor/newIndicator', function ($args) use ($formEditor, $subordinate) {
                 $package = array();
                 $package['name'] = XSSHelpers::sanitizeHTML($_POST['name']);
                 $package['format'] = strip_tags($_POST['format']);
@@ -103,7 +107,7 @@ class FormEditorController extends RESTfulResponse
                 $package['is_sensitive'] = $_POST['is_sensitive'];
                 $package['sort'] = (int)$_POST['sort'];
 
-                return $formEditor->addIndicator($package);
+                return $formEditor->addIndicator($package, $subordinate);
             });
 
             $this->index['POST']->register('formEditor/sort/batch', function ($args) use ($formEditor) {
@@ -173,11 +177,15 @@ class FormEditorController extends RESTfulResponse
                 return $formEditor->setCondition((int)$args[0], $_POST['conditions']);
             });
 
-            $this->index['POST']->register('formEditor/new', function ($args) use ($formEditor) {
+            $this->index['POST']->register('formEditor/new', function ($args) use ($formEditor, $subordinate) {
                 return $formEditor->createForm(
                     XSSHelpers::sanitizeHTML($_POST['name']),
                     XSSHelpers::sanitizeHTML($_POST['description']),
-                    XSSHelpers::sanitizeHTML($_POST['parentID'])
+                    XSSHelpers::sanitizeHTML($_POST['parentID']),
+                    null,
+                    null,
+                    0,
+                    $subordinate
                 );
             });
 

--- a/LEAF_Request_Portal/api/controllers/WorkflowController.php
+++ b/LEAF_Request_Portal/api/controllers/WorkflowController.php
@@ -15,9 +15,12 @@ class WorkflowController extends RESTfulResponse
 
     private $workflow;
 
-    public function __construct($db, $login)
+    private $subordinate;
+
+    public function __construct($db, $login, $subordinate = false)
     {
         $this->workflow = new Workflow($db, $login);
+        $this->subordinate = $subordinate;
     }
 
     public function get($act)
@@ -142,6 +145,7 @@ class WorkflowController extends RESTfulResponse
     public function post($act)
     {
         $workflow = $this->workflow;
+        $subordinate = $this->subordinate;
 
         $this->verifyAdminReferrer();
 
@@ -161,8 +165,8 @@ class WorkflowController extends RESTfulResponse
             }
         });
 
-        $this->index['POST']->register('workflow/new', function ($args) use ($workflow) {
-            return $workflow->newWorkflow(XSSHelpers::xscrub($_POST['description']));
+        $this->index['POST']->register('workflow/new', function ($args) use ($workflow, $subordinate) {
+            return $workflow->newWorkflow(XSSHelpers::xscrub($_POST['description']), $subordinate);
         });
 
         $this->index['POST']->register('workflow/events', function ($args) use ($workflow) {
@@ -184,10 +188,10 @@ class WorkflowController extends RESTfulResponse
             return $workflow->createAction((int)$_POST['stepID'], (int)$_POST['nextStepID'], XSSHelpers::xscrub($_POST['action']));
         });
 
-        $this->index['POST']->register('workflow/[digit]/step', function ($args) use ($workflow) {
+        $this->index['POST']->register('workflow/[digit]/step', function ($args) use ($workflow, $subordinate) {
             $workflow->setWorkflowID((int)$args[0]);
 
-            return $workflow->createStep(XSSHelpers::xscrub($_POST['stepTitle']), XSSHelpers::xscrub($_POST['stepBgColor']), XSSHelpers::xscrub($_POST['stepFontColor']));
+            return $workflow->createStep(XSSHelpers::xscrub($_POST['stepTitle']), XSSHelpers::xscrub($_POST['stepBgColor']), XSSHelpers::xscrub($_POST['stepFontColor']), $subordinate);
         });
 
         $this->index['POST']->register('workflow/[digit]/initialStep', function ($args) use ($workflow) {

--- a/LEAF_Request_Portal/api/index.php
+++ b/LEAF_Request_Portal/api/index.php
@@ -17,6 +17,7 @@ require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 $login->setBaseDir('../');
 
 $p_db = $db;
+$subordinate = $settings['siteType'];
 
 $action = isset($_GET['a']) ? $_GET['a'] : $_SERVER['PATH_INFO'];
 $keyIndex = strpos($action, '/');
@@ -70,8 +71,8 @@ if ($login->checkGroup(1))
         echo $controller->handler($action);
     });
 
-    $controllerMap->register('formEditor', function () use ($p_db, $login, $action) {
-        $formEditorController = new Portal\FormEditorController($p_db, $login);
+    $controllerMap->register('formEditor', function () use ($p_db, $login, $action, $subordinate) {
+        $formEditorController = new Portal\FormEditorController($p_db, $login, $subordinate);
         echo $formEditorController->handler($action);
     });
 
@@ -110,8 +111,8 @@ $controllerMap->register('formWorkflow', function () use ($p_db, $login, $action
     echo $formWorkflowController->handler($action);
 });
 
-$controllerMap->register('workflow', function () use ($p_db, $login, $action) {
-    $workflowController = new Portal\WorkflowController($p_db, $login);
+$controllerMap->register('workflow', function () use ($p_db, $login, $action, $subordinate) {
+    $workflowController = new Portal\WorkflowController($p_db, $login, $subordinate);
     echo $workflowController->handler($action);
 });
 

--- a/LEAF_Request_Portal/api/index.php
+++ b/LEAF_Request_Portal/api/index.php
@@ -17,7 +17,7 @@ require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 $login->setBaseDir('../');
 
 $p_db = $db;
-$subordinate = $settings['siteType'];
+$subordinate = $settings['siteType'] == 'national_subordinate' ? true : false;
 
 $action = isset($_GET['a']) ? $_GET['a'] : $_SERVER['PATH_INFO'];
 $keyIndex = strpos($action, '/');


### PR DESCRIPTION
Summary:
When a site is configured as a Nationally Standardized Subordinate[0] site, the admin should not be able to:

Add new workflows[1]
Add new steps to existing workflows[2]
Add new forms[3]
Add new fields to existing forms[4]
For functions that can return a human readable error message, the error should state: "To make changes, please contact the administrator for the Nationally Standardized Primary site."

Potential Impact:
Really only for subordinate sites. The loophole that would allow an admin to modify workflows and forms has been closed.

Testing:
Being an admin and from a subordinate site access the workflow
    go to admin
    paste ?a=workflow to the end of the url
    from the console type newWorkflow(); and press enter
Do the same with form
    from admin add ?a=form to the url
    from the console type createForm(); press enter
In both instances you should get an alert with the message from above.