### PR TITLE
UserIDs are case insensitive

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1705,7 +1705,7 @@ class Form
 
         // give the requestor access if the record explictly gives them write access
         if ($resRecords[0]['isWritableUser'] == 1 &&
-            ($this->login->getUserID() == $resRecords[0]['userID'] || $this->checkIfBackup($this->getEmpUID($resRecords[0]['userID'])))
+            (strtolower($this->login->getUserID()) == strtolower($resRecords[0]['userID']) || $this->checkIfBackup($this->getEmpUID($resRecords[0]['userID'])))
         )
         {
             $this->cache["hasWriteAccess_{$recordID}_{$categoryID}"] = 1;
@@ -1915,7 +1915,7 @@ class Form
 
                 break;
             case -2: // dependencyID -2 : requestor followup
-                 if ($details['userID'] == $this->login->getUserID())
+                 if (strtolower($details['userID']) == strtolower($this->login->getUserID()))
                  {
                      return true;
                  }
@@ -2224,7 +2224,7 @@ class Form
                         }
 
                         // request initiator
-                        if ($dep['userID'] == $this->login->getUserID()) {
+                        if (strtolower($dep['userID']) == strtolower($this->login->getUserID())) {
                             $temp[$dep['recordID']] = 1;
                         }
 


### PR DESCRIPTION
UserIDs are case insensitive, so comparisons should account for this.

Steps to reproduce issue:
1. Identify a record that has been sent back to the "Request Initiator" (the very first step in the workflow)
2. Access the database: Portal.records table, and edit the userID for the record so it has a different letter case
3. Note that the data fields are locked

### Potential Impact
This modifies sensitive functions that deal with read/write access, however the changes are very clear.

### Testing
- [Automated test added](https://github.com/department-of-veterans-affairs/LEAF/pull/2226/commits/a5ec479e36fa770b34d21dc6a4e5142e273d4f7a#diff-66c58f3bac1d07f8de672faa21954bf8afc63f5ecc63cdfa976e8bc53caef400R50)

- [ ] Issue cannot be reproduced with this patch