### PR TITLE
LEAF-4157 - Resolve UX issue in formSearch.js

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -958,12 +958,17 @@ var LeafFormSearch = function (containerID) {
                                 "</option>";
                         }
                         categories += "</select>";
-                        $("#" + prefixID + "widgetMatch_" + widgetID).html(
-                            categories
-                        );
-                        chosenOptions();
-                        if (callback != undefined) {
-                            callback();
+                        // quick and dirty fix to avoid a race condition related to custom
+                        // implementations of formSearch. Since the new default UI will trigger
+                        // the parent ajax call, we don't want to overwrite the existing widget
+                        if($("#" + prefixID + "widgetMatch_" + widgetID).html() == "") {
+                            $("#" + prefixID + "widgetMatch_" + widgetID).html(
+                                categories
+                            );
+                            chosenOptions();
+                            if (callback != undefined) {
+                                callback();
+                            }
                         }
                     },
                 });


### PR DESCRIPTION
This resolves an issue where the search term's first item could be drawn incorrectly.

Steps to reproduce issue:
1. Report Builder: set the filter to "Title CONTAINS test"
2. Continue and Generate the report
3. Refresh the screen
4. Click "Modify Report"
5. Note that the filter incorrectly states "Title CONTAINS [Resolved]", where [Resolved] is a dropdown.

### Potential Impact
Areas that depend on formSearch.js.

### Testing
- [x] The issue cannot be reproduced after this patch has been applied
