### PR TITLE
LEAF-4155: Custom Fields not added to non-custom email templates

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1365,12 +1365,15 @@ class FormWorkflow
             if (preg_match('/CustomEvent_/', $event['eventID'])) {
                 $customEvent = $event['eventID'];
             }
+            $fields = $this->getFields();
+
             switch ($event['eventID']) {
                 case 'std_email_notify_next_approver': // notify next approver
                     $email = new Email();
 
                     $email->addSmartyVariables(array(
-                        "comment" => $comment
+                        "comment" => $comment,
+                        "field" => $fields
                     ));
 
                     $dir = $this->getDirectory();
@@ -1414,7 +1417,8 @@ class FormWorkflow
                             "service" => $requestRecords[0]['service'],
                             "lastStatus" => $requestRecords[0]['lastStatus'],
                             "comment" => $comment,
-                            "siteRoot" => $this->siteRoot
+                            "siteRoot" => $this->siteRoot,
+                            "field" => $fields
                         ));
                         $email->setTemplateByID(Email::NOTIFY_COMPLETE);
 
@@ -1470,7 +1474,6 @@ class FormWorkflow
                         $email = new Email();
 
                         $title = strlen($requestRecords[0]['title']) > 45 ? substr($requestRecords[0]['title'], 0, 42) . '...' : $requestRecords[0]['title'];
-                        $fields = $this->getFields();
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $title,
@@ -1540,7 +1543,9 @@ class FormWorkflow
                                            'workflowID' => $workflowID,
                                            'stepID' => $stepID,
                                            'actionType' => $actionType,
-                                           'comment' => $comment, );
+                                           'comment' => $comment,
+                                           "field" => $fields
+                        );
 
                         $customClassName = "Portal\\CustomEvent_{$event['eventID']}";
 


### PR DESCRIPTION
### Summary
There was reported behavior that showed custom email fields not showing in cases other than custom emails. This change modifies the logic so that custom email fields are usable in the body of any type of email.

### Potential Impact
Custom email fields are now usable in default email templates.

### Testing
Test every kind of email with custom email fields
* Custom emails
* Notify Requestor
* Notify Next Approver