### PR TITLE
LEAF-4165 - User Access Group History

### DIFF
--- a/LEAF_Request_Portal/sources/Group.php
+++ b/LEAF_Request_Portal/sources/Group.php
@@ -392,7 +392,7 @@ class Group
             $vars = array(':userID' => $member,
                           ':groupID' => $groupID, );
 
-            $this->dataActionLogger->logAction(DataActions::MODIFY, LoggableTypes::EMPLOYEE, [
+            $this->dataActionLogger->logAction(DataActions::DELETE, LoggableTypes::EMPLOYEE, [
                 new LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
                 new LogItem("users", "groupID", $groupID, $this->getGroupName($groupID))
             ]);
@@ -422,7 +422,7 @@ class Group
     public function removeMember($member, $groupID): void
     {
         if (is_numeric($groupID) && $member != '') {
-            $this->dataActionLogger->logAction(DataActions::DELETE, LoggableTypes::EMPLOYEE, [
+            $this->dataActionLogger->logAction(DataActions::PRUNE, LoggableTypes::EMPLOYEE, [
                 new LogItem("users", "userID", $member, $this->getEmployeeDisplay($member)),
                 new LogItem("users", "groupID", $groupID, $this->getGroupName($groupID))
             ]);

--- a/app/Leaf/Logger/Formatters/DataActions.php
+++ b/app/Leaf/Logger/Formatters/DataActions.php
@@ -11,4 +11,5 @@ class DataActions
     const RESTORE = 'restore';
     const CREATE = 'create';
     const MERGE = 'merge';
+    const PRUNE = 'prune';
 }

--- a/app/Leaf/Logger/Formatters/PortalGroupFormatter.php
+++ b/app/Leaf/Logger/Formatters/PortalGroupFormatter.php
@@ -24,6 +24,10 @@ class PortalGroupFormatter{
         DataActions::DELETE.'-'.LoggableTypes::EMPLOYEE => [
             "message" => "removed <strong>user:</strong> %s",
             "variables" => "userID"
+        ],
+        DataActions::PRUNE.'-'.LoggableTypes::EMPLOYEE => [
+            "message" => "pruned <strong>user:</strong> %s",
+            "variables" => "userID"
         ]
     ];
 


### PR DESCRIPTION
### Summary:
This addresses a Help Desk ticket where users couldn't view the deleted timestamp in the User Group history modal.

### Potential Impact:
Users will now see deleted and pruned users correctly in the group history Modal.

### Testing:
- Removal:
Navigate to Admin > User Access > Select User Group
Add Employee > Select User > Click "Save"
Click "Delete" > Click "View History"
Verify the display of "user" removed user: "removed user"

- Pruning:
Navigate to Admin > User Access > Select User Group
Click "Show Inactive Users" > Click "Prune" > Click "View History"
Verify the display of "user" pruned user: "pruned user"