### PR TITLE
LEAF 4166 prevent checkmark if initial value is empty

### DIFF
--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -119,7 +119,7 @@
             <ul style="list-style: none">
             <!--{foreach from=$indicator.value item=option}-->
                     <input type="hidden" name="<!--{$indicator.indicatorID}-->[<!--{$idx}-->]" value="no" />
-                    <!--{if $indicator.value[$idx] != 'no'}-->
+                    <!--{if $indicator.value[$idx] != 'no' && $indicator.value[$idx] !== ''}-->
                         <li><img class="print" src="dynicons/?img=dialog-apply.svg&w=16" style="vertical-align: middle" alt="checked" />
                         <!--{$option|sanitize}--></li>
                     <!--{/if}-->


### PR DESCRIPTION
To reproduce this issue:
Create a request that includes a checkboxes format question.
Go directly to the print view / review page.
Note that a checkmark displays even though no information was entered.

Testing / Impact
Specific to checkboxes format form questions.
Ensure above behavior no longer occurs and that no unexpected behavior is introduced.