### PR TITLE
Leaf 4171 - Improve customizability for Employee Selector

### DIFF
--- a/LEAF_Nexus/js/employeeSelector.js
+++ b/LEAF_Nexus/js/employeeSelector.js
@@ -19,6 +19,7 @@ function employeeSelector(containerID) {
   this.intervalID = null;
   this.selectHandler = null;
   this.resultHandler = null;
+  this.selectHandlers = [];
   this.selectLink = null;
   this.selectionData = new Object();
   this.optionNoLimit = 0;
@@ -108,6 +109,7 @@ employeeSelector.prototype.select = function (id) {
   if (this.selectHandler != null) {
     this.selectHandler();
   }
+  this.selectHandlers.forEach(selectHandler => selectHandler());
 };
 
 employeeSelector.prototype.setSelectHandler = function (func) {
@@ -116,6 +118,15 @@ employeeSelector.prototype.setSelectHandler = function (func) {
 
 employeeSelector.prototype.setResultHandler = function (func) {
   this.resultHandler = func;
+};
+
+nationalEmployeeSelector.prototype.addSelectHandler = function (func) {
+    if(typeof func == 'function') {
+        this.selectHandlers.push(func);
+    }
+    else {
+        console.error('argument supplied to addSelectHandler must be a function');
+    }
 };
 
 employeeSelector.prototype.setSelectLink = function (link) {

--- a/LEAF_Nexus/js/employeeSelector.js
+++ b/LEAF_Nexus/js/employeeSelector.js
@@ -120,7 +120,7 @@ employeeSelector.prototype.setResultHandler = function (func) {
   this.resultHandler = func;
 };
 
-nationalEmployeeSelector.prototype.addSelectHandler = function (func) {
+employeeSelector.prototype.addSelectHandler = function (func) {
     if(typeof func == 'function') {
         this.selectHandlers.push(func);
     }

--- a/LEAF_Nexus/js/nationalEmployeeSelector.js
+++ b/LEAF_Nexus/js/nationalEmployeeSelector.js
@@ -19,6 +19,7 @@ function nationalEmployeeSelector(containerID) {
   this.intervalID = null;
   this.selectHandler = null;
   this.resultHandler = null;
+  this.selectHandlers = [];
   this.selectLink = null;
   this.selectionData = new Object();
   this.optionNoLimit = 0;
@@ -161,6 +162,7 @@ nationalEmployeeSelector.prototype.select = function (id) {
   if (this.selectHandler != null) {
     this.selectHandler();
   }
+  this.selectHandlers.forEach(selectHandler => selectHandler());
 };
 
 nationalEmployeeSelector.prototype.setSelectHandler = function (func) {
@@ -169,6 +171,15 @@ nationalEmployeeSelector.prototype.setSelectHandler = function (func) {
 
 nationalEmployeeSelector.prototype.setResultHandler = function (func) {
   this.resultHandler = func;
+};
+
+nationalEmployeeSelector.prototype.addSelectHandler = function (func) {
+    if(typeof func == 'function') {
+        this.selectHandlers.push(func);
+    }
+    else {
+        console.error('argument supplied to addSelectHandler must be a function');
+    }
 };
 
 nationalEmployeeSelector.prototype.setSelectLink = function (link) {


### PR DESCRIPTION
This simplifies customization of the employee selector. Instead of requiring a dev to re-implement the default select handler, this introduces the new method addSelectHandler() to execute custom functions after the default handler has run.

Example use case: https://github.com/department-of-veterans-affairs/LEAF-Developer-Examples/blob/master/forms/custom_fields/copy_orgchart_employee_email_to_new_field.md

### Potential Impact
Loading of employeeSelector.js and nationalEmployeeSelector.js.

### Testing
Successful completion of these tests ensure that the modified files have been loaded correctly.
- [x] On the Main page -> Advanced Options, you can search for "Initiator IS [name]"
- [x] When filling out a record, you can fill out an orgchart_employee field
