### PR TITLE
Leaf 4172 - Avoid ambiguous query when used in combination with a data query

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3001,7 +3001,7 @@ class Form
             $vars[':' . $q['id'] . $count] = $q['match'];
             switch ($q['id']) {
                 case 'recordID':
-                    $conditions .= "{$gate}recordID {$operator} :recordID{$count}";
+                    $conditions .= "{$gate}records.recordID {$operator} :recordID{$count}";
 
                     break;
                 case 'recordIDs':
@@ -3017,7 +3017,7 @@ class Form
                     }
                     $validRecordIDs = trim($validRecordIDs, ',');
 
-                    $conditions .= "{$gate}recordID IN ({$validRecordIDs})";
+                    $conditions .= "{$gate}records.recordID IN ({$validRecordIDs})";
 
                     unset($vars[":recordIDs{$count}"]);
 


### PR DESCRIPTION
This resolves an issue where a Report Builder query that contains the following terms results in an ambiguous query.
- RecordID
- Data field

The ambiguity happens because the Data field uses a join that retrieves the RecordID from a different table.

### Potential Impact
Searches for record ID

### Testing
[Automated test case](https://github.com/mgaoVA/LEAF_test_experiments/commit/f3ef7f815d37823eefb65bdac027aabb4c1d1baf#diff-b7b1922b928b6c4ca9f0342a10188972bc7aa07897032f05faff1cb2b96f5234R115)
- [x] On the main page, typing a valid record ID # returns the associated record
- [x] Searching for a record ID AND a specific data field returns expected data[0]


[0] For example if record 500 contains a field filled with 12345, you should expect to find it when searching for Record ID = 500 AND Any standard data field CONTAINS 123*.