### PR TITLE
Leaf 4173 - Prevent invalid query

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -281,10 +281,12 @@ class FormWorkflow
                         }, $groupIDs);
     
             $groupIDs = implode(',', $groupIDs);
-            $res = $this->db->prepared_query("SELECT groupID, name FROM `groups`
-                                                WHERE groupID IN ({$groupIDs})", []);
-            foreach($res as $group) {
-                $groupNames[$group['groupID']] = $group['name'];
+            if($groupIDs != "") {
+                $res = $this->db->prepared_query("SELECT groupID, name FROM `groups`
+                                                   WHERE groupID IN ({$groupIDs})", []);
+                foreach($res as $group) {
+                    $groupNames[$group['groupID']] = $group['name'];
+                }
             }
         }
 


### PR DESCRIPTION
This prevents an invalid query, because the groupID variable here can actually be blank. The invalid query did not cause any end-user impact, however it's cleaner to not run an invalid query in the first place.

### Potential Impact
Queries that involve "group designated" records

### Testing
This passes [existing tests](https://github.com/mgaoVA/LEAF_test_experiments/blob/main/Go/formQuery_test.go#L71) related to group designated records.