### PR TITLE
LEAF-4107-Remove-Console-Logs-From-Editors

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -280,7 +280,6 @@
             },
             url: '../api/templateFileHistory/_' + currentFile,
             success: function(res) {
-                console.log("File history has been saved.");
                 getFileHistory(currentFile);
             }
         })
@@ -471,7 +470,6 @@
             dataType: 'json',
             success: function(res) {
                 if (res.length === 0) {
-                    console.log('There are no files in the directory');
                     var contentMessage = '<p class="contentMessage">There are no history files.</p>';
                     $('.file-history-res').html(contentMessage);
                     return;
@@ -482,7 +480,6 @@
                 });
 
                 if (fileNames.indexOf(template) === -1) {
-                    console.log('Template file not found in directory');
                     return;
                 }
 
@@ -859,8 +856,6 @@
 
         if (windowWidth < 1024) {
             $('.leaf-right-nav').css('right', '-100%');
-        } else {
-            console.log('Please check the width of the window');
         }
         $.ajax({
             type: 'GET',

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -313,7 +313,6 @@
                     console.log('Error occurred during the save operation:', errorThrown);
                 }
             });
-            console.log('Your Template has been saved.');
         }
 
         function showDialog(message, color) {
@@ -382,7 +381,6 @@
                 currentSubjectContent = subject;
                 currentEmailToContent = emailToData;
                 currentEmailCcContent = emailCcData;
-                console.log("File history has been saved.");
                 getFileHistory(currentFile);
             }
         });
@@ -418,7 +416,6 @@
             dataType: 'json',
             success: function(res) {
                 if (res.length === 0) {
-                    console.log('There are no files in the directory');
                     var contentMessage = '<p class="contentMessage">There are no history files.</p>';
                     $('.file-history-res').html(contentMessage);
                     return;
@@ -429,7 +426,6 @@
                 });
 
                 if (!fileNames.includes(template)) {
-                    console.log('Template file not found in directory');
                     return;
                 }
 
@@ -630,7 +626,6 @@
             dataType: 'json',
             cache: false,
             success: function(res) {
-                console.log(res);
                 loadContent(currentName, currentFile, currentSubjectFile, currentEmailToFile,
                     currentEmailCcFile);
                 exitExpandScreen();
@@ -664,7 +659,6 @@
         } else if (templateFile !== null) {
             loadContent(templateName, templateFile, templateSubjectFile, templateEmailToFile, templateEmailCcFile);
         } else {
-            console.log('else');
             loadContent(undefined, 'LEAF_main_email_template.tpl', undefined, undefined, undefined);
         }
     }
@@ -1170,8 +1164,6 @@
 
         if (windowWidth < 1024) {
             $('.leaf-right-nav').css('right', '-100%');
-        } else {
-            console.log('Please check the width of the window');
         }
         $.ajax({
             type: 'GET',

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -218,7 +218,6 @@
             },
             url: '../api/applet/fileHistory/_' + currentFile,
             success: function(res) {
-                console.log("File history has been saved.");
                 getFileHistory(currentFile);
             }
         });
@@ -404,7 +403,6 @@
             url: '../api/applet/deleteHistoryFileReport/_' + templateFile + '?' +
                 $.param({'CSRFToken': '<!--{$CSRFToken}-->'}),
                 success: function() {
-                    console.log(templateFile + ', was deleted');
                     location.reload();
                 }
         });
@@ -438,7 +436,6 @@
             dataType: 'json',
             success: function(res) {
                 if (res.length === 0) {
-                    console.log('There are no files in the directory');
                     var contentMessage = '<p class="contentMessage">There are no history files.</p>';
                     $('.file-history-res').html(contentMessage);
                     return;
@@ -449,7 +446,6 @@
                 });
 
                 if (fileNames.indexOf(template) === -1) {
-                    console.log('Template file not found in directory');
                     return;
                 }
 
@@ -854,8 +850,6 @@
 
         if (windowWidth < 1024) {
             $('.leaf-right-nav').css('right', '-100%');
-        } else {
-            console.log('Please check the width of the window');
         }
         $.ajax({
             type: 'GET',

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -446,6 +446,7 @@
                 });
 
                 if (fileNames.indexOf(template) === -1) {
+                    alert('Template file not found in directory');
                     return;
                 }
 


### PR DESCRIPTION
### Summary:

Cleaned code for template editors to prevent console logs from displaying in dev tools during certain processes.

### Potential Impact:

Users will no longer encounter console logs during specified processes, enhancing the overall user interface.

### Testing:
1. Navigate to the template editor.
2. Open the browser's developer tools (F12).
3. Select the console tab.
4. Perform actions like saving and deleting. Confirm that no console logs are visible during these processes.