### PR TITLE
LEAF 4184 reset limit offset to 0 on filtered search

### DIFF
--- a/LEAF_Request_Portal/admin/templates/view_form_library.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_form_library.tpl
@@ -47,6 +47,7 @@ function showPreview(recordID) {
 
 function applyFilter(search) {
     query.updateDataTerm('data', '3', 'LIKE', '*' + search + '*');
+    query.setLimitOffset(0);
     query.execute();
     announceFilter(search);
 }


### PR DESCRIPTION
Sets the query limit offset back to 0 when applying a search filter to LEAF Library results.

Testing/Impact

LEAF Library page.
Business Lines filter should return filtered results.

Follow-up testing will need to occur on staging/preprod
This update cannot easily be tested locally because local dev would need a library portal with specific form/indicators and a sufficient number of posted forms.