### PR TITLE
Leaf 4186 - Persist original parameters

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -11,7 +11,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   let results = {};
   let batchSize = 500;
   let abortSignal;
-  let firstRun = true;
+  let firstRun = true; // keep track of query limit state, to align with user intent
   let origLimit, origLimitOffset;
 
   clearTerms();
@@ -93,6 +93,7 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
    * @memberOf LeafFormQuery
    */
   function setLimit(offset = 50, limit = 0) {
+    firstRun = true;
     if (limit === 0) {
       query.limit = offset;
     } else {

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -11,6 +11,8 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
   let results = {};
   let batchSize = 500;
   let abortSignal;
+  let firstRun = true;
+  let origLimit, origLimitOffset;
 
   clearTerms();
 
@@ -280,6 +282,15 @@ var LeafFormQuery = function () { //NOTE: keeping this a var in case custom code
    * @memberOf LeafFormQuery
    */
   function execute() {
+    if(firstRun) {
+        firstRun = false;
+        origLimit = query.limit;
+        origLimitOffset = query.limitOffset;
+    } else {
+        query.limit = origLimit;
+        query.limitOffset = origLimitOffset;
+    }
+
     if (query.getData != undefined && query.getData.length == 0) {
       delete query.getData;
     }


### PR DESCRIPTION
This prevents an issue where subsequent executions of formQuery don't reset limit counters to their original intended state.

To reproduce the issue, view this LEAF Programmer script on a site that has more than 500 records:
```html
<script>

async function main() {

    let resultDom = document.querySelector('#result');
    
    let query = new LeafFormQuery();

    let result = await query.execute();
    resultDom.innerHTML += `First run #: ${Object.keys(result).length}<br />`;
    
    let result2 = await query.execute();
    resultDom.innerHTML += `Second run should be the same #: ${Object.keys(result2).length}`;

}

document.addEventListener('DOMContentLoaded', main);
</script>

<div id="result"></div>

```


### Potential Impact
Areas where formQuery.js is used, such as the main page and report builder

### Testing
- [x] The numbers in the provided LEAF Programmer script match
- [ ] PREPROD: The LEAF Library's filters on the left-hand side work normally