### PR TITLE
hotfix sub email template

### DIFF
--- a/LEAF_Request_Portal/utils/LEAF_exportStandardConfig.php
+++ b/LEAF_Request_Portal/utils/LEAF_exportStandardConfig.php
@@ -28,12 +28,14 @@ function exportTable($db, $tempFolder, $table) {
         case 'category_staples':
         case 'dependencies':
         case 'indicators':
+        case 'events':
         case 'route_events':
         case 'workflows':
         case 'workflow_steps':
         case 'step_dependencies':
         case 'workflow_routes':
         case 'step_modules':
+        case 'email_templates':
             break;
         default:
             exit();
@@ -48,9 +50,11 @@ exportTable($db, $tempFolder, 'categories');
 exportTable($db, $tempFolder, 'category_staples');
 exportTable($db, $tempFolder, 'dependencies');
 exportTable($db, $tempFolder, 'indicators');
+exportTable($db, $tempFolder, 'events');
 exportTable($db, $tempFolder, 'route_events');
 exportTable($db, $tempFolder, 'workflows');
 exportTable($db, $tempFolder, 'workflow_steps');
 exportTable($db, $tempFolder, 'step_dependencies');
 exportTable($db, $tempFolder, 'workflow_routes');
 exportTable($db, $tempFolder, 'step_modules');
+exportTable($db, $tempFolder, 'email_templates');


### PR DESCRIPTION
Summary:
When a primary site pushes changes to the subordinate sites tables on the subordinate sites are truncated or deleted and then repopulated with data from the primary, With an update that went out a week or two ago the export did not get updated to include the events and email_templates tables. But they were included on the import side. So these tables are getting deleted and nothing is being added back in from the primary. This PR makes sure that the sql files are getting created so they can be pushed to the subordinate.

Potential Impact:
Subordinates will have the events and email_templates now.

Testing:
Push contents from a primary out to it's subordinates and be sure that the email templates are on the subordinate sites.