### PR TITLE
LEAF-4199 - Text updates

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -206,8 +206,8 @@ class FormWorkflow
                     $approver = $dir->lookupEmpUID($dRecords[$v['recordID']]['data']);
                     
                     if (empty($approver[0]['Fname']) && empty($approver[0]['Lname'])) {
-                        $srcRecords[$i]['description'] = $srcRecords[$i]['stepTitle'] . ' (' . $dRecords[$v['recordID']]['name'] . ')';
-                        $srcRecords[$i]['approverName'] = $dRecords[$v['recordID']]['name'];
+                        $srcRecords[$i]['description'] = $srcRecords[$i]['stepTitle'] . ' ( *NEEDS REASSIGNMENT* ' . $dRecords[$v['recordID']]['name'] . ')';
+                        $srcRecords[$i]['approverName'] = '*NEEDS REASSIGNMENT* ' . $dRecords[$v['recordID']]['name'];
                         $srcRecords[$i]['approverUID'] = 'indicatorID:' . $res[$i]['indicatorID_for_assigned_empUID'];
                     }
                     else {

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -1,5 +1,5 @@
 <!--{if $deleted > 0}-->
-    <div style="font-size: 36px"><img src="dynicons/?img=emblem-unreadable.svg&amp;w=96"
+    <div style="font-size: 36px"><img src="dynicons/?img=emblem-unreadable.svg&amp;w=96" alt=""
             style="float: left" /> Notice: This request has been marked as cancelled and will be permanently deleted.<br />
         <span class="buttonNorm" onclick="restoreRequest(<!--{$recordID|strip_tags}-->)"><img
                 src="dynicons/?img=document-open.svg&amp;w=32" /> Restore request</span>

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -1,8 +1,8 @@
 <!--{if $deleted > 0}-->
-    <div style="font-size: 36px"><img src="dynicons/?img=emblem-unreadable.svg&amp;w=96" alt="Unreadable"
-            style="float: left" /> Notice: This request has been marked as deleted.<br />
+    <div style="font-size: 36px"><img src="dynicons/?img=emblem-unreadable.svg&amp;w=96"
+            style="float: left" /> Notice: This request has been marked as cancelled and will be permanently deleted.<br />
         <span class="buttonNorm" onclick="restoreRequest(<!--{$recordID|strip_tags}-->)"><img
-                src="dynicons/?img=user-trash-full.svg&amp;w=32" alt="un-delete" /> Un-delete request</span>
+                src="dynicons/?img=document-open.svg&amp;w=32" /> Restore request</span>
     </div><br style="clear: both" />
     <hr />
 <!--{/if}-->

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -190,9 +190,8 @@
     };
 
     function scrubHTML(input) {
-        let t = document.createElement('div');
-        t.innerHTML = input;
-        return t.innerText;
+        let t = new DOMParser().parseFromString(input, 'text/html');
+        return t.textContent;
     }
 
     function interfaceReady() {


### PR DESCRIPTION
3 changes:
1. When there's a disabled account associated with a "person designated" request, the workflow shows a visible "\*NEEDS REASSIGNMENT\*" message.
2. Text related to "restore records" has been re-worded to clarify its status.
3. In the Inbox, approverName can contain the label of a field in the event there's a disabled account in a "person designated" field, which can contain HTML formatting. This change scrubs HTML from the text to ensure formatting is consistent.

## Potential Impact
- Admins may require notification to explain the "NEEDS REASSIGNMENT" message

## Testing
1. Set up a record that's pending a "person desginated" field
2. Disable the account associated with the "person desginated" field
- [ ] The workflow for the record should show "NEEDS REASSIGNMENT"
- [ ] The Inbox (Organize by Forms + View as Admin) should show "NEEDS REASSIGNMENT" as one of the sections