### PR TITLE
LEAF-4200 - Fix default Inbox columns

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -413,7 +413,7 @@
 
         let customCols = [];
         if (customColumns == false) {
-            site.columns = site.columns ?? 'UID,service,title,status';
+            site.columns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
         }
         site.columns.split(',').forEach(col => {
             if (isNaN(col)) {


### PR DESCRIPTION
This resolves an issue where default columns incorrectly shows "UID", instead of "UID,service,title,status".

## Potential Impact
- Inbox when the Sitemap has been populated

## Testing
1. Create a new entry in the Sitemap with an active site. Or remove and recreate an existing entry.
2. Open the Inbox.
- [ ] When expanding a site and form, the default columns should include UID, Service, Title, Status, and Action.