### PR TITLE
LEAF 4193 - add relative position to parent to prevent form shift

### DIFF
--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -521,7 +521,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         ] == null
                     ) {
                         name =
-                            "Warning: User not selected for currennt action (Contact Administrator)";
+                            "Warning: User not selected for current action (Contact Administrator)";
                     } else {
                         name =
                             "Pending action from " +

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -445,7 +445,7 @@
             <!--{$indicator.html}-->
         <!--{/if}-->
         <!--{if $indicator.format == 'date' && ($indicator.isMasked == 0 || $indicator.value == '')}-->
-            <span class="text">
+            <span class="text" style="position:relative;">
                 <input type="text" id="<!--{$indicator.indicatorID|strip_tags}-->" name="<!--{$indicator.indicatorID|strip_tags}-->" style="background: url(dynicons/?img=office-calendar.svg&w=16); background-repeat: no-repeat; background-position: 4px center; padding-left: 24px; font-size: 1.3em; font-family: monospace" value="<!--{$indicator.value|sanitize}-->" />
                 <input class="ui-helper-hidden-accessible" id="<!--{$indicator.indicatorID|strip_tags}-->_focusfix" type="text" />
                 <span id="<!--{$indicator.indicatorID|strip_tags}-->_error" style="color: red; display: none">Incorrect Date</span>


### PR DESCRIPTION
Adds relative position to the parent of the date format _focusfix element.
This prevents the modal content from shifting in the Inbox 'take action' modal when the date is updated.


testing / impact

Date format questions.  Ensure that display is not unintentionally impacted elsewhere.
See Jira LEAF-4193 for a test form.