### PR TITLE
LEAF-3190 prevent built in workflow modification

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -983,7 +983,7 @@
         dialog.setSaveHandler(function() {
             addStep(currentWorkflow, $('#stepTitle').val(), function(stepID) {
                 if (isNaN(stepID)) {
-                    console.log(stepID);
+                    alert(stepID);
                 } else {
                     loadWorkflow(currentWorkflow);
                 }
@@ -1374,8 +1374,12 @@
                 type: 'DELETE',
                 url: `../api/workflow/${workflowID}/step/${stepID}/_${action}/${nextStepID}?`
                     + $.param({ 'CSRFToken': CSRFToken }),
-                success: function() {
-                    loadWorkflow(workflowID);
+                success: function(res) {
+                    if (+res === 1) {
+                        loadWorkflow(workflowID);
+                    } else {
+                        alert(res)
+                    }
                 },
                 error: (err) => console.log(err),
             });
@@ -2177,85 +2181,89 @@
      * Created at: 7/26/2023, 1:08:10 PM (America/New_York)
      */
     function duplicateWorkflow() {
-        $('.workflowStepInfo').css('display', 'none');
+        if (+currentWorkflow > 0) {
+            $('.workflowStepInfo').css('display', 'none');
 
-        dialog.setTitle('Duplicate current workflow');
-        dialog.setContent('<br /><label for="description">New Workflow Title:</label> <input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
-        dialog.setSaveHandler(function() {
-            let old_steps = {};
-            let workflowID;
-            let title = $('#description').val();
+            dialog.setTitle('Duplicate current workflow');
+            dialog.setContent('<br /><label for="description">New Workflow Title:</label> <input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
+            dialog.setSaveHandler(function() {
+                let old_steps = {};
+                let workflowID;
+                let title = $('#description').val();
 
-            postWorkflow(function(workflow_id) {
-                workflowID = workflow_id;
-                dialog.hide();
-            });
-
-            workflows[workflowID] = workflows[currentWorkflow];
-            workflows[workflowID]['workflowID'] = parseInt(workflowID);
-            workflows[workflowID]['description'] = title;
-            old_steps[-1] = -1;
-
-            for(let i in steps) {
-                // add step, if successful update that step
-                addStep(workflowID, steps[i].stepTitle, function(stepID) {
-
-                    if (isNaN(stepID)) {
-                        console.log(stepID);
-                    } else {
-                        old_steps[steps[i].stepID] = stepID;
-                        updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
-
-                        updateTitle(steps[i].stepTitle, stepID, function(res) {
-                            // Alls well that ends well.
-                        });
-
-                        if (steps[i].stepData != null) {
-                            let auto = JSON.parse(steps[i].stepData);
-
-                            let seriesData = {
-                                AutomatedEmailReminders: {
-                                    'Automate Email Group': auto.AutomatedEmailReminders.AutomateEmailGroup,
-                                    'Days Selected': auto.AutomatedEmailReminders.DaysSelected,
-                                    'Date Selected': auto.AutomatedEmailReminders?.DateSelected || '',
-                                    'Additional Days Selected': auto.AutomatedEmailReminders.AdditionalDaysSelected,
-                                }
-                            };
-
-                            updateStepData(seriesData, stepID, function (res) {
-                                // Alls well that ends well.
-                            });
-                        }
-
-                        updateApprover(steps[i].indicatorID_for_assigned_empUID, stepID, function (res) {
-                            // Alls well that ends well.
-                        });
-
-                        updateGroupApprover(steps[i].indicatorID_for_assigned_groupID, stepID, function (res) {
-                            // Alls well that ends well.
-                        });
-
-                        // set requireDigitalSignature
-                        // this endpoint does not exist in this file at this time.
-
-                        updateDependencies(steps[i].stepID, old_steps);
-                    }
+                postWorkflow(function(workflow_id) {
+                    workflowID = workflow_id;
+                    dialog.hide();
                 });
 
+                workflows[workflowID] = workflows[currentWorkflow];
+                workflows[workflowID]['workflowID'] = parseInt(workflowID);
+                workflows[workflowID]['description'] = title;
+                old_steps[-1] = -1;
 
-            }
+                for(let i in steps) {
+                    // add step, if successful update that step
+                    addStep(workflowID, steps[i].stepTitle, function(stepID) {
 
-            workflows[workflowID]['initialStepID'] = parseInt(old_steps[workflows[currentWorkflow].initialStepID]);
+                        if (isNaN(stepID)) {
+                            console.log(stepID);
+                        } else {
+                            old_steps[steps[i].stepID] = stepID;
+                            updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
 
-            updateInitialStep(workflowID, workflows[workflowID]['initialStepID'], function () {
-                // nothing to do here
+                            updateTitle(steps[i].stepTitle, stepID, function(res) {
+                                // Alls well that ends well.
+                            });
+
+                            if (steps[i].stepData != null) {
+                                let auto = JSON.parse(steps[i].stepData);
+
+                                let seriesData = {
+                                    AutomatedEmailReminders: {
+                                        'Automate Email Group': auto.AutomatedEmailReminders.AutomateEmailGroup,
+                                        'Days Selected': auto.AutomatedEmailReminders.DaysSelected,
+                                        'Date Selected': auto.AutomatedEmailReminders?.DateSelected || '',
+                                        'Additional Days Selected': auto.AutomatedEmailReminders.AdditionalDaysSelected,
+                                    }
+                                };
+
+                                updateStepData(seriesData, stepID, function (res) {
+                                    // Alls well that ends well.
+                                });
+                            }
+
+                            updateApprover(steps[i].indicatorID_for_assigned_empUID, stepID, function (res) {
+                                // Alls well that ends well.
+                            });
+
+                            updateGroupApprover(steps[i].indicatorID_for_assigned_groupID, stepID, function (res) {
+                                // Alls well that ends well.
+                            });
+
+                            // set requireDigitalSignature
+                            // this endpoint does not exist in this file at this time.
+
+                            updateDependencies(steps[i].stepID, old_steps);
+                        }
+                    });
+
+
+                }
+
+                workflows[workflowID]['initialStepID'] = parseInt(old_steps[workflows[currentWorkflow].initialStepID]);
+
+                updateInitialStep(workflowID, workflows[workflowID]['initialStepID'], function () {
+                    // nothing to do here
+                });
+
+                updateRoutes(workflowID, old_steps);
+                updateRouteEvents(currentWorkflow, workflowID, old_steps);
+                loadWorkflowList(workflowID);
             });
-
-            updateRoutes(workflowID, old_steps);
-            updateRouteEvents(currentWorkflow, workflowID, old_steps);
-            loadWorkflowList(workflowID);
-        });
-        dialog.show();
+            dialog.show();
+       } else {
+           alert('Built In workflows cannot be copied')
+       }
     }
 
     /**
@@ -2602,7 +2610,11 @@
                 CSRFToken: CSRFToken
             },
             success: function(res) {
-                callback(res)
+                if (+res === 1) {
+                    callback(res)
+                } else {
+                    alert(res)
+                }
             },
             error: (err) => console.log(err),
         });

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2181,89 +2181,85 @@
      * Created at: 7/26/2023, 1:08:10 PM (America/New_York)
      */
     function duplicateWorkflow() {
-        if (+currentWorkflow > 0) {
-            $('.workflowStepInfo').css('display', 'none');
+        $('.workflowStepInfo').css('display', 'none');
 
-            dialog.setTitle('Duplicate current workflow');
-            dialog.setContent('<br /><label for="description">New Workflow Title:</label> <input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
-            dialog.setSaveHandler(function() {
-                let old_steps = {};
-                let workflowID;
-                let title = $('#description').val();
+        dialog.setTitle('Duplicate current workflow');
+        dialog.setContent('<br /><label for="description">New Workflow Title:</label> <input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
+        dialog.setSaveHandler(function() {
+            let old_steps = {};
+            let workflowID;
+            let title = $('#description').val();
 
-                postWorkflow(function(workflow_id) {
-                    workflowID = workflow_id;
-                    dialog.hide();
-                });
-
-                workflows[workflowID] = workflows[currentWorkflow];
-                workflows[workflowID]['workflowID'] = parseInt(workflowID);
-                workflows[workflowID]['description'] = title;
-                old_steps[-1] = -1;
-
-                for(let i in steps) {
-                    // add step, if successful update that step
-                    addStep(workflowID, steps[i].stepTitle, function(stepID) {
-
-                        if (isNaN(stepID)) {
-                            console.log(stepID);
-                        } else {
-                            old_steps[steps[i].stepID] = stepID;
-                            updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
-
-                            updateTitle(steps[i].stepTitle, stepID, function(res) {
-                                // Alls well that ends well.
-                            });
-
-                            if (steps[i].stepData != null) {
-                                let auto = JSON.parse(steps[i].stepData);
-
-                                let seriesData = {
-                                    AutomatedEmailReminders: {
-                                        'Automate Email Group': auto.AutomatedEmailReminders.AutomateEmailGroup,
-                                        'Days Selected': auto.AutomatedEmailReminders.DaysSelected,
-                                        'Date Selected': auto.AutomatedEmailReminders?.DateSelected || '',
-                                        'Additional Days Selected': auto.AutomatedEmailReminders.AdditionalDaysSelected,
-                                    }
-                                };
-
-                                updateStepData(seriesData, stepID, function (res) {
-                                    // Alls well that ends well.
-                                });
-                            }
-
-                            updateApprover(steps[i].indicatorID_for_assigned_empUID, stepID, function (res) {
-                                // Alls well that ends well.
-                            });
-
-                            updateGroupApprover(steps[i].indicatorID_for_assigned_groupID, stepID, function (res) {
-                                // Alls well that ends well.
-                            });
-
-                            // set requireDigitalSignature
-                            // this endpoint does not exist in this file at this time.
-
-                            updateDependencies(steps[i].stepID, old_steps);
-                        }
-                    });
-
-
-                }
-
-                workflows[workflowID]['initialStepID'] = parseInt(old_steps[workflows[currentWorkflow].initialStepID]);
-
-                updateInitialStep(workflowID, workflows[workflowID]['initialStepID'], function () {
-                    // nothing to do here
-                });
-
-                updateRoutes(workflowID, old_steps);
-                updateRouteEvents(currentWorkflow, workflowID, old_steps);
-                loadWorkflowList(workflowID);
+            postWorkflow(function(workflow_id) {
+                workflowID = workflow_id;
+                dialog.hide();
             });
-            dialog.show();
-       } else {
-           alert('Built In workflows cannot be copied')
-       }
+
+            workflows[workflowID] = workflows[currentWorkflow];
+            workflows[workflowID]['workflowID'] = parseInt(workflowID);
+            workflows[workflowID]['description'] = title;
+            old_steps[-1] = -1;
+
+            for(let i in steps) {
+                // add step, if successful update that step
+                addStep(workflowID, steps[i].stepTitle, function(stepID) {
+
+                    if (isNaN(stepID)) {
+                        console.log(stepID);
+                    } else {
+                        old_steps[steps[i].stepID] = stepID;
+                        updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
+
+                        updateTitle(steps[i].stepTitle, stepID, function(res) {
+                            // Alls well that ends well.
+                        });
+
+                        if (steps[i].stepData != null) {
+                            let auto = JSON.parse(steps[i].stepData);
+
+                            let seriesData = {
+                                AutomatedEmailReminders: {
+                                    'Automate Email Group': auto.AutomatedEmailReminders.AutomateEmailGroup,
+                                    'Days Selected': auto.AutomatedEmailReminders.DaysSelected,
+                                    'Date Selected': auto.AutomatedEmailReminders?.DateSelected || '',
+                                    'Additional Days Selected': auto.AutomatedEmailReminders.AdditionalDaysSelected,
+                                }
+                            };
+
+                            updateStepData(seriesData, stepID, function (res) {
+                                // Alls well that ends well.
+                            });
+                        }
+
+                        updateApprover(steps[i].indicatorID_for_assigned_empUID, stepID, function (res) {
+                            // Alls well that ends well.
+                        });
+
+                        updateGroupApprover(steps[i].indicatorID_for_assigned_groupID, stepID, function (res) {
+                            // Alls well that ends well.
+                        });
+
+                        // set requireDigitalSignature
+                        // this endpoint does not exist in this file at this time.
+
+                        updateDependencies(steps[i].stepID, old_steps);
+                    }
+                });
+
+
+            }
+
+            workflows[workflowID]['initialStepID'] = parseInt(old_steps[workflows[currentWorkflow].initialStepID]);
+
+            updateInitialStep(workflowID, workflows[workflowID]['initialStepID'], function () {
+                // nothing to do here
+            });
+
+            updateRoutes(workflowID, old_steps);
+            updateRouteEvents(currentWorkflow, workflowID, old_steps);
+            loadWorkflowList(workflowID);
+        });
+        dialog.show();
     }
 
     /**

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -313,7 +313,7 @@ class Workflow
 
         // Don't allow changes to standardized components
         // Exclude stepID -1 since it's the requestor
-        if($stepID < -1) {
+        if($this->workflowID < 0 || $stepID < -1) {
             return 'Restricted command.';
         }
 
@@ -362,7 +362,7 @@ class Workflow
 
         // Don't allow changes to standardized components
         // Exclude stepID -1 since it's the requestor
-        if($stepID < -1) {
+        if($this->workflowID < 0 || $stepID < -1) {
             return 'Restricted command.';
         }
 
@@ -575,7 +575,7 @@ class Workflow
         }
 
         // Don't allow changes to standardized components
-        if($stepID < 0) {
+        if($this->workflowID < 0 || $stepID < 0) {
             return 'Restricted command.';
         }
 


### PR DESCRIPTION
Adds an update to prevent users from creating a Requestor --> End connection on build in workflows.  This correction is necessary because it creates an unavoidable help desk ticket as the user cannot undo this change.

Also prevents duplication of built in workflows and provides more obvious feedback about modifications to built-in workflow being restricted.


Impact / Testing

Workflow Editor
-It should no longer be possible to modify the initial requestor --> step connection on built in workflows.
-Confirm that custom workflows still behave as expected.