### PR TITLE
LEAF-4191 print to PDF internal forms

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -936,13 +936,12 @@ class Form
             $categoryData[$cat['categoryID']] = $cat['categoryID'];
             $categoryNames[$cat['categoryID']] = $cat['categoryName'];
         }
+        $parentIDs = implode(',', array_values($categoryData));
 
-        //Check for Internal Forms of Main categoryID
-        $vars = array(':parentID' => $resCategory[0]['categoryID']);
-
+        //Check for forms with these parentIDs (Internal Forms)
+        $vars = array(':parentIDs' => $parentIDs);
         $resInternal = $this->db->prepared_query('SELECT * FROM categories
-                                            WHERE parentID=:parentID', $vars);
-
+                                            WHERE FIND_IN_SET(parentID, :parentIDs) AND `disabled`=0', $vars);
         $count = count($resInternal);
         $internalIDs = array();
         for ($i = 0; $i < $count;$i++) {


### PR DESCRIPTION
Update to
-prevent deleted internal forms from appearing on the Print to PDF download.
-ensure all active internal forms appear on Print to PDF download when forms are stapled.

Impact /Testing

Print to PDF Feature
Deleted forms should not appear on the document.
All active internal forms should appear on the document.