### PR TITLE
LEAF 4194 show requirement changes in workflow history

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -798,7 +798,11 @@
             $.ajax({
                 type: 'DELETE',
                 url: `../api/workflow/step/${stepID}/dependencies?`
-                    + $.param({ 'dependencyID': dependencyID, 'CSRFToken': CSRFToken }),
+                    + $.param({
+                        'dependencyID': dependencyID,
+                        'workflowID': currentWorkflow,
+                        'CSRFToken': CSRFToken
+                    }),
                 success: function() {
                     $('.workflowStepInfo').css('display', 'none');
                     showStepInfo(stepID);
@@ -2543,9 +2547,11 @@
      */
     function postStepDependency(stepID, dependencyID, callback) {
         $.ajax({
-                type: 'POST',
-                url: '../api/workflow/step/' + stepID + '/dependencies',
-                data: {dependencyID: dependencyID,
+            type: 'POST',
+            url: '../api/workflow/step/' + stepID + '/dependencies',
+            data: {
+                dependencyID: dependencyID,
+                workflowID: currentWorkflow,
                 CSRFToken: CSRFToken
             },
             success: function() {

--- a/LEAF_Request_Portal/api/controllers/WorkflowController.php
+++ b/LEAF_Request_Portal/api/controllers/WorkflowController.php
@@ -205,6 +205,7 @@ class WorkflowController extends RESTfulResponse
         });
 
         $this->index['POST']->register('workflow/step/[digit]/dependencies', function ($args) use ($workflow) {
+            $workflow->setWorkflowID((int)$_POST['workflowID']);
             return $workflow->linkDependency((int)$args[0], (int)$_POST['dependencyID']);
         });
 
@@ -281,6 +282,7 @@ class WorkflowController extends RESTfulResponse
         });
 
         $this->index['DELETE']->register('workflow/step/[digit]/dependencies', function ($args) use ($workflow) {
+            $workflow->setWorkflowID((int)$_GET['workflowID']);
             return $workflow->unlinkDependency((int)$args[0], (int)$_GET['dependencyID']);
         });
 

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -800,9 +800,14 @@ class Workflow
         $res = $this->db->prepared_query('INSERT INTO step_dependencies (stepID, dependencyID)
                                             VALUES (:stepID, :dependencyID)', $vars);
 
+        $depVars = array(':dependencyID' => $dependencyID);
+        $dep = $this->db->prepared_query("SELECT `description` FROM dependencies WHERE dependencyID=:dependencyID", $depVars)[0];
+        $depDescr = $dep["description"];
+
         $this->dataActionLogger->logAction(DataActions::ADD, LoggableTypes::STEP_DEPENDENCY, [
+            new LogItem("workflows", "workflowID", $this->workflowID),
             new LogItem("step_dependencies", "stepID",  $stepID),
-            new LogItem("step_dependencies", "dependencyID",  $dependencyID)
+            new LogItem("step_dependencies", "dependencyID",  $dependencyID, $depDescr)
         ]);
 
         // populate records_dependencies so we can filter on items immediately
@@ -844,9 +849,14 @@ class Workflow
     									AND filled=0
                                         AND records_dependencies.time IS NULL', $vars);
 
+        $depVars = array(':dependencyID' => $dependencyID);
+        $dep = $this->db->prepared_query("SELECT `description` FROM dependencies WHERE dependencyID=:dependencyID", $depVars)[0];
+        $depDescr = $dep["description"];
+
         $this->dataActionLogger->logAction(DataActions::DELETE, LoggableTypes::STEP_DEPENDENCY, [
+            new LogItem("workflows", "workflowID", $this->workflowID),
             new LogItem("step_dependencies", "stepID",  $stepID),
-            new LogItem("step_dependencies", "dependencyID",  $dependencyID)
+            new LogItem("step_dependencies", "dependencyID",  $dependencyID, $depDescr)
         ]);
 
         return true;

--- a/app/Leaf/Logger/Formatters/WorkflowFormatter.php
+++ b/app/Leaf/Logger/Formatters/WorkflowFormatter.php
@@ -66,6 +66,14 @@ class WorkflowFormatter
             "message"=>"set <strong>name:</strong> %s in <strong>workflow:</strong> %s",
             "variables"=>"description,workflowID"
         ],
+        DataActions::ADD.'-'.LoggableTypes::STEP_DEPENDENCY => [
+            "message"=>"added requirement <strong>%s </strong> to <strong>step %s</strong>",
+            "variables"=>"dependencyID,stepID"
+        ],
+        DataActions::DELETE.'-'.LoggableTypes::STEP_DEPENDENCY => [
+            "message"=>"removed requirement <strong>%s </strong> from <strong>step %s</strong>",
+            "variables"=>"dependencyID,stepID"
+        ],
     ];
 
     const TABLE = "workflows";


### PR DESCRIPTION
Update to display workflow step requirement (dependencies) changes in the workflow history.

Impact / Testing

Workflow Editor
Workflow history should show addition or removal of step requirements.
note: this update does not address changes to requirement groups since custom requirements are not workflow specific.




