### PR TITLE
Leaf 4207 - Add missing dialog template

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -719,6 +719,8 @@
     $(function() {
         document.title = 'Inbox - ' + document.title;
 
+        dialog_confirm = new dialogController('confirm_xhrDialog', 'confirm_xhr', 'confirm_loadIndicator', 'confirm_button_save', 'confirm_button_cancelchange');
+
         let urlParams = new URLSearchParams(window.location.search);
         if(urlParams.get('adminView') != null) {
             nonAdmin = false;
@@ -855,6 +857,7 @@
 </style>
 
 <!--{include file="site_elements/generic_OkDialog.tpl"}-->
+<!--{include file="site_elements/generic_confirm_xhrDialog.tpl"}-->
 
 <div id="genericDialog" style="visibility: hidden; display: none">
     <div>


### PR DESCRIPTION
This resolves an issue where files can't be deleted using the in-line workflow interface on the Inbox page.

Steps to reproduce issue:
- Precondition: The request must have a workflow step that contains an inline file upload field, and is currently on that step
1. Open the Inbox, find the request, and click "Take Action"
2. Attempt to delete a file referenced in the file upload area

### Potential Impact
No external dependencies

### Testing
- [ ] The issue can no-longer be reproduced