### PR TITLE
Leaf 4208 - Resolve issue related to incorrect "custom" designation

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -890,34 +890,28 @@
                     type: 'GET',
                     url: '../api/template/custom',
                     dataType: 'json',
-                    success: function (result) {
+                    success: function (customTemplates) {
                         let template_excluded = 'import_from_webHR.tpl';
-                        let res_array = $.parseJSON(result);
                         let buffer = '<ul class="leaf-ul">';
                         let filesMobile = '<h3>Template Files:</h3><div class="template_select_container"><select class="templateFiles">';
                         
-                        if (res_array.status['code'] === 2) {
+                        if (Array.isArray(customTemplates)) {
                             for (let i in res) {
                                 if (res[i] === template_excluded) {
                                     // Will skip the excluded template, until further notice.
                                     continue;
                                 }
 
-                                if (result.includes(res[i])) {
+                                let custom = '';
+                                if (customTemplates.includes(res[i])) {
                                     custom = '<span class=\'custom_file\' style=\'color: red; font-size: .75em\'>(custom)</span>';
-                                } else {
-                                    custom = '';
                                 }
-
                                 let file = res[i].replace('.tpl', '');
 
                                 buffer += '<li><div class="template_files"><a href="#" data-file="' + res[i] + '">' + file + '</a> ' + custom + '</div></li>';
 
                                 filesMobile += '<option value="' + res[i] + '">' + file + ' ' + custom + '</option>';
                             }
-                        } else if (res_array.status['code'] === 4) {
-                            buffer += '<li><div class="template_files">' + res_array.status['message'] + '</div></li>';
-                            filesMobile += '<select><option>' + res_array.status['message'] + '</option></select>';
                         } else {
                             buffer += '<li>Internal error occurred, if this persists contact your Primary Admin.</li>';
                         }

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -1263,16 +1263,15 @@
                     type: 'GET',
                     url: '../api/emailTemplates/custom',
                     dataType: 'json',
-                    success: function (result) {
-                        let res_array = $.parseJSON(result);
+                    success: function (customTemplates) {
                         let buffer = '<ul class="leaf-ul">';
                         let filesMobile = '<h3>Template Files:</h3><div class="template_select_container"><select class="templateFiles">';
 
-                        if (res_array.status['code'] === 2) {
+                        if (Array.isArray(customTemplates)) {
                             for (let i in res) {
                                 let custom = '';
 
-                                if (result.includes(res[i].fileName)) {
+                                if (customTemplates.includes(res[i].fileName)) {
                                     custom = '<span class=\'custom_file\' style=\'color: red; font-size: .75em\'>(custom)</span>';
                                 }
 
@@ -1291,9 +1290,6 @@
 
                             filesMobile += '</select></div>';
                             buffer += '</ul>';
-                        } else if (res_array.status['code'] === 4) {
-                            buffer += '<li>' + res_array.status['message'] + '</li>';
-                            filesMobile += '<select><option>' + res_array.status['message'] + '</option></select>';
                         } else {
                             buffer += '<li>Internal error occurred. If this persists, contact your Primary Admin.</li>';
                             filesMobile += '<div>Internal error occurred. If this persists, contact your Primary Admin.</div>';

--- a/LEAF_Request_Portal/api/controllers/EmailTemplateController.php
+++ b/LEAF_Request_Portal/api/controllers/EmailTemplateController.php
@@ -37,9 +37,7 @@ class EmailTemplateController extends RESTfulResponse
         });
 
         $this->index['GET']->register('emailTemplates/custom', function ($args) use ($emailTemplate) {
-            $return_value = $emailTemplate->getCustomEmailTemplateList();
-
-            return json_encode($return_value);
+            return $emailTemplate->getCustomEmailTemplateList();
         });
 
         $this->index['GET']->register('emailTemplates/[text]', function ($args) use ($emailTemplate) {

--- a/LEAF_Request_Portal/api/controllers/TemplateController.php
+++ b/LEAF_Request_Portal/api/controllers/TemplateController.php
@@ -41,9 +41,7 @@ class TemplateController extends RESTfulResponse
       });
 
         $this->index['GET']->register('template/custom', function ($args) use ($template) {
-            $return_value = $template->getCustomTemplateList();
-
-            return json_encode($return_value);
+            return $template->getCustomTemplateList();
         });
 
       $this->index['GET']->register('template/[text]', function ($args) use ($template) {

--- a/LEAF_Request_Portal/sources/EmailTemplate.php
+++ b/LEAF_Request_Portal/sources/EmailTemplate.php
@@ -132,37 +132,27 @@ class EmailTemplate
     }
 
     /**
-     * @return array
+     * getCustomEmailTemplateList retrieves a list of custom email templates
+     * @return array of templates
+     * @return string error message
      *
      * Created at: 6/6/2023, 1:40:09 PM (America/New_York)
      */
-    public function getCustomEmailTemplateList(): array
+    public function getCustomEmailTemplateList(): array|string
     {
+        $return_value = [];
+
         if (!$this->login->checkGroup(1)) {
-            $return_value = array(
-                'status' => array(
-                    'code' => 4,
-                    'message' => 'Admin access required'
-                )
-            );
+            return 'Admin access required';
         }
 
         $list = scandir('../templates/email/custom_override');
-        $out = array();
 
         foreach ($list as $item) {
             if (preg_match('/.tpl$/', $item)) {
-                $out[] = $item;
+                $return_value[] = $item;
             }
         }
-
-        $return_value = array(
-            'status' => array(
-                'code' => 2,
-                'message' => ''
-            ),
-            'data' => $out
-        );
 
         return $return_value;
     }

--- a/LEAF_Request_Portal/sources/Template.php
+++ b/LEAF_Request_Portal/sources/Template.php
@@ -50,37 +50,28 @@ class Template
     }
 
     /**
-     * @return array
+     * getCustomTemplateList retrieves a list of custom templates
+     * @return array of templates
+     * @return string error message
      *
      * Created at: 5/24/2023, 10:22:51 AM (America/New_York)
      */
-    public function getCustomTemplateList(): array
+    public function getCustomTemplateList(): array|string
     {
+        $return_value = [];
+
         if (!$this->login->checkGroup(1))
         {
-            $return_value = array(
-                'status' => array(
-                    'code' => 4,
-                    'message' => 'Admin access required'
-                )
-            );
+            return 'Admin access required';
         }
+        
         $list = scandir('../templates/custom_override');
-        $out = array();
 
         foreach ($list as $item) {
             if (preg_match('/.tpl$/', $item)) {
-                $out['success'][] = $item;
+                $return_value[] = $item;
             }
         }
-
-        $return_value = array(
-            'status' => array(
-                'code' => 2,
-                'message' => ''
-            ),
-            'data' => $out
-        );
 
         return $return_value;
     }


### PR DESCRIPTION
This resolves an issue where templates are incorrectly listed as "custom".

Steps to reproduce issue:
- Precondition: The "intial_form" and "form" templates have not been customized.
1. Navigate to the Template Editor
2. Modify the "initial_form" template
3. Click refresh
4. Note that the "form" template is incorrectly listed with a "custom" flag.

### Potential Impact
None, because there are no external dependencies on api/template and api/emailTemplates.

### Testing
- [ ] The issue cannot be reproduced