### PR TITLE
LEAF 4195 add files to legacy inbox view

### DIFF
--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -268,6 +268,7 @@ switch ($action) {
             'js/workflow.js',
             'js/formGrid.js',
             'js/gridInput.js',
+            APP_JS_PATH . '/LEAF/XSSHelpers.js',
             APP_JS_PATH . '/choicesjs/choices.min.js'));
 
         $t_form = new Smarty;

--- a/LEAF_Request_Portal/templates/view_inbox.tpl
+++ b/LEAF_Request_Portal/templates/view_inbox.tpl
@@ -44,6 +44,7 @@ The following is a list of requests that are pending your action:
 <!-- DIALOG BOXES -->
 <!--{include file="site_elements/generic_dialog.tpl"}-->
 <!--{include file="site_elements/generic_OkDialog.tpl"}-->
+<!--{include file="site_elements/generic_confirm_xhrDialog.tpl"}-->
 
 <script type="text/javascript" src="js/functions/toggleZoom.js"></script>
 <script type="text/javascript" src="<!--{$app_js_path}-->/LEAF/sensitiveIndicator.js"></script>
@@ -53,6 +54,7 @@ The following is a list of requests that are pending your action:
 
     $(function() {
         dialog_message = new dialogController('genericDialog', 'genericDialogxhr', 'genericDialogloadIndicator', 'genericDialogbutton_save', 'genericDialogbutton_cancelchange');
+        dialog_confirm = new dialogController('confirm_xhrDialog', 'confirm_xhr', 'confirm_loadIndicator', 'confirm_button_save', 'confirm_button_cancelchange');
         dialog_ok = new dialogController('ok_xhrDialog', 'ok_xhr', 'ok_loadIndicator', 'confirm_button_ok', 'confirm_button_cancelchange');
         <!--{foreach from=$inbox item=dep}-->
         toggleDepVisibility('<!--{$dep.dependencyID|strip_tags}-->', 1, CSRFToken);


### PR DESCRIPTION
This resolves issues in the legacy inbox view affecting file/image upload and textarea format questions.
New inbox template dialog issue is already being addressed by LEAF-4207

Impact/Testing

**Legacy inbox Take Action modals** with file/image upload format or textarea questions should not cause errors in console when opened.  File/image upload and removal should behave as expected.
