### PR TITLE
Leaf 4210 - former backups cant be removed from system admin

### DIFF
--- a/LEAF_Request_Portal/sources/Group.php
+++ b/LEAF_Request_Portal/sources/Group.php
@@ -419,7 +419,7 @@ class Group
      *
      * @return void
      */
-    public function removeMember($member, $groupID): void
+    public function removeMember($member, $groupID, $backupID = ''): void
     {
         if (is_numeric($groupID) && $member != '') {
             $this->dataActionLogger->logAction(DataActions::PRUNE, LoggableTypes::EMPLOYEE, [
@@ -428,12 +428,13 @@ class Group
             ]);
 
             $vars = array(':userID' => $member,
-                          ':groupID' => $groupID);
+                          ':groupID' => $groupID,
+                          ':backupID' => $backupID);
             $sql = 'DELETE
                     FROM `users`
                     WHERE (`userID` = :userID
                         AND `groupID` = :groupID
-                        AND `backupID` = "")
+                        AND `backupID` = :backupID)
                     OR (`groupID` = :groupID
                         AND `backupID` = :userID)';
 


### PR DESCRIPTION
Summary:
When User A is added to System Admin via the User Access Groups page their backups are added as well. Subsequently, if a backup is removed from that User in the Nexus the portal side can never be updated, unless you remove the User A and then add them back in. In this story I updated the sync services in order to update and refresh the system admins, it only flushes backups that are no longer backups.

Potential Impact:
By fixing this backups that are no longer will not be receiving notifications for things they are no longer responsible for.

Testing:
Add a user, that you know has one or more backups as a system admin 
Go to Nexus and remove at least one of those backups

before fix
attempt to remove this backup from the system admin group (should not be removed)
do a sync service and check the system admin group (former backup should still be there)

after fix
attempt to remove this backup from the system admin group (should not be removed)
do a sync service and check the system admin group (former backup should no longer be in the list)