### PR TITLE
LEAF-4214 - Attempt to fix html scrubber

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -190,7 +190,7 @@
     };
 
     function scrubHTML(input) {
-        let t = new DOMParser().parseFromString(input, 'text/html');
+        let t = new DOMParser().parseFromString(input, 'text/html').body;
         return t.textContent;
     }
 


### PR DESCRIPTION
This seems to be the correct implementation of a plain JS HTML scrubber.

### Potential Impact
Local to the Inbox, no external dependencies.

### Testing
- [ ] When a record is assigned to a designated person, the Inbox should not show "null" when viewing as Admin + Organize by Roles