### PR TITLE
LEAF 4196 update file paths for combined inbox 

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -398,6 +398,7 @@ switch ($action) {
             $t_form->assign('categoryText', XSSHelpers::sanitizeHTML($categoryText));
             $t_form->assign('deleted', (int)$recordInfo['deleted']);
             $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
+            $t_form->assign('abs_portal_path', ABSOLUTE_PORT_PATH);
             $t_form->assign('is_admin', $login->checkGroup(1));
 
             switch ($action) {

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -134,7 +134,8 @@
             <!--{if $indicator.value[0] != ''}-->
             <!--{assign var='idx' value=0}-->
             <!--{foreach from=$indicator.value item=file}-->
-            <a href="file.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" target="_blank" class="printResponse"><img src="dynicons/?img=mail-attachment.svg&amp;w=24" alt="" /><!--{$file}--></a><br />
+            <a href="<!--{$abs_portal_path}-->/file.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" target="_blank" class="printResponse">
+                <img src="dynicons/?img=mail-attachment.svg&amp;w=24" alt="" /><!--{$file}--></a><br />
             <!--{assign var='idx' value=$idx+1}-->
             <!--{/foreach}-->
             <!--{else}-->
@@ -149,7 +150,10 @@
             <!--{assign var='idx' value=0}-->
             <!--{foreach from=$indicator.value item=file}-->
                 <!--{if $indicator.value != '[protected data]'}-->
-                <img alt="image upload: <!--{$file}-->" src="image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" style="max-width: 200px" onclick="window.open('image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
+                <img alt="image upload: <!--{$file}-->"
+                    src="<!--{$abs_portal_path}-->/image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->"
+                    style="max-width: 200px"
+                    onclick="window.open('<!--{$abs_portal_path}-->/image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
                 <!--{assign var='idx' value=$idx+1}-->
                 <!--{else}-->
                 [protected data]


### PR DESCRIPTION
Assigns an absolute portal path variable and updates the file path in print_subindicators_ajax.tpl to correct for potential cross portal request attachments in the combined inbox.


**Testing / Impact** 
Request file upload and image downloads and links should continue to behave as expected.
Although listed in the template editor, print_subindicators_ajax does not appear to actually be customizable, so there should not be issues from potential template customization.