### PR TITLE
LEAF 4223 idea inbox customizations

### DIFF
--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -436,7 +436,10 @@ switch ($action) {
         $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
         $t_form->assign('app_css_path', APP_CSS_PATH);
         $t_form->assign('app_js_path', APP_JS_PATH);
-        $main->assign('javascripts', array(APP_JS_PATH . '/choicesjs/choices.min.js'));
+        $main->assign('javascripts', array(
+            APP_JS_PATH . '/choicesjs/choices.min.js',
+            APP_JS_PATH . '/LEAF/XSSHelpers.js',
+        ));
         $main->assign('stylesheets', array(APP_JS_PATH . '/choicesjs/choices.min.css'));
 
         $main->assign('body', $t_form->fetch(customTemplate('mod_combined_inbox.tpl')));

--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -1195,6 +1195,17 @@ button.buttonNorm {
   cursor: pointer;
   font-size: 12px;
 }
+button.depInbox {
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  width:100%;
+  padding: 0.5rem;
+  border:0;
+  display:flex;
+  gap: 0.25rem;
+  justify-content:space-between;
+}
 
 .checkable {
   cursor: pointer;

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
@@ -31,6 +31,7 @@ font-weight: 300;
 }
 
 #side-bar {
+    min-width: 200px;
     text-align: left;
     position: sticky;
     top: 0;

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
@@ -31,7 +31,6 @@ font-weight: 300;
 }
 
 #side-bar {
-    min-width: 200px;
     text-align: left;
     position: sticky;
     top: 0;

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
@@ -24,7 +24,7 @@ font-weight: 300;
 }
 
 .site-title {
-    margin-bottom: 1rem;
+    padding: 0.25rem 0;
     font-weight: bold;
     font-size: 200%;
     line-height: 240%;
@@ -43,9 +43,14 @@ font-weight: 300;
 }
 
 .inbox {
-    margin-bottom: 1rem;
+    padding:0.5rem;
+    line-height:1.6;
 }
-
+.custom_forms {
+  margin-top: 1rem;
+  background-color:whitesmoke;
+  padding: 0 7.5px;
+}
 .drag-el {
     background-color: #eee;
     margin-bottom: 10px;

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
@@ -150,7 +150,7 @@ const CombinedInboxEditor = Vue.createApp({
                             }
                         });
                         this.allColumns.forEach((col) => {
-                            if (!site.columns.includes(col)) {
+                            if (!siteCols.includes(col)) {
                                 tmp.push({
                                     value: col,
                                     label: this.frontEndColumns[col],
@@ -269,15 +269,6 @@ const CombinedInboxEditor = Vue.createApp({
                     } else {
                         site.formColumns[selectedForm] = selectedValue;
                     }
-                    //update columns and formColumns properties of sites with the same portalURL
-                    const portalURL = this.getPortalURL(site.target);
-                    this.sites.forEach(s => {
-                        const sitePortalURL = this.getPortalURL(s.target);
-                        if(s.id !== site.id && sitePortalURL === portalURL) {
-                            s.columns = site.columns;
-                            s.formColumns = site.formColumns;
-                        }
-                    })
                     this.saveSettings();
                 });
             });
@@ -410,7 +401,7 @@ const CombinedInboxEditor = Vue.createApp({
                 @dragstart="startDrag($event, site)"
                 @drop="onDrop($event)"
                 :value="site.id"
-                :key="site.order + 'site.title'">
+                :key="site.id + '_' + site.order + 'site.title'">
                     &#x2630; {{site.title}}
                 </div>
             </div>
@@ -445,7 +436,7 @@ const CombinedInboxEditor = Vue.createApp({
                         <div v-if="Object.keys(site.formColumns).length > 0" class="custom_forms">
                             <h3>Form specific settings exist for the forms listed below</h3>
                             <template v-for="val, key in site.formColumns">
-                                <div v-if="siteForms[site.id]?.formTable?.[key]" style="display:flex; gap: 0.5rem;">
+                                <div v-if="siteForms[site.id]?.formTable?.[key]" :key="'site_form_table_' + key + val" style="display:flex; gap: 0.5rem;">
                                     <div><b>{{siteForms[site.id]?.formTable?.[key].categoryName}}</b><span style="font-size: 85%;"> ({{key}})</span></div>
                                     <div>{{siteForms[site.id]?.formTable?.[key].inboxHeaders}}</div>
                                 </div>

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
@@ -119,38 +119,24 @@ const CombinedInboxEditor = Vue.createApp({
 
                     const formattedSiteMap = inboxSites.map((site) => ({
                         ...site,
-                        columns: site?.columns || '',
+                        columns: site?.columns || 'service,title,status',
                         formColumns: site?.formColumns || {},
                         show: site.show ?? true
                     }));
                     this.sites = formattedSiteMap.sort((a, b) => a.order - b.order);
 
                     let portalURLs = {};
-                    let portalColumns = {};
-                    /* Initial pass to get URL and columns for each portal (no other great way to get columns at the moment).
-                    If there are multiple cards for a portal, the one with the most cols is used.  This is to prevent newly created cards
-                    without columns from overriding existing setup values */
                     this.sites.forEach((site) => {
-                        const siteCols = (site.columns || "").split(',').filter(c => c !== "");
                         const portalURL = this.getPortalURL(site.target);
                         portalURLs[portalURL] = 1;
-                        if (portalColumns[portalURL] === undefined) {
-                            portalColumns[portalURL] = siteCols;
-                        }
-                        if (siteCols.length > portalColumns[portalURL].length) {
-                            portalColumns[portalURL] = siteCols;
-                        }
+
                         this.choices[site.id] = {
                             portalURL,
-                            choices: [],
+                            choices: []
                         };
-                    });
-                    this.sites.forEach((site) => {
-                        const portalURL = this.choices[site.id].portalURL;
                         let tmp = [];
-                        //Add selected cols first to retain their order.  Add defaults if no columns exist across all cards.
-                        const siteCols = portalColumns[portalURL].length > 0 ? portalColumns[portalURL] : ['service','title','status'];
-                        site.columns = siteCols.join();
+                        //add selected cols first to retain their order
+                        const siteCols = (site.columns || "").split(',').filter(c => c !== "");
                         siteCols.forEach((col) => {
                             if (this.allColumns.includes(col)) {
                                 tmp.push({
@@ -164,7 +150,7 @@ const CombinedInboxEditor = Vue.createApp({
                             }
                         });
                         this.allColumns.forEach((col) => {
-                            if (!siteCols.includes(col)) {
+                            if (!site.columns.includes(col)) {
                                 tmp.push({
                                     value: col,
                                     label: this.frontEndColumns[col],
@@ -190,7 +176,6 @@ const CombinedInboxEditor = Vue.createApp({
                                 this.sites.forEach((site) => {
                                     this.setupChoices(site);
                                 });
-                                this.saveSettings(); //save any column updates from initial sync
                             }
                         })
                         .catch(err => {
@@ -227,6 +212,7 @@ const CombinedInboxEditor = Vue.createApp({
                             const formID = document.getElementById('form_select_' + site.id)?.value || null;
                             let columns = formID !== null ? site.formColumns[formID] || "service,title,status" : site.columns;
                             columns = columns.split(",");
+
                             this.choices[site.id].choices.map(c => {
                                 c.selected = columns.includes(c.value);
                             });
@@ -424,7 +410,7 @@ const CombinedInboxEditor = Vue.createApp({
                 @dragstart="startDrag($event, site)"
                 @drop="onDrop($event)"
                 :value="site.id"
-                :key="site.id + '_' + site.order + 'site.title'">
+                :key="site.order + 'site.title'">
                     &#x2630; {{site.title}}
                 </div>
             </div>
@@ -459,7 +445,7 @@ const CombinedInboxEditor = Vue.createApp({
                         <div v-if="Object.keys(site.formColumns).length > 0" class="custom_forms">
                             <h3>Form specific settings exist for the forms listed below</h3>
                             <template v-for="val, key in site.formColumns">
-                                <div v-if="siteForms[site.id]?.formTable?.[key]" :key="'site_form_table_' + key + val" style="display:flex; gap: 0.5rem;">
+                                <div v-if="siteForms[site.id]?.formTable?.[key]" style="display:flex; gap: 0.5rem;">
                                     <div><b>{{siteForms[site.id]?.formTable?.[key].categoryName}}</b><span style="font-size: 85%;"> ({{key}})</span></div>
                                     <div>{{siteForms[site.id]?.formTable?.[key].inboxHeaders}}</div>
                                 </div>

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
@@ -2,10 +2,11 @@ const CombinedInboxEditor = Vue.createApp({
     data() {
         return {
             loading: true,
+            updateKey: 0,
             sites: [],
             otherSitemapSites: [],
-            portalData: {},
-            choices: [],
+            portalForms: {},
+            choices: {},
             CSRFToken: CSRFToken,
             allColumns: ['service','title','status','dateInitiated','days_since_last_action','priority','dateSubmitted'],
             frontEndColumns: {
@@ -27,6 +28,16 @@ const CombinedInboxEditor = Vue.createApp({
                 'Date Submitted': 'dateSubmitted',
             },
         };
+    },
+    computed: {
+        siteForms() {
+            let data = {};
+            this.sites.forEach(site => {
+                const portalURL = this.getPortalURL(site.target);
+                data[site.id] = this.portalForms[portalURL]?.forms || [];
+            });
+            return data;
+        },
     },
     methods: {
         startDrag(evt, site) {
@@ -60,14 +71,12 @@ const CombinedInboxEditor = Vue.createApp({
             this.saveSettings();
         },
         
-        getIcon(icon, name) {
+        getIcon(icon) {
             if (icon != '') {
                 if (icon.indexOf('/') != -1) {
-                    icon = '<img src="' + icon + '" alt="icon for ' + name +
-                        '" style="vertical-align: middle; width: 76px; height:76px;" />';
+                    icon = '<img src="' + icon + '" alt="" style="vertical-align: middle; width: 76px; height:76px;" />';
                 } else {
-                    icon = '<img src="../libs/dynicons/?img=' + icon + '&w=76" alt="icon for ' + name +
-                        '" style="vertical-align: middle" />';
+                    icon = '<img src="../libs/dynicons/?img=' + icon + '&w=76" alt="" style="vertical-align: middle" />';
                 }
             }
             return icon;
@@ -76,89 +85,95 @@ const CombinedInboxEditor = Vue.createApp({
          * get sitemap JSON. setup base column values for LEAF cards.  save non-LEAF cards
         */
         runSetup() {
-            return new Promise((resolve, reject) => {
-                $.ajax({
-                    type: 'GET',
-                    url: '../api/site/settings/sitemap_json',
-                    success: (res) => {
-                        const siteMap = Object.values(JSON.parse(res[0].data))[0];
-                        let inboxSites = [];
-                        let otherSitemapSites = [];
-                        siteMap.forEach(s => {
-                            if(s.target.includes(window.location.hostname)) {
-                                inboxSites.push(s);
-                            } else {
-                                otherSitemapSites.push(s);
+            $.ajax({
+                type: 'GET',
+                url: '../api/site/settings/sitemap_json',
+                success: (res) => {
+                    const siteMap = Object.values(JSON.parse(res[0].data))[0];
+                    let inboxSites = [];
+                    let otherSitemapSites = [];
+                    siteMap.forEach(s => {
+                        if(s.target.includes(window.location.hostname)) {
+                            inboxSites.push(s);
+                        } else {
+                            otherSitemapSites.push(s);
+                        }
+                    });
+                    this.otherSitemapSites = otherSitemapSites;
+
+                    const formattedSiteMap = inboxSites.map((site) => ({
+                        ...site,
+                        columns: site?.columns || 'service,title,status',
+                        formColumns: site?.formColumns || {},
+                        show: site.show ?? true
+                    }));
+                    this.sites = formattedSiteMap.sort((a, b) => a.order - b.order);
+
+                    let portalURLs = {};
+                    this.sites.forEach((site) => {
+                        const portalURL = this.getPortalURL(site.target);
+                        portalURLs[portalURL] = 1;
+
+                        this.choices[site.id] = {
+                            portalURL,
+                            choices: []
+                        };
+                        let tmp = [];
+                        //add selected cols first to retain their order
+                        const siteCols = (site.columns || "").split(',').filter(c => c !== "");
+                        siteCols.forEach((col) => {
+                            if (this.allColumns.includes(col)) {
+                                tmp.push({
+                                    value: col,
+                                    label: this.frontEndColumns[col],
+                                    selected: true,
+                                    customProperties: {
+                                        header: this.frontEndColumns[col]
+                                    }
+                                });
                             }
                         });
-                        this.otherSitemapSites = otherSitemapSites;
-
-                        const formattedSiteMap = inboxSites.map((site) => ({
-                            ...site,
-                            columns: site?.columns || 'service,title,status',
-                            formColumns: site?.formColumns || {},
-                            show: site.show ?? true
-                        }));
-                        this.sites = formattedSiteMap.sort((a, b) => a.order - b.order);
-
-                        let count = 0; //TODO: try to optimize once per portal
-                        this.sites.forEach((site) => {
-                            this.choices.push({
-                                id: site.id,
-                                choices: []
-                            });
-                            let tmp = [];
-                            //add selected cols first to retain their order
-                            const siteCols = (site.columns || "").split(',').filter(c => c !== "");
-                            siteCols.forEach((col) => {
-                                if (this.allColumns.includes(col)) {
-                                    tmp.push({
-                                        value: col,
-                                        label: this.frontEndColumns[col],
-                                        selected: true,
-                                        customProperties: {
-                                            header: this.frontEndColumns[col]
-                                        }
-                                    });
-                                }
-                            });
-                            this.allColumns.forEach((col) => {
-                                if (!site.columns.includes(col)) {
-                                    tmp.push({
-                                        value: col,
-                                        label: this.frontEndColumns[col],
-                                        selected: false,
-                                        customProperties: {
-                                            header: this.frontEndColumns[col]
-                                        }
-                                    });
-                                }
-                            });
-                            this.choices.find((choice) => choice.id == site.id).choices = tmp;
-
-                            const portalURL = this.getPortalURL(site.target);
-
-                            this.getPortalData(site.id, portalURL)
-                            .then(() => {
-                                count += 1;
-                                if (count === this.sites.length) {
-                                    resolve();
-                                }
-                            })
-                            .catch(err => {
-                                console.log(err);
-                                reject(err);
-                            });
+                        this.allColumns.forEach((col) => {
+                            if (!site.columns.includes(col)) {
+                                tmp.push({
+                                    value: col,
+                                    label: this.frontEndColumns[col],
+                                    selected: false,
+                                    customProperties: {
+                                        header: this.frontEndColumns[col]
+                                    }
+                                });
+                            }
                         });
-                    },
-                    error: (err) => {
-                        reject(err);
+                        this.choices[site.id].choices = tmp;
+                    });
+
+                    const totalURLs = Object.keys(portalURLs).length;
+                    let count = 0;
+                    for (let key in portalURLs) {
+                        this.getPortalForms(key)
+                        .then(() => {
+                            count += 1;
+                            if (count === totalURLs) {
+                                this.loading = false;
+
+                                this.sites.forEach((site) => {
+                                    this.setupChoices(site);
+                                });
+                            }
+                        })
+                        .catch(err => {
+                            console.log(err);
+                        });
                     }
-                });
-            })
+                },
+                error: (err) => {
+                    reject(err);
+                }
+            });
         },
 
-        saveSettings() { 
+        saveSettings() {
             // sort the edited sites by order
             let sendObj = {
                 buttons:[]
@@ -176,7 +191,18 @@ const CombinedInboxEditor = Vue.createApp({
                     sitemap_json: JSON.stringify(sendObj)
                 },
                 success: (res) => {
-                    //1 if ok
+                    if(+res === 1) {
+                        this.sites.forEach(site => {
+                            const formID = document.getElementById('form_select_' + site.id)?.value || null;
+                            let columns = formID !== null ? site.formColumns[formID] || "service,title,status" : site.columns;
+                            columns = columns.split(",");
+
+                            this.choices[site.id].choices.map(c => {
+                                c.selected = columns.includes(c.value);
+                            });
+                            this.updateChoiceSelections(site.id, columns);
+                        });
+                    }
                 },
                 error: (err) => {
                     console.log(err);
@@ -187,11 +213,27 @@ const CombinedInboxEditor = Vue.createApp({
         sortSites() {
             this.sites.sort((a, b) => a.order - b.order);
         },
-
+        updateChoiceSelections(siteID, arrColumns) {
+            const choices = this.choices[siteID]?.choices || [];
+            const elChoicesSelect = document.getElementById('choice-' + siteID);
+            if(typeof elChoicesSelect?.choicesjs !== undefined) {
+                elChoicesSelect.choicesjs.clearChoices();
+                elChoicesSelect.choicesjs.setChoices(choices);
+                elChoicesSelect.choicesjs.removeActiveItems();
+                arrColumns.forEach(col => {
+                    const val = this.allColumns.includes(col) ? col : +col;
+                    const choice = choices.find(choice => choice.value === val) || null;
+                    if(choice !== null) {
+                        elChoicesSelect.choicesjs.setChoiceByValue(val);
+                    }
+                });
+                this.updateKey += 1;
+            }
+        },
         setupChoices(site) {
             setTimeout(() => {
                 let selectElement = document.getElementById('choice-' + site.id);
-                const siteChoices = this.choices.find((choice) => choice.id == site.id)?.choices || [];
+                const siteChoices = this.choices[site.id]?.choices || [];
 
                 const selChoices = new Choices(selectElement, {
                     allowHTML: false,
@@ -211,6 +253,15 @@ const CombinedInboxEditor = Vue.createApp({
                     } else {
                         site.formColumns[selectedForm] = selectedValue;
                     }
+                    //update columns and formColumns properties of sites with the same portalURL
+                    const portalURL = this.getPortalURL(site.target);
+                    this.sites.forEach(s => {
+                        const sitePortalURL = this.getPortalURL(s.target);
+                        if(s.id !== site.id && sitePortalURL === portalURL) {
+                            s.columns = site.columns;
+                            s.formColumns = site.formColumns;
+                        }
+                    })
                     this.saveSettings();
                 });
             });
@@ -235,7 +286,7 @@ const CombinedInboxEditor = Vue.createApp({
             }
             return portalURL;
         },
-        async getPortalData(siteID, portalURL) {
+        async getPortalForms(portalURL) {
             const resForms = await fetch(`${portalURL}api/form/categories`, {
                 headers: {
                     "Content-Type": "application/json",
@@ -244,72 +295,71 @@ const CombinedInboxEditor = Vue.createApp({
             });
             const forms = await resForms.json();
 
-            const resIndicators = await fetch(portalURL + "api/form/indicator/list", {
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                cache: "no-cache"
-            });
-            const indicators = await resIndicators.json();
-            const enabledIndicators = indicators.filter(i => i.isDisabled === 0);
-
-            this.portalData[siteID] = {
-                id: siteID,
-                portalURL: portalURL,
+            this.portalForms[portalURL] = {
                 forms: forms,
-                indicators: enabledIndicators,
             };
         },
-        setIndicatorChoices(event, site) {
-            let elChoicesSelect = document.getElementById('choice-' + site.id);
+
+        /** Used when a form selection is made.  Updates options and selection status.
+         * @param {object} event form select element onchange event
+         * @param {object} site object containing information about the specific card
+         * @returns removes encoded chars by passing through div and then strips all tags
+         */
+        async setIndicatorChoices(event, site) {
             const siteID = site.id;
-            const formID = event.currentTarget.value;
-            const indicators = this.portalData[siteID]?.indicators || [];
-            const formIndicators = indicators.filter(i => i.categoryID === formID);
+            const portalURL = this.getPortalURL(site.target);
+            const formID = event.currentTarget.value || null;
 
-            let siteChoices = this.choices.find(choice => choice.id === siteID);
-            siteChoices.choices = siteChoices.choices.filter(c => !Number.isInteger(+c.value));
+            let enabledIndicators = [];
+            if(formID !== null) {
+                const resIndicators = await fetch(portalURL + `api/form/indicator/list?forms=${formID}`, {
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    cache: "no-cache"
+                });
+                const indicators = await resIndicators.json();
+                enabledIndicators = indicators.filter(i => i.isDisabled === 0);
+            }
+            const formColumns = (site.formColumns?.[formID] || "service,title,status").split(",");
 
-            const choicesInfo = formIndicators.map(i => {
+            //rm prior indicators and re-add new
+            let siteChoices = this.choices[siteID];
+            siteChoices.choices = siteChoices.choices.filter(c => this.allColumns.includes(c.value));
+            siteChoices.choices.map(c => {
+                c.selected = formColumns.includes(c.value);
+            });
+            const indicatorChoices = enabledIndicators.map(i => {
                 const indName = XSSHelpers.stripAllTags(i.description || i.name);
+                const strIndID = String(i.indicatorID);
                 return {
                     label: i.categoryName + ': ' + indName + " (ID: " + i.indicatorID + ")",
-                    selected: site.columns.includes(i.indicatorID),
+                    selected: formColumns.includes(strIndID),
                     value: i.indicatorID,
                     customProperties: {
                         header: indName
                     }
                 }
             });
-            siteChoices.choices.push(...choicesInfo);
-            if(typeof elChoicesSelect?.choicesjs !== undefined) {
-                elChoicesSelect.choicesjs.clearChoices();
-                elChoicesSelect.choicesjs.setChoices(siteChoices.choices);
-                elChoicesSelect.choicesjs.removeActiveItems();
-                const formColumns = site?.formColumns?.[formID] || null;
-                const baseColumns = site?.columns || 'service,title,status';
-                const columns = (formColumns || baseColumns).split(',');
+            siteChoices.choices.push(...indicatorChoices);
 
-                let choices = [];
-                columns.forEach(c => {
-                    const val = isNaN(c) ? c : +c;
-                    let choice = siteChoices.choices.find(choice => choice.value === val) || null;
-                    if(choice !== null) {
-                        choices.push({ ...choice });
-                    }
-                });
-                elChoicesSelect.choicesjs.setValue(choices);
-            }
+            this.updateChoiceSelections(site.id, formColumns);
         },
+
         getHeaderHTML(site) {
-            let html = `<th class="col-header">UID</th>`;
+            console.log("called get html")
+            const formID = document.getElementById('form_select_' + site.id)?.value || null;
+            let html = `<tr><th class="col-header">UID</th>`;
             let indChoices = [];
             let filteredIndChoices = [];
 
-            const siteCols = site.columns.split(',').filter(c => c !== "");
+            const siteCols = formID === null ?
+                (site.columns || "").split(',').filter(c => c !== "") :
+                (site.formColumns[formID] || "service,title,status").split(',');
+
             const numericCols = siteCols.filter(str => +str > 0);
             if(numericCols.length > 0) { //don't bother getting and filtering if there aren't any indicator columns
-                indChoices = this.choices.find(choice => choice.id == site.id)?.choices || [];
+                indChoices = this.choices?.[site.id]?.choices || [];
                 filteredIndChoices = indChoices.filter(c => numericCols.includes(String(c.value)));
             }
             siteCols.forEach(col => {
@@ -319,18 +369,12 @@ const CombinedInboxEditor = Vue.createApp({
                 }
                 html += `<th class="col-header">${header}</th>`;
             });
-            html += `<th class="col-header">Action</th>`;
+            html += `<th class="col-header">Action</th></tr>`;
             return html;
         }
     },
     created() {
-        this.runSetup().then(() => {
-            this.loading = false;
-
-            this.sites.forEach((site) => {
-                this.setupChoices(site);
-            });
-        });
+        this.runSetup();
     },
     template: `
     <h1 style="margin: 3rem;">Combined Inbox Editor</h1>
@@ -366,24 +410,26 @@ const CombinedInboxEditor = Vue.createApp({
                     }"
                 >
                     <div class="site-title" :style="{backgroundColor: site.color, color: site.fontColor}">
-                        <span v-html="getIcon(site.icon, site.title)"></span>
+                        <span v-html="getIcon(site.icon)"></span>
                         {{site.title}}
                     </div>
                     <div class="inbox">
-                        <table style="width: 100%;" cellspacing=0>
-                            <tr v-html="getHeaderHTML(site)"></tr>
-                        </table>
+                        <table style="width: 100%;" cellspacing=0 v-html="getHeaderHTML(site)" :key="'headers_' + site.id + updateKey"></table>
                         <select :id="'choice-' + site.id" placeholder="select some options" multiple></select>
 
-                        <template v-if="portalData[site.id]?.forms">
-                            <label :for="'form_select_' + site.id">Select a form to add question headers</label><br/>
+                        <template v-if="siteForms[site.id]?.length > 0">
+                            <label :for="'form_select_' + site.id">Select a form for specific settings</label><br/>
                             <select :id="'form_select_' + site.id" placeholder="select a form" @change="setIndicatorChoices($event, site)">
                                 <option value="">Select a form</option>
-                                <option v-for="form in portalData[site.id].forms" :value="form.categoryID" :key="'form_' + site.id + '_' + form.categoryID">
+                                <option v-for="form in siteForms[site.id]" :value="form.categoryID" :key="'form_' + site.id + '_' + form.categoryID">
                                     {{form.categoryName}} ({{form.categoryID}})
                                 </option>
                             </select>
                         </template>
+                        <div v-if="Object.keys(site.formColumns).length > 0" style="margin-top: 1rem;">
+                            <h3>Form specific settings are set for the forms listed below (TODO:)</h3>
+                            <div v-for="val, key in site.formColumns">{{key}} | {{val}}</div>
+                        </div>
                     </div>
                 </div>
             </template>

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
@@ -1,11 +1,13 @@
 const CombinedInboxEditor = Vue.createApp({
     data() {
         return {
+            loading: true,
             sites: [],
             otherSitemapSites: [],
+            portalData: {},
             choices: [],
             CSRFToken: CSRFToken,
-            allColumns: 'service,title,status,dateInitiated,days_since_last_action,priority,dateSubmitted',
+            allColumns: ['service','title','status','dateInitiated','days_since_last_action','priority','dateSubmitted'],
             frontEndColumns: {
                 'service': 'Service',
                 'title': 'Title',
@@ -36,15 +38,20 @@ const CombinedInboxEditor = Vue.createApp({
         onDrop(evt) {
             const site = this.sites.find((site) => site.id == evt.dataTransfer.getData('siteID'));
             const target = this.sites.find((site) => site.id == evt.target.attributes.value.value);
-            
             if (site.order < target.order) {
                 for (let i = site.order; i <= target.order; i++) {
-                    this.sites.find((site) => site.order == i).order--;
+                    const site = this.sites.find((site) => site.order == i) || null;
+                    if(site !== null) {
+                        site.order--;
+                    }
                 }
                 site.order = target.order + 1;
             } else if (site.order > target.order) {
                 for (let i = site.order; i >= target.order; i--) {
-                    this.sites.find((site) => site.order == i).order++;
+                    const site = this.sites.find((site) => site.order == i) || null;
+                    if(site !== null) {
+                        site.order++;
+                    }
                 }
                 site.order = target.order - 1;
             }
@@ -65,8 +72,10 @@ const CombinedInboxEditor = Vue.createApp({
             }
             return icon;
         },
-    
-        getMapSites() {
+        /**
+         * get sitemap JSON. setup base column values for LEAF cards.  save non-LEAF cards
+        */
+        runSetup() {
             return new Promise((resolve, reject) => {
                 $.ajax({
                     type: 'GET',
@@ -86,19 +95,23 @@ const CombinedInboxEditor = Vue.createApp({
 
                         const formattedSiteMap = inboxSites.map((site) => ({
                             ...site,
-                            columns: site.columns ?? 'service,title,status',
+                            columns: site?.columns || 'service,title,status',
+                            formColumns: site?.formColumns || {},
                             show: site.show ?? true
                         }));
                         this.sites = formattedSiteMap.sort((a, b) => a.order - b.order);
+
+                        let count = 0; //TODO: try to optimize once per portal
                         this.sites.forEach((site) => {
                             this.choices.push({
                                 id: site.id,
                                 choices: []
                             });
                             let tmp = [];
+                            //add selected cols first to retain their order
                             const siteCols = (site.columns || "").split(',').filter(c => c !== "");
                             siteCols.forEach((col) => {
-                                if (isNaN(col)) {
+                                if (this.allColumns.includes(col)) {
                                     tmp.push({
                                         value: col,
                                         label: this.frontEndColumns[col],
@@ -109,19 +122,33 @@ const CombinedInboxEditor = Vue.createApp({
                                     });
                                 }
                             });
-                            this.allColumns.split(',').forEach((col) => {
+                            this.allColumns.forEach((col) => {
                                 if (!site.columns.includes(col)) {
                                     tmp.push({
                                         value: col,
                                         label: this.frontEndColumns[col],
-                                        selected: false, customProperties: {
+                                        selected: false,
+                                        customProperties: {
                                             header: this.frontEndColumns[col]
                                         }
                                     });
                                 }
                             });
                             this.choices.find((choice) => choice.id == site.id).choices = tmp;
-                            resolve();
+
+                            const portalURL = this.getPortalURL(site.target);
+
+                            this.getPortalData(site.id, portalURL)
+                            .then(() => {
+                                count += 1;
+                                if (count === this.sites.length) {
+                                    resolve();
+                                }
+                            })
+                            .catch(err => {
+                                console.log(err);
+                                reject(err);
+                            });
                         });
                     },
                     error: (err) => {
@@ -164,78 +191,152 @@ const CombinedInboxEditor = Vue.createApp({
         setupChoices(site) {
             setTimeout(() => {
                 let selectElement = document.getElementById('choice-' + site.id);
-                new Choices(selectElement, {
+                const siteChoices = this.choices.find((choice) => choice.id == site.id)?.choices || [];
+
+                const selChoices = new Choices(selectElement, {
                     allowHTML: false,
                     removeItemButton: true,
                     editItems: true,
                     maxItemCount: 7,
                     shouldSort: false,
                     placeholderValue: "Click to search. Limit 7 columns.",
-                    choices: this.choices.find((choice) => choice.id == site.id).choices,
+                    choices: siteChoices,
                 });
+                selectElement.choicesjs = selChoices;
                 selectElement.addEventListener('change', (event) => {
-                    let selectedValue = Array.prototype.slice.call(event.target.children).map((child) => child.value).join(',');
-                    site.columns = selectedValue;
+                    const selectedValue = Array.prototype.slice.call(event.target.children).map((child) => child.value).join(',');
+                    const selectedForm = document.getElementById(`form_select_${site.id}`)?.value || null;
+                    if(selectedForm === null) {
+                        site.columns = selectedValue;
+                    } else {
+                        site.formColumns[selectedForm] = selectedValue;
+                    }
                     this.saveSettings();
                 });
             });
         },
-        async getIndicators(portalURL = '') {
-            if (portalURL === '') {
-                return [];
+        getPortalURL(cardURL) {
+            let portalURL = cardURL;
+            if(portalURL.indexOf('/admin/') != -1) {
+                portalURL = portalURL.substring(0, portalURL.indexOf('/admin/') + 1);
+            } else if(portalURL.indexOf('/?') != -1) {
+                portalURL = portalURL.substring(0, portalURL.indexOf('/?') + 1);
+            } else if(portalURL.indexOf('/index.php?') != -1) {
+                portalURL = portalURL.substring(0, portalURL.indexOf('/index.php?') + 1);
+            } else if(portalURL.indexOf('/report.php?') != -1) {
+                portalURL = portalURL.substring(0, portalURL.indexOf('/report.php?') + 1);
+            } else if(portalURL.indexOf('/api/open/form/query/') != -1) {
+                portalURL = portalURL.substring(0, portalURL.indexOf('/api/open/form/query/') + 1);
+            } else if(portalURL.indexOf('/open.php?') != -1) {
+                portalURL = portalURL.substring(0, portalURL.indexOf('/open.php?') + 1);
             }
             if(!portalURL.endsWith('/')) {
                 portalURL += '/';
             }
-            const indicators = await fetch(portalURL + "api/form/indicator/list", {
+            return portalURL;
+        },
+        async getPortalData(siteID, portalURL) {
+            const resForms = await fetch(`${portalURL}api/form/categories`, {
                 headers: {
                     "Content-Type": "application/json",
                 },
                 cache: "no-cache"
             });
-            return await indicators.json();
+            const forms = await resForms.json();
+
+            const resIndicators = await fetch(portalURL + "api/form/indicator/list", {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                cache: "no-cache"
+            });
+            const indicators = await resIndicators.json();
+            const enabledIndicators = indicators.filter(i => i.isDisabled === 0);
+
+            this.portalData[siteID] = {
+                id: siteID,
+                portalURL: portalURL,
+                forms: forms,
+                indicators: enabledIndicators,
+            };
+        },
+        setIndicatorChoices(event, site) {
+            let elChoicesSelect = document.getElementById('choice-' + site.id);
+            const siteID = site.id;
+            const formID = event.currentTarget.value;
+            const indicators = this.portalData[siteID]?.indicators || [];
+            const formIndicators = indicators.filter(i => i.categoryID === formID);
+
+            let siteChoices = this.choices.find(choice => choice.id === siteID);
+            siteChoices.choices = siteChoices.choices.filter(c => !Number.isInteger(+c.value));
+
+            const choicesInfo = formIndicators.map(i => {
+                const indName = XSSHelpers.stripAllTags(i.description || i.name);
+                return {
+                    label: i.categoryName + ': ' + indName + " (ID: " + i.indicatorID + ")",
+                    selected: site.columns.includes(i.indicatorID),
+                    value: i.indicatorID,
+                    customProperties: {
+                        header: indName
+                    }
+                }
+            });
+            siteChoices.choices.push(...choicesInfo);
+            if(typeof elChoicesSelect?.choicesjs !== undefined) {
+                elChoicesSelect.choicesjs.clearChoices();
+                elChoicesSelect.choicesjs.setChoices(siteChoices.choices);
+                elChoicesSelect.choicesjs.removeActiveItems();
+                const formColumns = site?.formColumns?.[formID] || null;
+                const baseColumns = site?.columns || 'service,title,status';
+                const columns = (formColumns || baseColumns).split(',');
+
+                let choices = [];
+                columns.forEach(c => {
+                    const val = isNaN(c) ? c : +c;
+                    let choice = siteChoices.choices.find(choice => choice.value === val) || null;
+                    if(choice !== null) {
+                        choices.push({ ...choice });
+                    }
+                });
+                elChoicesSelect.choicesjs.setValue(choices);
+            }
+        },
+        getHeaderHTML(site) {
+            let html = `<th class="col-header">UID</th>`;
+            let indChoices = [];
+            let filteredIndChoices = [];
+
+            const siteCols = site.columns.split(',').filter(c => c !== "");
+            const numericCols = siteCols.filter(str => +str > 0);
+            if(numericCols.length > 0) { //don't bother getting and filtering if there aren't any indicator columns
+                indChoices = this.choices.find(choice => choice.id == site.id)?.choices || [];
+                filteredIndChoices = indChoices.filter(c => numericCols.includes(String(c.value)));
+            }
+            siteCols.forEach(col => {
+                let header = this.frontEndColumns[col] || null; //look here first
+                if (header === null && filteredIndChoices.length > 0) {
+                    header = filteredIndChoices.find(c => +c.value === +col)?.customProperties?.header || "";
+                }
+                html += `<th class="col-header">${header}</th>`;
+            });
+            html += `<th class="col-header">Action</th>`;
+            return html;
         }
     },
     created() {
-        this.getMapSites().then(() => {
+        this.runSetup().then(() => {
+            this.loading = false;
+
             this.sites.forEach((site) => {
-                let portalURL = site.target;
-                if(portalURL.indexOf('/admin/') != -1) {
-                    portalURL = portalURL.substring(0, portalURL.indexOf('/admin/') + 1);
-                } else if(portalURL.indexOf('/?') != -1) {
-                    portalURL = portalURL.substring(0, portalURL.indexOf('/?') + 1);
-                } else if(portalURL.indexOf('/index.php?') != -1) {
-                    portalURL = portalURL.substring(0, portalURL.indexOf('/index.php?') + 1);
-                } else if(portalURL.indexOf('/report.php?') != -1) {
-                    portalURL = portalURL.substring(0, portalURL.indexOf('/report.php?') + 1);
-                } else if(portalURL.indexOf('/api/open/form/query/') != -1) {
-                    portalURL = portalURL.substring(0, portalURL.indexOf('/api/open/form/query/') + 1);
-                } else if(portalURL.indexOf('/open.php?') != -1) {
-                    portalURL = portalURL.substring(0, portalURL.indexOf('/open.php?') + 1);
-                }
-                this.getIndicators(portalURL).then((indicators) => {
-                    let siteChoices = this.choices.find((choice) => choice.id === site.id);
-                    const choicesInfo = indicators.map(i => {
-                        const indName = XSSHelpers.stripAllTags(i.description || i.name);
-                        return {
-                            label: i.categoryName + ': ' + indName + " (ID: " + i.indicatorID + ")",
-                            selected: site.columns.includes(i.indicatorID),
-                            value: i.indicatorID,
-                            customProperties: {
-                                header: indName
-                            }
-                        }
-                    });
-                    siteChoices.choices.push(...choicesInfo);
-                    this.setupChoices(site);
-                });
+                this.setupChoices(site);
             });
         });
     },
     template: `
     <h1 style="margin: 3rem;">Combined Inbox Editor</h1>
 
-    <div id="editor-container">
+    <h2 v-if="loading">Loading Site Data ...</h2>
+    <div v-else id="editor-container">
         <div id="side-bar" class="inbox" style="display: block;">
             Edit Columns 
             <br/>
@@ -249,7 +350,7 @@ const CombinedInboxEditor = Vue.createApp({
                 @dragstart="startDrag($event, site)"
                 @drop="onDrop($event)"
                 :value="site.id"
-                :key="site.order">
+                :key="site.order + 'site.title'">
                     &#x2630; {{site.title}}
                 </div>
             </div>
@@ -257,11 +358,12 @@ const CombinedInboxEditor = Vue.createApp({
         <div id="inbox-preview" style="display: block;">
             <template v-for="site in sites" :key="site.id">
                 <div :id="'site-container-' + site.id" 
-                class="site-container" 
-                :style="{
-                    borderRight: '8px solid' + site.color, 
-                    borderLeft: '8px solid' + site.color, 
-                    borderBottom: '8px solid' + site.color}"
+                    class="site-container"
+                    :style="{
+                        borderRight: '8px solid' + site.color,
+                        borderLeft: '8px solid' + site.color,
+                        borderBottom: '8px solid' + site.color
+                    }"
                 >
                     <div class="site-title" :style="{backgroundColor: site.color, color: site.fontColor}">
                         <span v-html="getIcon(site.icon, site.title)"></span>
@@ -269,17 +371,19 @@ const CombinedInboxEditor = Vue.createApp({
                     </div>
                     <div class="inbox">
                         <table style="width: 100%;" cellspacing=0>
-                            <tr>
-                            <th class="col-header">UID</th>
-                            <template v-if="site.columns.split(',')[0] !== ''">
-                                <template v-for="column in site.columns.split(',')" :key="column">
-                                <th class='col-header' value='column'>{{choices.find((choice) => choice.id == site.id)?.choices?.find((choice) => choice.value == column)?.customProperties?.header}}</th>
-                                </template>
-                            </template>
-                            <th class="col-header">Action</th>
-                            </tr>
+                            <tr v-html="getHeaderHTML(site)"></tr>
                         </table>
                         <select :id="'choice-' + site.id" placeholder="select some options" multiple></select>
+
+                        <template v-if="portalData[site.id]?.forms">
+                            <label :for="'form_select_' + site.id">Select a form to add question headers</label><br/>
+                            <select :id="'form_select_' + site.id" placeholder="select a form" @change="setIndicatorChoices($event, site)">
+                                <option value="">Select a form</option>
+                                <option v-for="form in portalData[site.id].forms" :value="form.categoryID" :key="'form_' + site.id + '_' + form.categoryID">
+                                    {{form.categoryName}} ({{form.categoryID}})
+                                </option>
+                            </select>
+                        </template>
                     </div>
                 </div>
             </template>

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
@@ -336,7 +336,9 @@ const CombinedInboxEditor = Vue.createApp({
                 const indicators = await resIndicators.json();
                 enabledIndicators = indicators.filter(i => i.isDisabled === 0);
             }
-            const formColumns = (site.formColumns?.[formID] || "service,title,status").split(",");
+            const formColumns = formID === null ?
+                (site.columns || "service,title,status").split(",") :
+                (site.formColumns?.[formID] || "service,title,status").split(",");
 
             //rm prior indicators and re-add new
             let siteChoices = this.choices[siteID];
@@ -391,7 +393,7 @@ const CombinedInboxEditor = Vue.createApp({
         this.runSetup();
     },
     template: `
-    <h1 style="margin: 3rem;">Combined Inbox Editor</h1>
+    <h1 style="margin: 3rem;">Combined Inbox Editor (beta)</h1>
 
     <h2 v-if="loading">Loading Site Data ...</h2>
     <div v-else id="editor-container">
@@ -430,7 +432,7 @@ const CombinedInboxEditor = Vue.createApp({
                     <div class="inbox">
                         <table style="width: 100%;" cellspacing=0 v-html="getHeaderHTML(site)" :key="'headers_' + site.id + updateKey"></table>
                         <select :id="'choice-' + site.id" placeholder="select some options" multiple></select>
-
+                        <p>If no form is selected, choices will be applied to the 'organize by role' view and to all forms without specific settings.</p>
                         <template v-if="siteForms[site.id]?.forms?.length > 0">
                             <label :for="'form_select_' + site.id">Select a form to add specific settings</label><br/>
                             <select :id="'form_select_' + site.id" placeholder="select a form" @change="setIndicatorChoices($event, site)">

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -446,17 +446,19 @@
             });
         }
 
-        let customCols = [];
+        let headerColumns = "";
         if (customColumns === false) {
             const baseColumns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
             const formColumns = site.formColumns[categoryID] || null;
             if (formColumns !== null) {
-                site.columns = formColumns;
+                headerColumns = formColumns;
             } else {
-                site.columns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
+                headerColumns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
             }
+            headerColumns = headerColumns.split(",")
         }
-        site.columns.split(',').forEach(col => {
+        let customCols = [];
+        headerColumns.forEach(col => {
             if (isNaN(col)) {
                 customCols.push(headerDefinitions[col](site));
             } else {

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -195,8 +195,8 @@
                 callback: function(data, blob) {
                     const recordBlob = blob[data.recordID];
                     const priority = recordBlob.priority;
-                    const priorityText = priority === -10 ? '<b style="color:#c00;">EMERGENCY</b>' : 'standard';
-                    $('#' + data.cellContainerID).html(priority + `&nbsp;${priorityText}`);
+                    const priorityText = priority === -10 ? '<b style="color:#c00;">EMERGENCY</b>' : 'normal';
+                    $('#' + data.cellContainerID).html(priorityText);
                 }
             }
         },

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -614,16 +614,17 @@
         const siteColumns = (site?.columns || "").split(',').filter(c => c !== "");
         const formColumns = site?.formColumns || {};
         let arrFormColumns = [];
+        let cols = '';
         for (let key in formColumns) {
-            let cols = formColumns[key];
+            cols = formColumns[key] ?? '';
             cols = cols.split(',');
             arrFormColumns = arrFormColumns.concat(cols)
         }
         let allColumns = siteColumns.concat(arrFormColumns);
         allColumns = Array.from(new Set(allColumns));
-
+        let col = '';
         for (let i in allColumns) {
-            const col = allColumns[i];
+            col = allColumns[i] ?? '';
             if (!isNaN(parseInt(col))) {
                 getData.push(parseInt(col));
             } else {

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -76,7 +76,7 @@
                         $('#' + data.cellContainerID).html('<a href="' + site.url +
                             'index.php?a=printview&recordID=' + data.recordID + '" target="_blank">' +
                             blob[data.recordID].title + '</a>' +
-                            ' <button id="' + data.cellContainerID +
+                            ' <button type="button" id="' + data.cellContainerID +
                             '_preview" class="buttonNorm">Quick View</button>' +
                             '<div id="inboxForm' + hash + '_' + data.recordID +
                             '" style="background-color: white; display: none; height: 300px; overflow: scroll"></div>'
@@ -398,14 +398,15 @@
             $('#inbox').append(`<a name="${hash}"></a>
 				<div id="siteContainer${hash}" style="box-shadow: 0 2px 3px #a7a9aa; border: 1px solid black; 
 				background-color: ${site.backgroundColor}; margin: 0px auto 1.5rem">
-				<div style="font-weight: bold; font-size: 200%; line-height: 240%; background-color: ${site.backgroundColor}; color: ${site.fontColor}; ">${icon} ${site.name} </div>
+				<div style="padding:0.5rem;font-weight:bold;font-size:200%;line-height: 240%; background-color: ${site.backgroundColor}; color: ${site.fontColor}; ">${icon} ${site.name} </div>
 				<div id="siteFormContainer${hash}" class="siteFormContainers"></div>
     			</div>`);
         }
         $(`#siteFormContainer${hash}`).append(`<div id="depContainer${hash}_${depID}" class="depContainer">
-            <div id="depLabel${hash}_${depID}" class="depInbox" style="padding: 8px; background-color: ${site.backgroundColor}">
-			<span style="float: right; text-decoration: underline; font-weight: bold; color: ${site.fontColor}">View ${recordIDs.length} requests</span>
-			<span style="font-size: 130%; font-weight: bold; color: ${site.fontColor}">${categoryName}</span></div>
+            <button type="button" id="depLabel${hash}_${depID}" class="depInbox" style="background-color: ${site.backgroundColor}">
+                <span style="font-size: 130%; font-weight: bold; color: ${site.fontColor}">${categoryName}</span>
+                <span style="text-align:end;text-decoration: underline; font-weight: bold; color: ${site.fontColor}">View ${recordIDs.length} requests</span>
+            </button>
 			<div id="depList${hash}_${depID}" style="width: 90%; margin: auto; display: none"></div></div>`);
         $('#depLabel' + hash + '_' + depID).on('click', function() {
             buildInboxGridView(res, depID, categoryName, recordIDs, site, hash, categoryIDs);
@@ -476,7 +477,7 @@
             callback: function(data, blob) {
                 let depDescription = 'Take Action';
                 $('#' + data.cellContainerID).css('text-align', 'center');
-                $('#' + data.cellContainerID).html('<button id="btn_action' + hash + '_' + stepID + '_' +
+                $('#' + data.cellContainerID).html('<button type="button" id="btn_action' + hash + '_' + stepID + '_' +
                                                    data.recordID +
                                                    '" class="buttonNorm" style="text-align: center; font-weight: bold; white-space: normal">' +
                                                    depDescription + '</button>');
@@ -551,15 +552,18 @@
             $('#inbox').append(`<a name="${hash}"></a>
 				<div id="siteContainer${hash}" style="box-shadow: 0 2px 3px #a7a9aa; border: 1px solid black; 
 				background-color: ${site.backgroundColor}; margin: 0px auto 1.5rem">
-				<div style="font-weight: bold; font-size: 200%; line-height: 240%; background-color: ${site.backgroundColor}; color: ${site.fontColor}; ">${icon} ${site.name} </div>
+				<div style="padding:0.5rem;font-weight: bold; font-size: 200%; line-height: 240%; background-color: ${site.backgroundColor}; color: ${site.fontColor}; ">${icon} ${site.name} </div>
 				<div id="siteFormContainer${hash}" class="siteFormContainers"></div>
     			</div>`);
         }
         $(`#siteFormContainer${hash}`).append(`<div id="depContainer${hash}_${stepID}" class="depContainer">
-            <div id="depLabel${hash}_${stepID}" class="depInbox" style="padding: 8px; background-color: ${site.backgroundColor}">
-			<span style="float: right; text-decoration: underline; font-weight: bold; color: ${site.fontColor}">View ${recordIDs.length} requests</span>
-			<span style="font-size: 130%; font-weight: bold; color: ${site.fontColor}">${stepName}</span><br />
-            <span style="color: ${site.fontColor}">${categoryName}</span></div>
+            <button type="button" id="depLabel${hash}_${stepID}" class="depInbox" style="background-color: ${site.backgroundColor}">
+                <div>
+                    <span style="font-size: 130%; font-weight: bold; color: ${site.fontColor}">${stepName}</span><br />
+                    <span style="color: ${site.fontColor}">${categoryName}</span>
+                </div>
+                <span style="text-align:end;text-decoration: underline; font-weight: bold; color: ${site.fontColor}">View ${recordIDs.length} requests</span>
+            </button>
 			<div id="depList${hash}_${stepID}" style="width: 90%; margin: auto; display: none"></div></div>`);
         $('#depLabel' + hash + '_' + stepID).on('click', function() {
             buildInboxGridView(res, stepID, stepName, recordIDs, site, hash);
@@ -938,13 +942,15 @@
     <h1>Loading...</h1>
     <div id="progressbar"></div>
     <h2 id="progressDetail"></h2>
-    <button id="btn_progressStop" class="buttonNorm">Stop and show results</button>
+    <button type="button" id="btn_progressStop" class="buttonNorm">Stop and show results</button>
 </div>
 
 <div id="viewport" style="visibility: hidden">
-<button id="btn_adminView" class="buttonNorm" style="float: right; <!--{if !$empMembership['groupID'][1]}-->display: none<!--{/if}-->">View as Admin</button>
-<button id="btn_organize" class="buttonNorm" style="float: right">Organize by Roles</button>
-<button id="btn_expandAll" class="buttonNorm" style="float: right">Toggle sections</button>
+<div style="display:flex;gap:0.25rem;justify-content:flex-end;">
+    <button type="button" id="btn_expandAll" class="buttonNorm">Toggle sections</button>
+    <button type="button" id="btn_organize" class="buttonNorm">Organize by Roles</button>
+    <button type="button" id="btn_adminView" class="buttonNorm" style="<!--{if !$empMembership['groupID'][1]}-->display: none<!--{/if}-->">View as Admin</button>
+</div>
 <br />
 <div id="inboxContainer">
     <div id="index" class="inbox">Jump to section:

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -187,6 +187,34 @@
                 }
             }
         },
+        'priority': function(site) {
+            return {
+                name: 'Priority',
+                indicatorID: 'priority',
+                editable: false,
+                callback: function(data, blob) {
+                    const recordBlob = blob[data.recordID];
+                    const priority = recordBlob.priority;
+                    const priorityText = priority === -10 ? '<b style="color:#c00;">EMERGENCY</b>' : 'standard';
+                    $('#' + data.cellContainerID).html(priority + `&nbsp;${priorityText}`);
+                }
+            }
+        },
+        'dateSubmitted': function(site) {
+            return {
+                name: 'Date Submitted',
+                indicatorID: 'dateSubmitted',
+                editable: false,
+                callback: function(data, blob) {
+                    const recordBlob = blob[data.recordID];
+                    let submittedText = "Not Submitted";
+                    if (recordBlob.submitted > 0) {
+                        submittedText = new Date(recordBlob.submitted * 1000).toLocaleDateString();
+                    }
+                    $('#' + data.cellContainerID).html(submittedText);
+                }
+            }
+        },
     };
 
     function scrubHTML(input) {
@@ -484,7 +512,12 @@
             formGrid.setHeaders(tHeaders);
         }
         formGrid.setData(tGridData);
-        formGrid.sort('recordID', 'asc');
+        const priorityHeader = formGrid.headers().find(h => h.indicatorID === 'priority') || null;
+        if (priorityHeader === null) {
+            formGrid.sort('recordID', 'asc');
+        } else {
+            formGrid.sort('priority', 'asc');
+        }
         formGrid.renderBody();
         //formGrid.loadData(tGridData.map(v => v.recordID).join(','));
         $('#' + formGrid.getPrefixID() + 'table').css('width', '99%');
@@ -544,7 +577,7 @@
         let query = new LeafFormQuery();
         query.setRootURL(site.url);
         query.setExtraParams(
-            '&x-filterData=recordID,categoryIDs,categoryNames,date,title,service,submitted,stepID,blockingStepID,lastStatus,stepTitle,action_history.time,unfilledDependencyData' +
+            '&x-filterData=recordID,categoryIDs,categoryNames,date,title,service,submitted,priority,stepID,blockingStepID,lastStatus,stepTitle,action_history.time,unfilledDependencyData' +
             nonAdminParam);
         query.onProgress(progress => {
             $('#progressCount').html(`~${progress} `);

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -431,7 +431,7 @@
                     site.columns[categoryID].split(',').forEach(col => {
                         // assign standard headers
                         if (isNaN(parseInt(col)) &&
-                            headerDefinitions[col] != undefined) {
+                            headerDefinitions[col] != undefined && typeof headerDefinitions[col] === 'function') {
                             customCols.push(headerDefinitions[col](site));
                         } else if (parseInt(col) > 0) { // assign custom data headers
                             let label = dataDictionary[site.url]?.[col]?.description;
@@ -460,7 +460,7 @@
         }
         let customCols = [];
         headerColumns.forEach(col => {
-            if (isNaN(col)) {
+            if (isNaN(col) && typeof headerDefinitions[col] === 'function') {
                 customCols.push(headerDefinitions[col](site));
             } else {
                 customCols.push({


### PR DESCRIPTION
**Combined Inbox Editor (beta) and LEAF_Inbox options updates**

-Fix bug that causes non portal sitemap cards to be deleted.

-Fix error that occurred if the sitemap card target does not end in a slash.

-Add js XSSHelpers to strip out all potential HTML in custom header names and update custom headers to use the short label if it's available instead of the full indicator name for the multiselect plugin options.

-Add Priority and Date Submitted header options.  Inbox view will automatically sort by priority if this header is present.

-Add ability to add form-specific settings for indicator questions.

-Inbox View 508 Adjustments:
Category Headers are now buttons instead of divs for keyboard accessibility.
Top buttons for view and organization options now tab left to right.


**Testing / Impact**
This update is specific to the admin side Combined Inbox Editor and the combined inbox view (LEAF_Inbox).
Errors noted above should no longer occur on the Inbox Editor, and both the Editor and Inbox should otherwise continue to behave as expected.
