### PR TITLE
LEAF 4233 fix null service name

### DIFF
--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -541,7 +541,7 @@ class Service
 
     public function getQuadrads()
     {
-        $res = $this->db->prepared_query('SELECT groupID, name FROM services
+        $res = $this->db->prepared_query('SELECT groupID, `service` AS `name` FROM services
     								LEFT JOIN `groups` USING (groupID)
     								WHERE groupID IS NOT NULL
     								GROUP BY groupID


### PR DESCRIPTION
Fixes empty header elements for ELT groups in the portal Service Chiefs admin area.

Uses the services.service field (the service name) rather than the groups.name field when selecting quadrads since the group name is null on this join unless the ELT is tagged with the portal (which users should not need to do).

Using the suggestion to select the service field as name to avoid needing further front end adjustments.


**Testing/Impact**

Create a new ELT in the nexus and a new Service under that ELT (nexus admin, Setup Wizard, Exec Leadership Team and Services steps).  Sync services in the portal.

In the Service Chiefs area, the new ELT name should appear in the h2 header tags with sub-services listed beneath it.
