### PR TITLE
Leaf 4239 - cleanup after 4204 release

### DIFF
--- a/app/Leaf/Site.php
+++ b/app/Leaf/Site.php
@@ -81,16 +81,8 @@ class Site
     private function checkPath(): array
     {
         $vars = array(':site_path' => $this->match);
-        // this needs to be this way until we release 4204, the two new fields won't
-        // be available until after the db_update is run which means several sites
-        // could be down for several minutes. Getting * will prevent this from
-        // happening and we can switch it back once we know everything is working as
-        // intended.
-        /* $sql = 'SELECT `site_path`, `site_uploads`, `portal_database`, `orgchart_path`,
+        $sql = 'SELECT `site_path`, `site_uploads`, `portal_database`, `orgchart_path`,
                     `orgchart_database`, `launchpadID`, `decommissionTimestamp`
-                FROM `sites`
-                WHERE `site_path` = BINARY :site_path'; */
-        $sql = 'SELECT *
                 FROM `sites`
                 WHERE `site_path` = BINARY :site_path';
 


### PR DESCRIPTION
Summary: A query needed to pull as Select * so that we wouldn't break the site while everything was pushed last Thursday. This is just to clean that query up and make it pull specific fields.

Potential Impact:
There shouldn't be any impact. It was only changed to prevent the site from breaking during deployment. This sets it back to what it was before with the addition of the 2 fields added in that deploy.