### PR TITLE
LEAF 2938 log form falsey value updates

### DIFF
--- a/LEAF_Request_Portal/sources/FormEditor.php
+++ b/LEAF_Request_Portal/sources/FormEditor.php
@@ -455,7 +455,7 @@ class FormEditor
     								SET categoryName=:input
                                     WHERE categoryID=:categoryID', $vars);
 
-        if(!empty($input)){
+        if(isset($input)){
             $this->dataActionLogger->logAction(DataActions::MODIFY,LoggableTypes::FORM,[
                 new LogItem("categories", "categoryID", $categoryID),
                 new LogItem("categories", "categoryName", $input)
@@ -475,7 +475,7 @@ class FormEditor
     								SET categoryDescription=:input
                                     WHERE categoryID=:categoryID', $vars);
 
-        if(!empty($input)){
+        if(isset($input)){
             $this->dataActionLogger->logAction(DataActions::MODIFY,LoggableTypes::FORM,[
                 new LogItem("categories", "categoryID", $categoryID),
                 new LogItem("categories", "categoryDescription", $input)
@@ -505,7 +505,7 @@ class FormEditor
 		    								SET workflowID=:input
 		    								WHERE categoryID=:categoryID', $vars);
 
-            if(!empty($input)){
+            if(isset($input)){
                 $this->dataActionLogger->logAction(DataActions::MODIFY,LoggableTypes::FORM,[
                     new LogItem("categories", "categoryID", $categoryID),
                     new LogItem("categories", "workflowID", $input)
@@ -527,7 +527,7 @@ class FormEditor
                         SET needToKnow=:input
                         WHERE categoryID=:categoryID', $vars);
 
-        if(!empty($input)){
+        if(isset($input)){
             $this->dataActionLogger->logAction(DataActions::MODIFY,LoggableTypes::FORM,[
                 new LogItem("categories", "categoryID", $categoryID),
                 new LogItem("categories", "needToKnow", $input)
@@ -547,7 +547,7 @@ class FormEditor
     								SET sort=:input
                                     WHERE categoryID=:categoryID', $vars);
 
-        if(!empty($input)){
+        if(isset($input)){
             $this->dataActionLogger->logAction(DataActions::MODIFY,LoggableTypes::FORM,[
                 new LogItem("categories", "categoryID", $categoryID),
                 new LogItem("categories", "sort", $input)
@@ -567,7 +567,7 @@ class FormEditor
     								SET visible=:input
                                     WHERE categoryID=:categoryID', $vars);
 
-        if(!empty($input)){
+        if(isset($input)){
             $this->dataActionLogger->logAction(DataActions::MODIFY,LoggableTypes::FORM,[
                 new LogItem("categories", "categoryID", $categoryID),
                 new LogItem("categories", "visible", $input)


### PR DESCRIPTION
Updates the check prior to logging form changes for:
categoryName, categoryDescription, workflowID, sort, visible (availability), and need to know


**Impact / Testing**

Form Editor (server side)

Setting a form name or description to an empty value, removing a form workflow, turning off need to know, hiding a form, or setting a form sort order to 0 should all result in a log entry in the form history.  Form updates and logging should continue to behave as expected.