### PR TITLE
LEAF-4241 - INC31179685 : Mail error No Recipients

### DIFF
--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -596,8 +596,8 @@ class Email
             "LEFT JOIN records AS rec USING (recordID) ".
             "LEFT JOIN step_dependencies AS sd USING (stepID) ".
             "LEFT JOIN dependency_privs USING (dependencyID) ".
-            "LEFT JOIN users USING (groupID) ".
             "LEFT JOIN services AS ser USING (serviceID) ".
+            "LEFT JOIN users ON ser.groupID=users.groupID".
             "WHERE recordID=:recordID AND (active=1 OR active IS NULL)";
         $approvers = $this->portal_db->prepared_query($strSQL, $vars);
 


### PR DESCRIPTION
Issue:

Automated emails were not coming through, this is an error that we saw in our logs and did not have a case study to figure out what is going on since there were no paths shown around the error in the main log. 

What I found to be the issue, the query is not returning a userid, further inspection using directive in the sql query is not joining as one would expect. When I adjusted the query to specifically use specific columns it returns the data that I would have expected.

Affected Site:

Staging could be used to test this out. 

https://leaf.va.gov/VISN20/653/health_administration_service/index.php?a=printview&recordID=2104

 

Possible Problems:

The code talks about quadrads I do not think this is a quadrad issue it self but this code could be used for it. 


Testing queries: 

    `SELECT users.userID AS approverID, sd.dependencyID, sd.stepID, ser.serviceID, ser.service, ser.groupID AS quadrad, users.groupID, rec.title, rec.lastStatus FROM records_workflow_state 
            LEFT JOIN records AS rec USING (recordID) 
            LEFT JOIN step_dependencies AS sd USING (stepID) 
            LEFT JOIN dependency_privs USING (dependencyID) 
            LEFT JOIN users USING (groupID) 
            LEFT JOIN services AS ser USING (serviceID) 
            WHERE recordID=32187 AND (active=1 OR active IS NULL);`
			  
    `SELECT users.userID AS approverID, sd.dependencyID, sd.stepID, ser.serviceID, ser.service, ser.groupID AS quadrad, users.groupID, rec.title, rec.lastStatus FROM records_workflow_state 
            LEFT JOIN records AS rec USING (recordID) 
            LEFT JOIN step_dependencies AS sd USING (stepID) 
            LEFT JOIN dependency_privs USING (dependencyID) 
            LEFT JOIN services AS ser USING (serviceID) 
            LEFT JOIN users ON ser.groupID=users.groupID
            WHERE recordID=32187 AND (active=1 OR active IS NULL);`












