### PR TITLE
Leaf 4216 - fixes large number exports.

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -1028,9 +1028,10 @@ var LeafFormGrid = function (containerID, options) {
 
           line[i] =
             (dataFormat !== null &&
-              dataFormat !== "date" &&
+              dataFormat !== 'date' &&
               testDateFormat.test(line[i])) ||
-            (isNumber.test(line[i]) && line[i].length > 9)
+            (isNumber.test(line[i]) &&
+              dataFormat === 'text')
               ? `="${line[i]}"`
               : line[i];
           if (i == 0 && headers[i] == "UID") {

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -996,8 +996,8 @@ var LeafFormGrid = function (containerID, options) {
       if (currentRenderIndex != currentData.length) {
         renderBody(0, Infinity);
       }
-      var output = [];
-      var headers = [];
+      let output = [];
+      let headers = [];
       //removes triangle symbols so that ascii chars are not present in exported headers.
       $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
         $(val).html("");
@@ -1007,28 +1007,30 @@ var LeafFormGrid = function (containerID, options) {
       });
       output.push(headers); //first row will be headers
 
-      var line = [];
-      var i = 0;
-      var thisSite = document.createElement("a");
-      var numColumns = headers.length - 1;
+      let line = [];
+      let i = 0;
+      let numColumns = headers.length - 1;
       document
         .querySelectorAll("#" + prefixID + "tbody>tr>td")
         .forEach(function (val) {
-          var foundScripts = val.querySelectorAll("script");
+          let foundScripts = val.querySelectorAll("script");
 
-          for (var tIdx = 0; tIdx < foundScripts.length; tIdx++) {
+          for (let tIdx = 0; tIdx < foundScripts.length; tIdx++) {
             foundScripts[tIdx].parentNode.removeChild(foundScripts[tIdx]);
           }
 
-          var trimmedText = val.innerText.trim();
+          let trimmedText = val.innerText.trim();
           line[i] = trimmedText;
           //prevent some values from being interpretted as dates by excel
           const dataFormat = val.getAttribute("data-format");
           const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
+          const isNumber = /^\d+$/;
+
           line[i] =
-            dataFormat !== null &&
-            dataFormat !== "date" &&
-            testDateFormat.test(line[i])
+            (dataFormat !== null &&
+              dataFormat !== "date" &&
+              testDateFormat.test(line[i])) ||
+            (isNumber.test(line[i]) && line[i].length > 9)
               ? `="${line[i]}"`
               : line[i];
           if (i == 0 && headers[i] == "UID") {
@@ -1060,8 +1062,8 @@ var LeafFormGrid = function (containerID, options) {
         rows += '"' + thisRow.join('","') + '",\r\n';
       });
 
-      var download = document.createElement("a");
-      var now = new Date().getTime();
+      let download = document.createElement("a");
+      let now = new Date().getTime();
       download.setAttribute(
         "href",
         "data:text/csv;charset=utf-8," + encodeURIComponent(rows)


### PR DESCRIPTION
Summary:
exporting data where fields have a large number (approximately 10 numbers or more) caused Excel to format it as an exponential number. This fix will force Excel to look at those numbers as text keep the number as it was.

Impact:
If someone wanted the number to be shown as an exponential number they would have to force Excel to do it after opening the file.

Testing:
create a report that have fields with only numbers and more than 10 numbers long. export it and notice the way Excel formats it.