### PR TITLE
Leaf 4250 - Simplify group/service management in Request Portals

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -361,8 +361,7 @@ function searchGroupsOldAccount(accountAndTaskInfo, queue) {
             .then(res => res.json()).then(data => {
                 let groupInfo = {};
                 //filter groups directly associated with old account (position handled differently)
-                const selectedAccountGroups = data.filter(g => g.members.some(m => m.userName === oldAccount &&
-                        (parseInt(m.locallyManaged) === 1 || m.regionallyManaged === true)));
+                const selectedAccountGroups = data.filter(g => g.members.some(m => m.userName === oldAccount));
 
                 selectedAccountGroups.forEach(g => {
                     let oldMemberSettings = g.members.find(m => m.userName === oldAccount);
@@ -410,7 +409,7 @@ function searchGroupsOldAccount(accountAndTaskInfo, queue) {
                             callback: function(data, blob) {
                                 const k = `group_${data.recordID}`;
                                 const isLocal = parseInt(groupInfo[k].oldMemberSettings.locallyManaged) === 1;
-                                const isRegional = groupInfo[k].oldMemberSettings.regionallyManaged === true;
+                                const isRegional = !isLocal;
 
                                 const displayName = `${groupInfo[k].oldMemberSettings.lastName}, ${groupInfo[k].oldMemberSettings.firstName}`;
                                 const username = `${groupInfo[k].oldMemberSettings.userName}`;
@@ -748,7 +747,7 @@ function enqueueTask(res = {}, accountAndTaskInfo = {}, queue = {}) {
             indicatorID: res[recordID]?.indicatorID || 0,
             positionTitle: res[recordID]?.positionTitle || 0,
             locallyManaged: res[recordID]?.oldMemberSettings?.locallyManaged,
-            regionallyManaged: res[recordID]?.oldMemberSettings?.regionallyManaged,
+            regionallyManaged: !res[recordID]?.oldMemberSettings?.locallyManaged,
             newAccountExistsInGroup: res[recordID]?.newAccountExistsInGroup,
             newAccountExistsForPosition: res[recordID]?.newAccountExistsForPosition
         }

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -307,7 +307,7 @@ function populateMembers(groupID, members) {
     let memberCt = -1;
     let adminCt = (members.length - 1);
     for(let i in members) {
-        if(members[i].active == 1 && members[i].backupID == "") {
+        if(members[i].active == 1) {
             memberCt++;
         }
     }
@@ -315,7 +315,7 @@ function populateMembers(groupID, members) {
     let countTxt = (memberCt > 0) ? (' + ' + memberCt + ' others') : '';
     let countAdminTxt = (adminCt > 0) ? (' + ' + adminCt + ' others') : '';
     for(let i in members) {
-        if (members[i].active == 1 && members[i].backupID == "" && groupID != 1) {
+        if (members[i].active == 1 && groupID != 1) {
             if (j == 0) {
                 $('#members' + groupID).append('<div class="groupUserFirst">' + toTitleCase(members[i].Fname) + ' ' + toTitleCase(members[i].Lname) + countTxt + '</div>');
             }
@@ -505,10 +505,9 @@ function getGroupList() {
                     function openGroup(groupID, parentGroupID, groupName) {
                         $.ajax({
                             type: 'GET',
-                            url: '../api/group/' + groupID + '/membersWBackups',
-                            success: function(response) {
-                                if (response.status.code == 2) {
-                                    let res = response.data;
+                            url: '../api/group/' + groupID + '/members',
+                            success: function(res) {
+                                if (Array.isArray(res)) {
                                     dialog.clear();
                                     dialog.setTitle("Edit Group");
                                     let button_deleteGroup = '<div><button id="deleteGroup_' + groupID + '" class="usa-button usa-button--secondary leaf-btn-small leaf-marginTop-1rem">Delete Group</button></div>';
@@ -517,16 +516,15 @@ function getGroupList() {
                                         '<a class="leaf-group-link" href="<!--{$orgchartPath}-->/?a=view_group&groupID=' + groupID + '" title="groupID: ' + groupID + '" target="_blank"><h2 role="heading" tabindex="-1">' + groupName + '</h2></a><br /><h3 role="heading" tabindex="-1" class="leaf-marginTop-1rem">Add Employee</h3><div id="employeeSelector"></div><br/><br/><hr/><div id="employees"></div>');
 
                                     $('#employees').html('<div id="employee_table" style="display: table-header-group"></div><br /><div id="showInactive" class="fas fa-angle-right" style="cursor: pointer;"></div><div id="inactive_table" style="display: none"></div>');
-                                    let employee_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Local</th><th>Nexus</th><th>Actions</th></tr></thead><tbody>';
-                                    let inactive_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Local</th><th>Nexus</th><th>Actions</th></tr></thead><tbody>';
+                                    let employee_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th title="Inherited from Nexus">Inherited</th><th>Actions</th></tr></thead><tbody>';
+                                    let inactive_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Actions</th></tr></thead><tbody>';
                                     let counter = 0;
                                     for(let i in res) {
                                         if (res[i].backupID == '') {
                                             let employeeName = `<td class="leaf-user-link" title="${res[i].empUID} - ${res[i].userName}" style="font-size: 1em; font-weight: 700;"><a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${res[i].empUID}" target="_blank">${toTitleCase(res[i].Lname)}, ${toTitleCase(res[i].Fname)}</a></td>`;
                                             let employeeUserName = `<td  class="leaf-user-link" title="${res[i].empUID} - ${res[i].userName}" style="font-size: 1em; font-weight: 600;"><a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${res[i].empUID}" target="_blank">${res[i].userName}</a></td>`;
                                             let backups = `<td style="font-size: 0.8em">`;
-                                            let isLocal = `<td style="font-size: 0.8em;">${res[i].locallyManaged > 0 ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
-                                            let isRegional = `<td style="font-size: 0.8em;">${res[i].regionallyManaged ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
+                                            let isInherited = `<td style="font-size: 0.8em;">${res[i].locallyManaged == 0 ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
                                             let removeButton = `<td style="font-size: 0.8em; text-align: center;"><button id="removeMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Remove this user from this group">Remove</button>`;
                                             let addToNexusButton = `<button id="addNexusMember_${counter}" class="usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; margin-left: 2px !important; min-width: 4rem;" title="Add this user to Nexus group">Add to Nexus</button>`;
 
@@ -541,21 +539,13 @@ function getGroupList() {
 
                                             if (res[i].active === 1) {
                                                 let actions = `${removeButton}`;
-                                                if (res[i].regionallyManaged === false) {
-                                                    actions += `${addToNexusButton}`;
-                                                }
                                                 actions += '</td>';
-                                                employee_table += `<tr class="id-${res[i].empUID}">${employeeName}${employeeUserName}${backups}${isLocal}${isRegional}${actions}</tr>`;
+                                                employee_table += `<tr class="id-${res[i].empUID}">${employeeName}${employeeUserName}${backups}${isInherited}${actions}</tr>`;
                                             } else {
-                                                let pruneMemberButton = '';
-                                                if (res[i].regionallyManaged === false) {
-                                                    pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="pruneMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Prune this user from this group">Prune</button>`;
-                                                } else {
-                                                    pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="reActivateMember_${counter}" class="usa-button usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Reactivate this user for this group">Reactivate</button>`;
-                                                }
+                                                let pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="reActivateMember_${counter}" class="usa-button usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Reactivate this user for this group">Reactivate</button>`;
                                                 let actions = `${pruneMemberButton}`;
                                                 actions += '</td>';
-                                                inactive_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${isRegional}${actions}</tr>`;
+                                                inactive_table += `<tr>${employeeName}${employeeUserName}${backups}${actions}</tr>`;
                                             }
                                             counter++;
                                         }
@@ -741,9 +731,8 @@ function getGroupList() {
 
                                                             let backups = row.insertCell(2);
                                                             let isLocal = row.insertCell(3);
-                                                            let isRegional = row.insertCell(4);
 
-                                                            let removeButton = row.insertCell(5);
+                                                            let removeButton = row.insertCell(4);
                                                             removeButton.style.cssText = "font-size: 0.8em; text-align: center;";
 
                                                             employeeName.innerHTML = `+ <a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${selectedUser.empUID}" target="_blank">${toTitleCase(selectedUser.lastName)}, ${toTitleCase(selectedUser.firstName)}</a>`;
@@ -808,7 +797,7 @@ function getGroupList() {
                                         dialog.show();
                                     }, 0);
                                 } else {
-                                    displayDialogOk(response.status['message']);
+                                    displayDialogOk(res);
                                 }
                             },
                             cache: false

--- a/LEAF_Request_Portal/admin/templates/mod_groups.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_groups.tpl
@@ -599,13 +599,8 @@ function getGroupList() {
                                                 });
 
                                                 $('#reActivateMember_' + counter).on('click', function () {
-                                                    dialog_confirm.setContent('Are you sure you want to Reactivate this member?');
-                                                    dialog_confirm.setSaveHandler(function () {
-                                                        reactivateMember(groupID, res[i].userName);
-                                                        dialog_confirm.hide();
-                                                        dialog.hide();
-                                                    });
-                                                    dialog_confirm.show();
+                                                    reactivateMember(groupID, res[i].userName);
+                                                    dialog.hide();
                                                 });
                                             }
                                             counter++;

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -314,13 +314,8 @@ function initiateModal(serviceID = 0, serviceName = '') {
                                 dialog_confirm.show();
                             });
                             $('#reactivateMember_' + counter).on('click', function () {
-                                dialog_confirm.setContent('Are you sure you want to reactivate this member?');
-                                dialog_confirm.setSaveHandler(function () {
-                                    reactivateMember(serviceID, res[i].userName);
-                                    dialog_confirm.hide();
-                                    dialog.hide();
-                                });
-                                dialog_confirm.show();
+                                reactivateMember(serviceID, res[i].userName);
+                                dialog.hide();
                             });
                         }
                         counter++;

--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -153,7 +153,7 @@ function removeUser(groupID = -1, userID = '') {
     } else {
         $.ajax({
             async: false,
-            type: 'POST',
+            type: 'DELETE',
             url: "../api/service/" + groupID + "/members/_" + userID,
             data: {'CSRFToken': '<!--{$CSRFToken}-->'},
             fail: function(err) {
@@ -238,8 +238,8 @@ function initiateModal(serviceID = 0, serviceName = '') {
                     '<a class="leaf-group-link" href="<!--{$orgchartPath}-->/?a=view_group&groupID=' + serviceID + '" title="groupID: ' + serviceID + '" target="_blank"><h2 role="heading" tabindex="-1">' + serviceName + '</h2></a><h3 role="heading" tabindex="-1" class="leaf-marginTop-1rem">Add Employee</h3><div id="employeeSelector"></div></br><div id="employees"></div>');
 
                 $('#employees').html('<div id="employee_table" style="display: table-header-group"></div><br /><div id="showInactive" class="fas fa-angle-right" style="cursor: pointer;"></div><div id="inactive_table" style="display: none"></div>');
-                let employee_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Local</th><th>Actions</th></tr></thead><tbody>';
-                let inactive_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Local</th><th>Actions</th></tr></thead><tbody>';
+                let employee_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th title="Inherited from Nexus">Inherited</th><th>Actions</th></tr></thead><tbody>';
+                let inactive_table = '<br/><table class="table-bordered"><thead><tr><th>Name</th><th>Username</th><th>Backups</th><th>Actions</th></tr></thead><tbody>';
 
                 let counter = 0;
                 for(let i in res) {
@@ -247,8 +247,7 @@ function initiateModal(serviceID = 0, serviceName = '') {
                         let employeeName = `<td class="leaf-user-link" title="${res[i].empUID} - ${res[i].userName}" style="font-size: 1em; font-weight: 700;"><a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${res[i].empUID}" target="_blank">${toTitleCase(res[i].Lname)}, ${toTitleCase(res[i].Fname)}</a></td>`;
                         let employeeUserName = `<td  class="leaf-user-link" title="${res[i].empUID} - ${res[i].userName}" style="font-size: 1em; font-weight: 600;"><a href="<!--{$orgchartPath}-->/?a=view_employee&empUID=${res[i].empUID}" target="_blank">${res[i].userName}</a></td>`;
                         let backups = `<td style="font-size: 0.8em">`;
-                        let isLocal = `<td style="font-size: 0.8em;">${res[i].locallyManaged > 0 ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
-                        let isRegional = `<td style="font-size: 0.8em;">${res[i].regionallyManaged ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
+                        let isInherited = `<td style="font-size: 0.8em;">${res[i].locallyManaged == 0 ? '<span style="color: green; font-size: 1.2rem; margin: 1rem;">&#10004;</span>' : ''}</td>`;
                         let removeButton = `<td style="font-size: 0.8em; text-align: center;"><button id="removeMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Remove this user from this group">Remove</button>`;
 
                         // Check for Backups
@@ -264,19 +263,13 @@ function initiateModal(serviceID = 0, serviceName = '') {
                             let actions = `${removeButton}`;
 
                             actions += '</td>';
-                            employee_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${actions}</tr>`;
+                            employee_table += `<tr>${employeeName}${employeeUserName}${backups}${isInherited}${actions}</tr>`;
                         } else {
-                            let pruneMemberButton = '';
-
-                            if (res[i].locallyManaged == 1) {
-                                pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="pruneMember_${counter}" class="usa-button usa-button--secondary leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Prune this user from this group">Prune</button>`;
-                            } else {
-                                pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="reactivateMember_${counter}" class="usa-button usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Reactivate this user for this group">Reactivate</button>`;
-                            }
+                            let pruneMemberButton = `<td style="font-size: 0.8em; text-align: center;"><button id="reactivateMember_${counter}" class="usa-button usa-button leaf-btn-small leaf-font0-8rem" style="font-size: 0.8em; display: inline-block; float: left; margin: auto; min-width: 4rem;" title="Reactivate this user for this group">Reactivate</button>`;
 
                             let actions = `${pruneMemberButton}`;
                             actions += '</td>';
-                            inactive_table += `<tr>${employeeName}${employeeUserName}${backups}${isLocal}${actions}</tr>`;
+                            inactive_table += `<tr>${employeeName}${employeeUserName}${backups}${actions}</tr>`;
                         }
                         counter++;
                     }
@@ -423,7 +416,7 @@ function initiateWidget(serviceID = 0, serviceName = '') {
 }
 
 /**
- * Get list of present services in portal.
+ * Get list of services and their members
  */
 function getGroupList() {
 	$.when(
@@ -434,7 +427,7 @@ function getGroupList() {
 	    }),
         $.ajax({
             type: 'GET',
-            url: '../api/service',
+            url: '../api/service/members',
             cache: false
         })
      )

--- a/LEAF_Request_Portal/api/controllers/GroupController.php
+++ b/LEAF_Request_Portal/api/controllers/GroupController.php
@@ -48,6 +48,7 @@ class GroupController extends RESTfulResponse
             return $group->getGroupsAndMembers(true);
         });
 
+        // Deprecated, see group/[digit]/members
         $this->index['GET']->register('group/[digit]/membersWBackups', function ($args) use ($group) {
             $members = $group->getMembers($args[0], false, true);
             return $members;
@@ -55,16 +56,11 @@ class GroupController extends RESTfulResponse
 
         $this->index['GET']->register('group/[digit]/members', function ($args) use ($group) {
             $members = $group->getMembers($args[0]);
-            $users = array();
 
-            foreach ($members['data'] as $key => $value) {
-                if ($members['data'][$key]['backupID'] == '') {
-                    $members['data'][$key]['backupID'] = null;
-                }
-            }
             return $members['data'];
         });
 
+        // Deprecated, see group/[digit]/members
         $this->index['GET']->register('group/[digit]/list_members', function ($args) use ($group) {
             return $group->getMembers($args[0]);
         });
@@ -100,6 +96,7 @@ class GroupController extends RESTfulResponse
                 return $group->reActivateMember($args[1], $args[0]);
             });
 
+            // Deprecated. Likely no-longer needed.
             $this->index['POST']->register('group/[digit]/members/[text]/prune', function ($args) use ($group) {
                 return $group->removeMember($args[1], $args[0]);
             });

--- a/LEAF_Request_Portal/api/controllers/ServiceController.php
+++ b/LEAF_Request_Portal/api/controllers/ServiceController.php
@@ -39,11 +39,15 @@ class ServiceController extends RESTfulResponse
         });
 
         $this->index['GET']->register('service', function ($args) use ($db, $login, $service) {
-            return $service->getGroupsAndMembers();
+            return $service->getGroups();
         });
 
         $this->index['GET']->register('service/quadrads', function ($args) use ($db, $login, $service) {
             return $service->getQuadrads();
+        });
+
+        $this->index['GET']->register('service/members', function ($args) use ($db, $login, $service) {
+            return $service->getGroupsAndMembers();
         });
 
         $this->index['GET']->register('service/[digit]/members', function ($args) use ($db, $login, $service) {
@@ -72,6 +76,7 @@ class ServiceController extends RESTfulResponse
                     return $service->addMember($args[0], $_POST['userID']);
                 });
 
+                // Deprecated. See: DELETE service/[digit]/members/[text]
                 $this->index['POST']->register('service/[digit]/members/[text]', function ($args) use ($service) {
                     return $service->deactivateChief($args[0], $args[1]);
                 });
@@ -81,6 +86,7 @@ class ServiceController extends RESTfulResponse
                     return $service->reactivateChief($args[1], $args[0]);
                 });
 
+                // Deprecated. Likely no-longer needed.
                 $this->index['POST']->register('service/[digit]/members/[text]/prune', function ($args) use ($service) {
                     return $service->pruneChief($args[0], $args[1]);
                 });
@@ -109,7 +115,7 @@ class ServiceController extends RESTfulResponse
                 });
 
                 $this->index['DELETE']->register('service/[digit]/members/[text]', function ($args) use ($service) {
-                    return $service->removeMember($args[0], $args[1]);
+                    return $service->deactivateChief($args[0], $args[1]);
                 });
 
                 return $this->index['DELETE']->runControl($act['key'], $act['args']);


### PR DESCRIPTION
This simplifies Group/Service Chief management in Request Portals by eliminating the "prune" step, and resolves issues where "users can't be deleted from groups". Related API endpoints have also been simplified to minimize database queries and to align with intended behavior based on REST semantics.

In the User Access Group and Service Chiefs sections, the headers "Local" and "Nexus" have been removed. "Inherited" has been added, which represents whether the user was inherited from the Nexus.

The search in User Access Groups has also been updated to find backups.

### Impact
- Changes are primarily limited to the Admin Panel: User Access Groups and Service Chiefs
- Other dependencies include New Account Updater and print_form.tpl (it retrieves a list of services)

### Testing Focus Areas
- Preconditions:
  1. Nexus contains Group A containing User A
  2. Nexus contains Service B containing User B
  3. Sync Services
- [ ] Changes made within the Request Portal's "User Access Groups" persist through Sync Services
  1. Remove User A
  2. Sync Services
  3. User A remains inactive
  4. Reactivate User A (Open Group A and "Show Inactive Users")
  5. Add User C
  6. Sync Services
  7. User C remains active
  8. Remove User C
  9. There should not be a button to reactivate User C
- [ ] Changes made within the Request Portal's "Service Chiefs" persist through Sync Services (similar pattern as groups)
- [ ] New Account Updater works normally