### PR TITLE
LEAF 4248 update availability for variable used for uploads

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -76,7 +76,7 @@ switch ($action) {
                 $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
                 $t_form->assign('form', $indicator);
                 $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
-                $t_form->assign('abs_portal_filepath', ABSOLUTE_PORT_PATH.'/');
+                $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
                 $t_form->assign('orgchartImportTag', $settings['orgchartImportTags'][0]);
                 $t_form->assign('subindicatorsTemplate', customTemplate('subindicators.tpl'));
                 $t_form->assign('max_filesize', ini_get('upload_max_filesize'));
@@ -109,7 +109,7 @@ switch ($action) {
                 $indicator = $form->getIndicator($indicatorID, $series, $recordID);
                 $t_form->assign('indicator', $indicator[$indicatorID]);
                 $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
-                $t_form->assign('abs_portal_filepath', ABSOLUTE_PORT_PATH.'/');
+                $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
                 $t_form->display('print_subindicators_ajax.tpl');
             }
         }
@@ -400,7 +400,7 @@ switch ($action) {
             $t_form->assign('categoryText', XSSHelpers::sanitizeHTML($categoryText));
             $t_form->assign('deleted', (int)$recordInfo['deleted']);
             $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
-            $t_form->assign('abs_portal_filepath', ABSOLUTE_PORT_PATH.'/');
+            $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
             $t_form->assign('is_admin', $login->checkGroup(1));
 
             switch ($action) {

--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -76,6 +76,7 @@ switch ($action) {
                 $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
                 $t_form->assign('form', $indicator);
                 $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
+                $t_form->assign('abs_portal_filepath', ABSOLUTE_PORT_PATH.'/');
                 $t_form->assign('orgchartImportTag', $settings['orgchartImportTags'][0]);
                 $t_form->assign('subindicatorsTemplate', customTemplate('subindicators.tpl'));
                 $t_form->assign('max_filesize', ini_get('upload_max_filesize'));
@@ -108,6 +109,7 @@ switch ($action) {
                 $indicator = $form->getIndicator($indicatorID, $series, $recordID);
                 $t_form->assign('indicator', $indicator[$indicatorID]);
                 $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
+                $t_form->assign('abs_portal_filepath', ABSOLUTE_PORT_PATH.'/');
                 $t_form->display('print_subindicators_ajax.tpl');
             }
         }

--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -398,7 +398,7 @@ switch ($action) {
             $t_form->assign('categoryText', XSSHelpers::sanitizeHTML($categoryText));
             $t_form->assign('deleted', (int)$recordInfo['deleted']);
             $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
-            $t_form->assign('abs_portal_path', ABSOLUTE_PORT_PATH);
+            $t_form->assign('abs_portal_filepath', ABSOLUTE_PORT_PATH.'/');
             $t_form->assign('is_admin', $login->checkGroup(1));
 
             switch ($action) {

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -134,7 +134,7 @@
             <!--{if $indicator.value[0] != ''}-->
             <!--{assign var='idx' value=0}-->
             <!--{foreach from=$indicator.value item=file}-->
-            <a href="<!--{$abs_portal_path}-->/file.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" target="_blank" class="printResponse">
+            <a href="<!--{$abs_portal_filepath}-->file.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" target="_blank" class="printResponse">
                 <img src="dynicons/?img=mail-attachment.svg&amp;w=24" alt="" /><!--{$file}--></a><br />
             <!--{assign var='idx' value=$idx+1}-->
             <!--{/foreach}-->
@@ -151,9 +151,9 @@
             <!--{foreach from=$indicator.value item=file}-->
                 <!--{if $indicator.value != '[protected data]'}-->
                 <img alt="image upload: <!--{$file}-->"
-                    src="<!--{$abs_portal_path}-->/image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->"
+                    src="<!--{$abs_portal_filepath}-->image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->"
                     style="max-width: 200px"
-                    onclick="window.open('<!--{$abs_portal_path}-->/image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
+                    onclick="window.open('<!--{$abs_portal_filepath}-->image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
                 <!--{assign var='idx' value=$idx+1}-->
                 <!--{else}-->
                 [protected data]

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -134,7 +134,7 @@
             <!--{if $indicator.value[0] != ''}-->
             <!--{assign var='idx' value=0}-->
             <!--{foreach from=$indicator.value item=file}-->
-            <a href="<!--{$abs_portal_filepath}-->file.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" target="_blank" class="printResponse">
+            <a href="<!--{$portal_url}-->file.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->" target="_blank" class="printResponse">
                 <img src="dynicons/?img=mail-attachment.svg&amp;w=24" alt="" /><!--{$file}--></a><br />
             <!--{assign var='idx' value=$idx+1}-->
             <!--{/foreach}-->
@@ -151,9 +151,9 @@
             <!--{foreach from=$indicator.value item=file}-->
                 <!--{if $indicator.value != '[protected data]'}-->
                 <img alt="image upload: <!--{$file}-->"
-                    src="<!--{$abs_portal_filepath}-->image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->"
+                    src="<!--{$portal_url}-->image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->"
                     style="max-width: 200px"
-                    onclick="window.open('<!--{$abs_portal_filepath}-->image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
+                    onclick="window.open('<!--{$portal_url}-->image.php?form=<!--{$recordID}-->&amp;id=<!--{$indicator.indicatorID}-->&amp;series=<!--{$indicator.series}-->&amp;file=<!--{$idx}-->', 'newName', 'width=550', 'height=550'); return false;" />
                 <!--{assign var='idx' value=$idx+1}-->
                 <!--{else}-->
                 [protected data]

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -725,7 +725,7 @@
                             formData.append('series', series);
                             $.ajax({
                                 type: 'POST',
-                                url: `<!--{$abs_portal_filepath}-->api/form/${recordID}`,
+                                url: `<!--{$portal_url}-->api/form/${recordID}`,
                                 data: formData,
                                 success: (res) => {
                                     loaderEl.style.display = 'none';
@@ -773,7 +773,7 @@
                         <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" 
                             style="background-color:<!--{if $counter % 2 == 1}-->#e4f2ff<!--{else}-->#d7e5ff<!--{/if}-->; padding: 4px; display: flex; align-items: center" >
                             <img src="dynicons/?img=mail-attachment.svg&amp;w=16" alt="" /> 
-                            <a href="<!--{$abs_portal_filepath}-->file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
+                            <a href="<!--{$portal_url}-->file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
                             <span style="display: inline-block; margin-left: auto; padding: 4px">
                                 <button type="button" class="link"
                                     title="delete file <!--{$file|sanitize}-->"
@@ -789,7 +789,7 @@
                                 dialog_confirm.setSaveHandler(function() {
                                     $.ajax({
                                         type: 'POST',
-                                        url: "<!--{$abs_portal_filepath}-->ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
+                                        url: "<!--{$portal_url}-->ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
                                         data: {
                                             recordID: <!--{$recordID|strip_tags}-->,
                                             indicatorID: <!--{$indicator.indicatorID|strip_tags}-->,

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -725,7 +725,7 @@
                             formData.append('series', series);
                             $.ajax({
                                 type: 'POST',
-                                url: `./api/form/${recordID}`,
+                                url: `<!--{$abs_portal_filepath}-->api/form/${recordID}`,
                                 data: formData,
                                 success: (res) => {
                                     loaderEl.style.display = 'none';
@@ -773,7 +773,7 @@
                         <div id="file_<!--{$recordID|strip_tags}-->_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->_<!--{$counter}-->" 
                             style="background-color:<!--{if $counter % 2 == 1}-->#e4f2ff<!--{else}-->#d7e5ff<!--{/if}-->; padding: 4px; display: flex; align-items: center" >
                             <img src="dynicons/?img=mail-attachment.svg&amp;w=16" alt="" /> 
-                            <a href="file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
+                            <a href="<!--{$abs_portal_filepath}-->file.php?form=<!--{$recordID|strip_tags}-->&amp;id=<!--{$indicator.indicatorID|strip_tags}-->&amp;series=<!--{$indicator.series|strip_tags}-->&amp;file=<!--{$counter}-->" target="_blank"><!--{$file|sanitize}--></a>
                             <span style="display: inline-block; margin-left: auto; padding: 4px">
                                 <button type="button" class="link"
                                     title="delete file <!--{$file|sanitize}-->"
@@ -789,7 +789,7 @@
                                 dialog_confirm.setSaveHandler(function() {
                                     $.ajax({
                                         type: 'POST',
-                                        url: "ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
+                                        url: "<!--{$abs_portal_filepath}-->ajaxIndex.php?a=deleteattachment&recordID=<!--{$recordID|strip_tags}-->&indicatorID=<!--{$indicator.indicatorID|strip_tags}-->&series=<!--{$indicator.series|strip_tags}-->",
                                         data: {
                                             recordID: <!--{$recordID|strip_tags}-->,
                                             indicatorID: <!--{$indicator.indicatorID|strip_tags}-->,


### PR DESCRIPTION
Updated:
Tentative solution to resolve an uncovered issue that can cause cross site upload format questions updated through Combined Inbox Take Action form fields to either fail, or potentially upload to the incorrect ERM folder.


Also resolves an issue that results in a temporary incorrect link in the indicator print display loaded into form questions after an edit is made through a print view area.  The variable name was also updated to help avoid confusion.


Testing / Impact

Site specific and Cross site upload format questions (fileupload, image) should behave as expected on site specific pages and in the combined inbox view. 