### PR TITLE
RC 69c1 fix inbox error, handle no cards case better

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -1264,7 +1264,6 @@ button.buttonNorm {
 button.depInbox {
   cursor: pointer;
   text-align: left;
-  white-space: nowrap;
   width:100%;
   padding: 0.5rem;
   border:0;

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.css
@@ -1,3 +1,6 @@
+#body {
+  min-height: 100vh;
+}
 .col-header {
 font-weight: 300;
     font-size: 100%;

--- a/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
+++ b/LEAF_Request_Portal/js/combined_inbox_editor/src/combined_inbox_editor.vue.js
@@ -165,22 +165,25 @@ const CombinedInboxEditor = Vue.createApp({
                     });
 
                     const totalURLs = Object.keys(portalURLs).length;
-                    let count = 0;
-                    for (let key in portalURLs) {
-                        this.getPortalForms(key)
-                        .then(() => {
-                            count += 1;
-                            if (count === totalURLs) {
-                                this.loading = false;
-
-                                this.sites.forEach((site) => {
-                                    this.setupChoices(site);
-                                });
-                            }
-                        })
-                        .catch(err => {
-                            console.log(err);
-                        });
+                    if (totalURLs === 0) {
+                        this.loading = false;
+                    } else {
+                        let count = 0;
+                        for (let key in portalURLs) {
+                            this.getPortalForms(key)
+                            .then(() => {
+                                count += 1;
+                                if (count === totalURLs) {
+                                    this.loading = false;
+                                    this.sites.forEach((site) => {
+                                        this.setupChoices(site);
+                                    });
+                                }
+                            })
+                            .catch(err => {
+                                console.log(err);
+                            });
+                        }
                     }
                 },
                 error: (err) => {
@@ -387,6 +390,7 @@ const CombinedInboxEditor = Vue.createApp({
     <h1 style="margin: 3rem;">Combined Inbox Editor (beta)</h1>
 
     <h2 v-if="loading">Loading Site Data ...</h2>
+    <div v-else-if="sites.length === 0" style="margin-left:48px;">Cards can be created in the <a href="../report.php?a=LEAF_sitemaps_template">Sitemap Editor</a></div>
     <div v-else id="editor-container">
         <div id="side-bar" class="inbox" style="display: block;">
             Edit Columns 

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -450,7 +450,7 @@
         let headerColumns = "";
         if (customColumns === false) {
             const baseColumns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
-            const formColumns = site.formColumns[categoryID] || null;
+            const formColumns = site?.formColumns?.[categoryID] || null;
             if (formColumns !== null) {
                 headerColumns = formColumns;
             } else {

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -452,9 +452,9 @@
             const baseColumns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
             const formColumns = site?.formColumns?.[categoryID] || null;
             if (formColumns !== null) {
-                headerColumns = formColumns;
+                headerColumns = 'UID,' + formColumns;
             } else {
-                headerColumns = site.columns == null || site.columns == 'UID' ? 'UID,service,title,status' : site.columns;
+                headerColumns = baseColumns;
             }
             headerColumns = headerColumns.split(",")
         }


### PR DESCRIPTION
Fixes a potential breaking error by chaining formColumns property, which can be missing.

More effectively handles the case of a portal not yet having any sitemaps cards:
-'loading...' replaced with a message and link to the Sitemap Editor, where cards are created.
-Adjusts some styling for the default display that is used in the inbox when the site has no sitemap cards