### PR TITLE
LEAF 4259 - set browsertype span to 11px, rm table font change

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -592,9 +592,6 @@ table.table {
   margin: 2px;
   color: black;
 }
-#searchContainer table {
-  font-size: 14px;
-}
 
 .table > thead {
   background-color: #e0e0e0;
@@ -1208,7 +1205,7 @@ span.browsetitle a {
 }
 
 span.browsetypes {
-  font-size: 80%;
+  font-size: 11px;
   color: #707070;
 }
 


### PR DESCRIPTION
Setting against RC for now for easier review.

Removes a change made on 69c1 that increased the search container font by 2px.
Explicitly sets browsetype span to 11px meet font size scan threshold.