### PR TITLE
LEAF 4261 change submenu location

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -237,6 +237,7 @@ span#headerMenu {
   font-size: 12px;
 }
 #headerMenuNav > ul {
+  position: relative;
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -245,7 +246,6 @@ span#headerMenu {
   gap: 0.25rem 0.75rem;
 }
 #headerMenu > nav > ul > li {
-  position: relative;
   box-sizing: border-box;
   height: 24px;
   margin: 0;
@@ -253,8 +253,6 @@ span#headerMenu {
 #headerMenu .controlled-element {
   position: absolute;
   top: calc(100% - 2px);
-  left: 50%;
-  transform: translate(-50%,0);
 }
 #headerMenu .controlled-element.is-shown {
   display: block;


### PR DESCRIPTION
Re-adjusts submenu location.
An alternative approach would be to lower the observer threshold (eg 0.75), but this seemed the simplest and cleanest looking one.

Testing

Non-admin side nav.  Submenus are positioned back at the end of the parent ul.
Distance between the default nav buttons 'links' and  'help' and the corresponding submenus is suitable for hover behavior.
Observer on both buttons should trigger in both admin and non-admin modes.
Help submenu should display the name and email of the portal's primary admin if the role has been set.
'Primary admin has not been set' should display if there is no primary admin.
