### PR TITLE
Leaf 4260 - service headings now show correctly

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_svcChief.tpl
@@ -429,10 +429,12 @@ function getGroupList() {
 	.done(function(res1, res2) {
 		let quadrads = res1[0];
 		let services = res2[0];
-	    for(let i in quadrads) {
-	    	$('#groupList').append('<h2>'+ toTitleCase(quadrads[i].name) +'</h2><div class="leaf-displayFlexRow" id="group_'+ quadrads[i].groupID +'"></div>');
-	    }
-	    for(let i in services) {
+
+	    for (let i in quadrads) {
+            $('#groupList').append('<h2>'+ toTitleCase(quadrads[i].name) +'</h2><div class="leaf-displayFlexRow" id="group_'+ quadrads[i].groupID +'"></div>');
+
+        }
+	    for (let i in services) {
             $('#group_' + services[i].groupID).append('<div tabindex="0" id="'+ services[i].serviceID +'" title="serviceID: '+ services[i].serviceID +'" class="groupBlockWhite">'
                     + '<h2 id="groupTitle'+ services[i].serviceID +'">'+ services[i].service +'</h2>'
                     + '<div id="members'+ services[i].serviceID +'"></div>'

--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -486,11 +486,15 @@ class Service
 
     public function getQuadrads()
     {
-        $res = $this->db->prepared_query('SELECT groupID, `service` AS `name` FROM services
-    								LEFT JOIN `groups` USING (groupID)
-    								WHERE groupID IS NOT NULL
-    								GROUP BY groupID
-    								ORDER BY name', array());
+        $vars = array();
+        $sql = 'SELECT `groupID`, `name`
+                FROM `services`
+                LEFT JOIN `groups` USING (`groupID`)
+                WHERE `groupID` IS NOT NULL
+                GROUP BY `groupID`
+                ORDER BY `name`';
+
+        $res = $this->db->prepared_query($sql, $vars);
 
         return $res;
     }

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -122,9 +122,7 @@ class System
                             if ($backups['status']['code'] == 2) {
                                 // check if this service is also an ELT
                                 // if so, update groups table
-                                $tagged = $tag->groupIsTagged($serviceID, Config::$orgchartImportTags[0]);
-
-                                if ($serviceID == $quadID && $tagged['status']['code'] == 2 && !empty($tagged['data'])) {
+                                if ($serviceID == $quadID) {
                                     $this->updateGroup($serviceID, $oc_db);
                                 } else {
                                     // make sure this is not in the groups table?
@@ -804,7 +802,7 @@ class System
     /**
      *
      * @return void
-     * 
+     *
      */
     private function cleanupSystemAdmin(): void
     {
@@ -905,6 +903,13 @@ class System
 
         $return_value = $this->db->pdo_delete_query($sql, $vars);
 
+        $sql = 'DELETE
+                FROM `groups`
+                WHERE `parentGroupID = -1';
+
+        $return_value = $this->db->pdo_delete_query($sql, $vars);
+
+
         return $return_value;
     }
 
@@ -931,7 +936,8 @@ class System
         $vars = array();
         $sql = 'DELETE
                 FROM `groups`
-                WHERE `groupID` > 1';
+                WHERE `groupID` > 1
+                AND parentGroupID <> -1';
 
         $return_value = $this->db->pdo_delete_query($sql, $vars);
 


### PR DESCRIPTION
Summary:
The headings on the services page were not always correct. The issue was pulling the service rather than the group name which was brought about by the ELT/Quadrad not being added to the groups table unless they were tagged in the ELT on the Nexus side. This change will add the ELT to the groups table no matter what. The query was changed back to using the group name.

Potential Impact:
This should just show the correct ELT name now. 

Testing:
Ensure there is an ELT in the Nexus that is not tagged for the portal
Complete a sync services
check that the ELT is the heading of a service