### PR TITLE
Remove the *_format property from api/form/query

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -762,13 +762,6 @@ var LeafFormGrid = function (containerID, options) {
                                            }"
                                            data-indicator-id="${
                                              headers[j].indicatorID
-                                           }"
-                                           data-format="${
-                                             currentData[i].s1[
-                                               "id" +
-                                                 headers[j].indicatorID +
-                                                 "_format"
-                                             ]
                                            }">
                                             ${data.data}</td>`;
             }
@@ -886,6 +879,7 @@ var LeafFormGrid = function (containerID, options) {
   }
 
   /**
+   * @deprecated See example.tpl for more efficient formGrid usage.
    * @memberOf LeafFormGrid
    */
   function loadData(recordIDs, callback) {
@@ -992,7 +986,14 @@ var LeafFormGrid = function (containerID, options) {
         'dynicons/?img=x-office-spreadsheet.svg&w=16" alt="" /> Export</button>'
     );
 
-    $("#" + prefixID + "getExcel").on("click", function () {
+    $("#" + prefixID + "getExcel").on("click", async function () {
+      // get indicator formats in case they need special handling (e.g. dates)
+      let iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format").then(res => res.json());
+      let indicatorFormats = {};
+      iFormatData.forEach(i => {
+        indicatorFormats[i.indicatorID] = i.format;
+      });
+
       if (currentRenderIndex != currentData.length) {
         renderBody(0, Infinity);
       }
@@ -1022,8 +1023,8 @@ var LeafFormGrid = function (containerID, options) {
 
           var trimmedText = val.innerText.trim();
           line[i] = trimmedText;
-          //prevent some values from being interpretted as dates by excel
-          const dataFormat = val.getAttribute("data-format");
+          //prevent some values from being interpreted as dates by excel
+          const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
           const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
           line[i] =
             dataFormat !== null &&

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2623,8 +2623,6 @@ class Form
 
 
                     $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID']] = isset($indicatorMasks[$item['indicatorID']]) && $indicatorMasks[$item['indicatorID']] == 1 ? '[protected data]' : $item['data'];
-                    $indFormat = explode("\n", $indicators[$item['indicatorID']]['format'])[0];
-                    $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID'] . '_format'] = $indFormat;
                     if (isset($item['dataOrgchart']))
                     {
                         $out[$item['recordID']]['s' . $item['series']]['id' . $item['indicatorID'] . '_orgchart'] = $item['dataOrgchart'];


### PR DESCRIPTION
This reduces overhead in user-created queries by removing an underutilized property, which improves load time and makes more efficient use of network resources.

Before:
```
[1]: "Hello"
[2]: "World"
[1_format]: "text"
[2_format]: "text"
```

After:
```
[1]: "Hello"
[2]: "World"
```

In _api/form/query_, the _*_format_ property is apparently only used to resolve a date handling issue in Excel exports. Since the majority of queries will never need the format, I took a different approach to resolve the issue by using _api/form/indicator/list_ only when the user requests an Excel export.


### Potential Impact
Is the _*_format_ property used anywhere else? If no, then there are no other dependencies and minimal impact

### Testing
- [ ] Existing date handling logic works in Excel exports
   - [ ] Text field containing 1/23/45 is not seen in Excel as the date Jan 23, 1945
   - [ ] Date field containing 1/23/45 is seen in Excel as the date Jan 23, 1945
