### PR TITLE
LEAF 4253 fix file name with spaces

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_form.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_form.tpl
@@ -1064,7 +1064,7 @@ function makeGrid(columns) {
                     for (let f = 0; f < fileManagerTextFiles.length; f++) {
                         const filename = XSSHelpers.stripAllTags(fileManagerTextFiles[f]);
                         const attrSelected = gridFile === filename ? 'selected' : '';
-                        options += `<option value=${filename} ${attrSelected}>${filename}</option>`
+                        options += `<option value="${filename}" ${attrSelected}>${filename}</option>`
                     }
                     $(gridBodyElement + ' > div:eq(' + i + ')').append(`
                         <div class="dropdown_file" style="margin-top: 0.5rem;">


### PR DESCRIPTION
Fixes an issue that causes the file name used to add grid cell dropdown options to be incorrect if the file name contains spaces.
