### PR TITLE
Leaf 4285 - Data dictionary UX

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Dictionary.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Dictionary.tpl
@@ -1,0 +1,65 @@
+<style>
+#content {
+    margin: 1rem;
+}
+</style>
+<script>
+async function getData() {
+
+    let indicators = await fetch('api/form/indicator/list').then(res => res.json());
+
+    // Initialize the Grid
+    let formGrid = new LeafFormGrid('grid'); // 'grid' maps to the associated HTML element ID
+
+    formGrid.enableToolbar();
+    formGrid.hideIndex();
+
+    // Required to initialize data for the grid
+    formGrid.setData(Object.keys(indicators).map(key => {
+        indicators[key].recordID = key; // formGrid expects there to be a recordID property that contains unique integers
+        return indicators[key];
+    }));
+    formGrid.setDataBlob(indicators);
+
+    // The column headers are configured here
+    formGrid.setHeaders([
+        {name: 'Field ID', indicatorID: 'indicatorID', editable: false, callback: function(data, blob) {
+            $('#'+data.cellContainerID).html(blob[data.recordID].indicatorID);
+        }},
+        {name: 'Form ID', indicatorID: 'categoryID', editable: false, callback: function(data, blob) {
+            $('#'+data.cellContainerID).html(blob[data.recordID].categoryID);
+        }},
+        {name: 'Form Name', indicatorID: 'categoryName', editable: false, callback: function(data, blob) {
+            $('#'+data.cellContainerID).html(blob[data.recordID].categoryName);
+        }},
+        {name: 'Format', indicatorID: 'format', editable: false, callback: function(data, blob) {
+            let rawFormat = blob[data.recordID].format;
+            let format = rawFormat.split("\n")[0];
+            $('#'+data.cellContainerID).html(format);
+        }},
+		{name: 'Short Label', indicatorID: 'label', editable: false, callback: function(data, blob) {
+            $('#'+data.cellContainerID).html(blob[data.recordID].description);
+        }},
+        {name: 'Name', indicatorID: 'name', editable: false, callback: function(data, blob) {
+            $('#'+data.cellContainerID).html(blob[data.recordID].name);
+        }},
+    ]);
+
+    // Load and populate the spreadsheet
+    formGrid.sort('indicatorID', 'asc');
+    formGrid.renderBody();
+}
+
+async function main() {
+    document.querySelector('title').innerText = 'Data Dictionary';
+    getData();
+
+}
+
+// Ensures the webpage has fully loaded before starting the program.
+document.addEventListener('DOMContentLoaded', main);
+</script>
+
+<h1>Data Dictionary</h1>
+<p>API endpoints: <a href="api/form/indicator/list" target="_blank">JSON</a> | <a href="api/form/indicator/list?format=csv" target="_blank">CSV</a> | <a href="api/form/indicator/list?format=htmltable&sort=indicatorID" target="_blank">HTML</a></p>
+<div id="grid"></div>

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -857,7 +857,7 @@ function showJSONendpoint() {
                            + '</select>'
                            + '<span id="formatStatus" style="background-color:green; padding:5px 5px; color:white; display:none;"></span>'
                            + '<br /><div id="exportPathContainer" contenteditable="true" style="border: 1px solid gray; padding: 4px; margin-top: 4px; width: 95%; height: 100px; word-break: break-all;"><span id="exportPath">'+ jsonPath +'</span><span id="exportFormat"></span></div>'
-                           + '<a href="./api/form/indicator/list?format=htmltable&sort=indicatorID" target="_blank">Data Dictionary Reference</a>'
+                           + '<a href="report.php?a=LEAF_Data_Dictionary" target="_blank">Data Dictionary Reference</a>'
                            + '<br /><br />'
                            + '<fieldset>'
                            + '<legend>Options</legend>'


### PR DESCRIPTION
This makes the Data Dictionary view more user friendly.

This also serves as an example for how features that require a table view could leverage formGrid.js to inherit basic features with little effort (sticky headers, sorting, export, consistent UI).

### Impact
No dependencies

### Testing
- [ ] The link in Report Builder -> JSON -> Data Dictionary Reference navigates to the new page.