### PR TITLE
LEAF 4283 add cc to tracker history

### DIFF
--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -360,8 +360,15 @@ class Email
      */
     private function logEmailSent(int $recordID): void
     {
+        $recipients = $this->emailRecipient;
+        foreach($this->emailCC as $cc) {
+            $recipients.=", ".$cc;
+        };
+        foreach($this->emailBCC as $bcc) {
+            $recipients.=", ".$bcc;
+        };
         $email_tracker = new EmailTracker($this->portal_db);
-        $email_tracker->postEmailTracker($recordID, 'Recipient(s): ' . $this->emailRecipient, 'Subject: ' . $this->emailSubject);
+        $email_tracker->postEmailTracker($recordID, 'Recipient(s): ' . $recipients, 'Subject: ' . $this->emailSubject);
     }
 
     /**

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -364,9 +364,6 @@ class Email
         foreach($this->emailCC as $cc) {
             $recipients.=", ".$cc;
         };
-        foreach($this->emailBCC as $bcc) {
-            $recipients.=", ".$bcc;
-        };
         $email_tracker = new EmailTracker($this->portal_db);
         $email_tracker->postEmailTracker($recordID, 'Recipient(s): ' . $recipients, 'Subject: ' . $this->emailSubject);
     }


### PR DESCRIPTION
This update adds cc values to the emails logged by the email tracker.

Testing / Impact

Step or submit a request with an appropriate event.
eg notify next, where designated approver has a backup. 
Customized notify next email template with cc field.

Users (eg backups) as CC on emails should show as having been emailed in the request history.
local - Confirm smtp server recipients are those expected and show in history.
live - Confirm email received, that recipients are those expected and show in history.