### PR TITLE
LEAF 4274 file options natural sorting

### DIFF
--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -146,11 +146,22 @@ var LeafForm = function (containerID) {
       }
 
       let options = uniqueList.map(o => XSSHelpers.stripAllTags(o.trim()));
-
       if (!isLevel2 && options.length> 0 && dropdownInfo[iID].crosswalkHasHeader === true) {
         dropdownInfo[iID].headerName = options[0];
       }
-      return options.filter(o => o !== dropdownInfo[iID].headerName && o !== "").sort().reverse();
+      options = options.filter(o => o !== dropdownInfo[iID].headerName && o !== "");
+      options = options.sort(
+          (a, b) => a.localeCompare(
+            b,
+            undefined,
+            {
+              numeric: true,
+              sensitivity: 'base',
+            }
+          )
+      );
+      options = options.reverse();
+      return options;
     }
 
     function setSelectOptions(arrOptions = [], iID, formdata) {

--- a/LEAF_Request_Portal/js/gridInput.js
+++ b/LEAF_Request_Portal/js/gridInput.js
@@ -159,7 +159,16 @@ var gridInput = function (gridParameters, indicatorID, series, recordID) {
               let list = fileContent.split(/\n/).map(line => line.split(",")[0]) || [];
               list = list.map(o => XSSHelpers.stripAllTags(o.trim()));
               const firstRow = list[0] || '';
-              list = Array.from(new Set(list)).sort();
+              list = Array.from(new Set(list)).sort(
+                (a, b) => a.localeCompare(
+                  b,
+                  undefined,
+                  {
+                    numeric: true,
+                    sensitivity: 'base',
+                  }
+                )
+              );
               fileOptions[filename] = {
                 firstRow,
                 options: list


### PR DESCRIPTION
Updates a sort method used to create options for grid cells and chosen dropdowns so that options with numeric values have a more natural order.


Impact / Testing

Grid format questions, dropdown from file type.
Dropdown and Multiselect format questions using loading via ifthen.
Confirm these continue to behave as expected.
The only difference should be the order of selections for grids and chosen dropdowns when values include numeric entries.

