### PR TITLE
LEAF-4296 - Resolve issue when rendering previous search UI

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -969,7 +969,7 @@ var LeafFormSearch = function (containerID) {
                                 "</option>";
                         }
                         categories += "</select>";
-                        // quick and dirty fix to avoid a race condition related to custom
+                        // quick and dirty fix to avoid a race condition related to common
                         // implementations of formSearch. Since the new default UI will trigger
                         // the parent ajax call, we don't want to overwrite the existing widget.
                         // This can cause a minor UX issue where changing the search term from anything

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -976,10 +976,11 @@ var LeafFormSearch = function (containerID) {
                             $("#" + prefixID + "widgetMatch_" + widgetID).html(
                                 categories
                             );
-                            chosenOptions();
-                            if (callback != undefined) {
-                                callback();
-                            }
+                        }
+
+                        chosenOptions();
+                        if (callback != undefined) {
+                            callback();
                         }
                     },
                 });

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -971,7 +971,9 @@ var LeafFormSearch = function (containerID) {
                         categories += "</select>";
                         // quick and dirty fix to avoid a race condition related to custom
                         // implementations of formSearch. Since the new default UI will trigger
-                        // the parent ajax call, we don't want to overwrite the existing widget
+                        // the parent ajax call, we don't want to overwrite the existing widget.
+                        // This can cause a minor UX issue where changing the search term from anything
+                        // else to a "Current Status" would result in a missing dropdown of status options.
                         if($("#" + prefixID + "widgetMatch_" + widgetID).html() == "") {
                             $("#" + prefixID + "widgetMatch_" + widgetID).html(
                                 categories


### PR DESCRIPTION
This resolves an issue with formSearch (e.g. main page advanced search or report builder) where the previously selected Current Status appears to revert to the default search option. This can cause significant confusion when modifying reports, since people would expect their previous selection to stay the same.

Technically the issue is that a callback wasn't being executed. The call was mistakenly embedded in a solution for a race condition.

Steps to reproduce the issue:
1. Set two search terms. The first search term can be anything other than Current Status. The second search term must be Current Status IS [Any specific step in a workflow]
2. Save the search (by applying filters on the main page, or generating a report in the Report Builder)
3. Refresh the view multiple times. Sometimes the Current Status will switch to the default "Resolved" selection.

### Potential Impact
Dependencies on formSearch.js, which includes the main page search and Report Builder.


### Testing
- [ ] The issue can no-longer be reproduced