### PR TITLE
LEAF 4286 service chiefs area member sorting

### DIFF
--- a/LEAF_Request_Portal/sources/Service.php
+++ b/LEAF_Request_Portal/sources/Service.php
@@ -470,6 +470,8 @@ class Service
                 }
             }
         }
+        $col = array_column( $members, "lastName" );
+        array_multisort( $col, SORT_ASC, $members );
 
         return $members;
     }


### PR DESCRIPTION
Adds two lines that are in the group getMembers call to sort by last name to the service getMembers call as well.


Testing / Impact

Service Chiefs page.
Group members will be listed alphabetically by last name.
No other functionality should change.

