### PR TITLE
LEAF 4287 expand timezone selection and validation

### DIFF
--- a/LEAF_Nexus/admin/index.php
+++ b/LEAF_Nexus/admin/index.php
@@ -108,7 +108,16 @@ switch ($action) {
 
            $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
 
-           $t_form->assign('timeZones', DateTimeZone::listIdentifiers(DateTimeZone::ALL));
+            $tz_additional = array(
+                "America/Puerto_Rico",
+                "Pacific/Guam",
+                "Pacific/Saipan",
+                "Pacific/Pago_Pago",
+                "Asia/Manila",
+            );
+            $tzones = array_merge(DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, 'US'), $tz_additional);
+            sort($tzones);
+            $t_form->assign('timeZones', $tzones);
 
            //$settings = $db->query_kv('SELECT * FROM settings', 'setting', 'data');
            $t_form->assign('timeZone', $settings['timeZone']);

--- a/LEAF_Nexus/admin/index.php
+++ b/LEAF_Nexus/admin/index.php
@@ -108,7 +108,7 @@ switch ($action) {
 
            $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
 
-           $t_form->assign('timeZones', DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, 'US'));
+           $t_form->assign('timeZones', DateTimeZone::listIdentifiers(DateTimeZone::ALL));
 
            //$settings = $db->query_kv('SELECT * FROM settings', 'setting', 'data');
            $t_form->assign('timeZone', $settings['timeZone']);

--- a/LEAF_Nexus/sources/System.php
+++ b/LEAF_Nexus/sources/System.php
@@ -94,7 +94,7 @@ class System
             return 'Admin access required';
         }
 
-        if (array_search($_POST['timeZone'], \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US')) === false)
+        if (array_search($_POST['timeZone'], \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)) === false)
         {
             return 'Invalid timezone';
         }

--- a/LEAF_Nexus/sources/System.php
+++ b/LEAF_Nexus/sources/System.php
@@ -93,8 +93,15 @@ class System
         {
             return 'Admin access required';
         }
-
-        if (array_search($_POST['timeZone'], \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)) === false)
+        $tz_additional = array(
+            "America/Puerto_Rico",
+            "Pacific/Guam",
+            "Pacific/Saipan",
+            "Pacific/Pago_Pago",
+            "Asia/Manila",
+        );
+        $tzones = array_merge(\DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US'), $tz_additional);
+        if (array_search($_POST['timeZone'], $tzones) === false)
         {
             return 'Invalid timezone';
         }

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -458,7 +458,7 @@ switch ($action) {
         $main->assign('javascripts', array(APP_JS_PATH . '/LEAF/XSSHelpers.js',
                                            '../js/formQuery.js'));
 
-        $t_form->assign('timeZones', DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, 'US'));
+        $t_form->assign('timeZones', DateTimeZone::listIdentifiers(DateTimeZone::ALL));
 
         $t_form->assign('importTags', $settings['orgchartImportTags'][0]);
 //   		$main->assign('stylesheets', array('css/mod_groups.css'));

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -457,8 +457,16 @@ switch ($action) {
         $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
         $main->assign('javascripts', array(APP_JS_PATH . '/LEAF/XSSHelpers.js',
                                            '../js/formQuery.js'));
-
-        $t_form->assign('timeZones', DateTimeZone::listIdentifiers(DateTimeZone::ALL));
+        $tz_additional = array(
+            "America/Puerto_Rico",
+            "Pacific/Guam",
+            "Pacific/Saipan",
+            "Pacific/Pago_Pago",
+            "Asia/Manila",
+        );
+        $tzones = array_merge(DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, 'US'), $tz_additional);
+        sort($tzones);
+        $t_form->assign('timeZones', $tzones);
 
         $t_form->assign('importTags', $settings['orgchartImportTags'][0]);
 //   		$main->assign('stylesheets', array('css/mod_groups.css'));

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -518,7 +518,15 @@ class System
             return 'Admin access required';
         }
 
-        if (array_search($_POST['timeZone'], \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)) === false)
+        $tz_additional = array(
+            "America/Puerto_Rico",
+            "Pacific/Guam",
+            "Pacific/Saipan",
+            "Pacific/Pago_Pago",
+            "Asia/Manila",
+        );
+        $tzones = array_merge(\DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US'), $tz_additional);
+        if (array_search($_POST['timeZone'], $tzones) === false)
         {
             return 'Invalid timezone';
         }

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -518,7 +518,7 @@ class System
             return 'Admin access required';
         }
 
-        if (array_search($_POST['timeZone'], \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US')) === false)
+        if (array_search($_POST['timeZone'], \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)) === false)
         {
             return 'Invalid timezone';
         }


### PR DESCRIPTION
Adds the following time zones to the available selections in portal and nexus site settings.
  "America/Puerto_Rico",
  "Pacific/Guam",
  "Pacific/Saipan",
  "Pacific/Pago_Pago",
  "Asia/Manila",

Testing / Impact

Portal and / or Nexus admins should be able to select and save the new time zone selections.

portal -> admin -> Site Settings (time zone)

Nexus -> admin -> Setup Wizard -> Site Preferences (time zone)