### PR TITLE
LEAF 4298 fix callback error in view_position set supervisor

### DIFF
--- a/LEAF_Nexus/templates/view_position.tpl
+++ b/LEAF_Nexus/templates/view_position.tpl
@@ -334,10 +334,10 @@ function changeSupervisor() {
             data: {positionID: posSel.selection,
                       CSRFToken: '<!--{$CSRFToken}-->'},
             success: function(response) {
-                if (Number.isInteger(response)) {
-                    window.location.reload();
-                } else {
+                if (response?.errors?.[0] !== undefined) {
                     dialog.setContent(`<strong style="display:table;margin:0 auto;"><img src="dynicons/?img=dialog-error.svg&amp;w=32" style="vertical-align:middle;float:left;" alt="" />${response.errors[0]}</strong>`);
+                } else {
+                    window.location.reload();
                 }
             },
             cache: false


### PR DESCRIPTION
Fixes a TypeError on the Nexus view_position page that occurs after updating a supervisor.

Impact / Testing

A TypeError should not occur when a supervisor is updated.
Trying to set the supervisor as a non-admin should show an intended alternate message.
