### PR TITLE
Leaf 4271 - orphaned users and chiefs

### DIFF
--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -795,8 +795,68 @@ class System
         }
 
         $this->cleanupSystemAdmin();
+        $this->cleanupUsers();
 
         return 'Syncing has finished. You are set to go.';
+    }
+
+    private function cleanupUsers(): void
+    {
+        $groups = new Group($this->db, $this->login);
+        $services = new Service($this->db, $this->login);
+
+        // Get all users with a backupID
+        $backupList = $this->getAllBackups('users', 'groupID');
+
+        // loop through this list and check for a user with the same userID without a backupID
+        foreach($backupList as $backup) {
+            $user = $this->getUserNoBackup($backup['groupID'], $backup['backupID'], 'users', 'groupID');
+
+            if (empty($user)) {
+                $groups->removeMember($backup['userID'], $backup['groupID'], $backup['backupID']);
+            }
+        }
+
+        // Get all service chiefs with a backupID
+        $backupList = $this->getAllBackups('service_chiefs', 'serviceID');
+
+        // loop through this list and check for a user with the same userID without a backupID
+        foreach($backupList as $backup) {
+            $user = $this->getUserNoBackup($backup['serviceID'], $backup['backupID'], 'service_chiefs', 'serviceID');
+
+            if (empty($user)) {
+                $services->removeChief($backup['serviceID'], $backup['userID'], $backup['backupID']);
+            }
+        }
+
+        // Or is there an easier query to do this in one step.
+    }
+
+    private function getUserNoBackup(int $serviceGroup, string $backup, string $table, string $id): array
+    {
+        $vars = array(':userID' => $backup,
+                      ':serviceGroup' => $serviceGroup);
+        $sql = "SELECT `userID`, {$id}, `backupID`
+                FROM {$table}
+                WHERE `userID` = :userID
+                AND {$id} = :serviceGroup
+                AND `backupID` = ''";
+
+        $user = $this->db->prepared_query($sql, $vars);
+
+        return $user;
+    }
+
+    private function getAllBackups(string $table, string $id): array
+    {
+        $vars = array();
+        $sql = "SELECT `userID`, {$id}, `backupID`
+                FROM {$table}
+                WHERE `backupID` != ''";
+
+        $backupList = $this->db->prepared_query($sql, $vars);
+
+        return $backupList;
     }
 
     /**


### PR DESCRIPTION
Summary:

deletedUser

When deletedUser had a backup that didn't get deleted or deletedUser was a backup to someone else who got deleted they will still get email notifications but will not show up in the service chief list.

userName        backupID
User1                                    Is a regular member of the group
User1            User2                User1 is a backup to User2
User3            User1                User3 is a backup to User1

In this scenario User1 will show up as a regular user and User3 will show as a backup for this user
User2 will not show up at all and user1 will not show as a backup because user2 isn't showing up anywhere.
However, User2 will get any notifications that this group gets because they are still in the group in the db.

It's not known how to get to this state but if the db is already in this state the notifications will go out.


Potential Impact:
Adding this to the sync services could cause the sync services to take longer than it does now. 


Testing:

manually setup your local db with the scenario listed above.

run sync services and note that User1 and User2 are removed from the db