### PR TITLE
Hotfix/form grid issue s72c1

### DIFF
--- a/LEAF_Nexus/css/style.css
+++ b/LEAF_Nexus/css/style.css
@@ -438,6 +438,20 @@ table#tform {
     empty-cells: show;
     text-align: left;
 }
+table {
+    height: 1px; /* table will ignore, needed to set other content to 100% height */
+}
+table .btn_leaf_grid_sort {
+    cursor: pointer;
+    padding: 4px 2px;
+    margin: 0;
+    border: 0;
+    width: 100%;
+    height: 100%;
+    background-color: inherit;
+    color: inherit;
+    font-size: inherit;
+}
 
 table#tform th {
     border: 0;

--- a/LEAF_Request_Portal/admin/css/style.css
+++ b/LEAF_Request_Portal/admin/css/style.css
@@ -13,6 +13,20 @@
   left: 0;
   z-index: 100;
 }
+table {
+  height: 1px; /* table will ignore, needed to set other content to 100% height */
+}
+table .btn_leaf_grid_sort {
+  cursor: pointer;
+  padding: 4px 2px;
+  margin: 0;
+  border: 0;
+  width: 100%;
+  height: 100%;
+  background-color: inherit;
+  color: inherit;
+  font-size: inherit;
+}
 
 .link {
   text-decoration: underline;

--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -44,18 +44,11 @@ label input {
     margin-left: 0.25rem;
     cursor: pointer;
 }
-table th button {
-    border: 0;
-    width: 100%;
-    color: inherit;
-    background-color: inherit;
-    cursor: pointer;
-}
 table th:not([id^="Vheader"]) {
     background-color: #252f3e;
     color: white;
     font-weight: normal;
-    font-size: 1rem;
+    font-size: 1rem !important;
     padding: 0.25rem;
 }
 table.leaf_grid th, table.leaf_grid td {

--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -44,6 +44,13 @@ label input {
     margin-left: 0.25rem;
     cursor: pointer;
 }
+table th button {
+    border: 0;
+    width: 100%;
+    color: inherit;
+    background-color: inherit;
+    cursor: pointer;
+}
 table th:not([id^="Vheader"]) {
     background-color: #252f3e;
     color: white;

--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -231,15 +231,19 @@ span#headerMenu {
   font-size: 12px;
   font-weight: normal;
 }
-
+table {
+  height: 1px;  /* table will ignore, needed to set other content to 100% height */
+}
 table .btn_leaf_grid_sort {
   cursor: pointer;
-  padding: 4px;
+  padding: 4px 2px;
   margin: 0;
   border: 0;
   width: 100%;
   height: 100%;
-  background-color: transparent;
+  background-color: inherit;
+  color: inherit;
+  font-size: inherit;
 }
 
 /* menu.tpl elements include nav and 1st level ul */

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -220,9 +220,8 @@ var LeafFormGrid = function (containerID, options) {
     let virtualHeader = `<tr id="${prefixID}tVirt_tr">`;
     if (showIndex) {
       temp +=
-        `<th scope="col"
-          id="${prefixID}header_UID" style="text-align:center">
-          <button type="button" class="btn_leaf_grid_sort"
+        `<th scope="col" style="text-align:center">
+          <button id="${prefixID}header_UID" type="button" class="btn_leaf_grid_sort"
             aria-label="unique ID, sortable">UID<span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
           </button>
         </th>`;
@@ -257,14 +256,13 @@ var LeafFormGrid = function (containerID, options) {
         divFilter.innerHTML = headers[i].name || '';
         const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
         const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
-        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+        thInnerContent = `<button type="button" id="${prefixID}header_${headers[i].indicatorID}" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
           </button>`;
       } else {
-        thInnerContent = `<div tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
+        thInnerContent = `<div tabindex="0" id="${prefixID}header_${headers[i].indicatorID}" style="padding:2px;">${headers[i].name}</div>`;
       }
       $("#" + prefixID + "thead_tr").append(
-        `<th scope="col"
-          id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">
+        `<th scope="col" style="text-align:${align}">
             ${thInnerContent}
         </th>`
       );
@@ -281,7 +279,7 @@ var LeafFormGrid = function (containerID, options) {
           "cursor",
           "pointer"
         );
-        $("#" + prefixID + "header_" + headers[i].indicatorID + ' > button').on(
+        $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click",
           null,
           headers[i].indicatorID,

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -245,17 +245,15 @@ var LeafFormGrid = function (containerID, options) {
         renderBody(0, Infinity);
       });
     }
-
+    let divFilter = document.createElement('div');
     for (let i in headers) {
       if (headers[i].visible == false) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      let headerName = '';
-      if(typeof XSSHelpers !== 'undefined') {
-        headerName = XSSHelpers.stripAllTags(headers[i].name || '').trim();
-      }
-      const ariaAttr = headerName !== '' ? ` aria-label="${headerName}, sortable"` : "";
+      divFilter.innerHTML = headers[i].name || '';
+      const textName = divFilter.textContent.trim();
+      const ariaAttr = textName !== '' ? ` aria-label="${textName}, sortable"` : "";
       $("#" + prefixID + "thead_tr").append(
         `<th scope="col"
           id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -223,8 +223,7 @@ var LeafFormGrid = function (containerID, options) {
         `<th scope="col"
           id="${prefixID}header_UID" style="text-align:center">
           <button type="button" class="btn_leaf_grid_sort"
-            aria-label="unique ID, sortable">UID
-            <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
+            aria-label="unique ID, sortable">UID<span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
           </button>
         </th>`;
       virtualHeader +=
@@ -258,9 +257,7 @@ var LeafFormGrid = function (containerID, options) {
         divFilter.innerHTML = headers[i].name || '';
         const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
         const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
-        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">
-            ${headers[i].name}
-            <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
           </button>`;
       } else {
         thInnerContent = `<div tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
@@ -378,11 +375,11 @@ var LeafFormGrid = function (containerID, options) {
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", ascending.");
       $(headerSelector).attr("aria-sort", "ascending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true"> ▲</span>');
+      $(headerSelector + "_sort").html('<span aria-hidden="true">▲</span>');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", descending.");
       $(headerSelector).attr("aria-sort", "descending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true"> ▼</span>')
+      $(headerSelector + "_sort").html('<span aria-hidden="true">▼</span>')
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -251,15 +251,24 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      divFilter.innerHTML = headers[i].name || '';
-      const textName = divFilter.textContent.trim();
-      const ariaAttr = textName !== '' ? ` aria-label="${textName}, sortable"` : "";
+
+      const canSort = headers[i].sortable == undefined || headers[i].sortable == true;
+      let thInnerContent = "";
+      if(canSort) {
+        divFilter.innerHTML = headers[i].name || '';
+        const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
+        const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
+        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">
+            ${headers[i].name}
+            <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+          </button>`;
+      } else {
+        thInnerContent = `<div tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
+      }
       $("#" + prefixID + "thead_tr").append(
         `<th scope="col"
           id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">
-          <button type="button" class="btn_leaf_grid_sort"${ariaAttr}>${headers[i].name}
-            <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
-          </button>
+            ${thInnerContent}
         </th>`
       );
       virtualHeader +=
@@ -297,7 +306,7 @@ var LeafFormGrid = function (containerID, options) {
 
     $("#" + prefixID + "table>thead>tr>th").css({
       border: "1px solid black",
-      padding: "0",
+      padding: "2px",
       "font-size": "12px",
     });
 

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -251,11 +251,15 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
+      let headerName = '';
+      if(typeof XSSHelpers !== 'undefined') {
+        headerName = XSSHelpers.stripAllTags(headers[i].name || '').trim();
+      }
+      const ariaAttr = headerName !== '' ? ` aria-label="${headerName}, sortable"` : "";
       $("#" + prefixID + "thead_tr").append(
         `<th scope="col"
           id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">
-          <button type="button" class="btn_leaf_grid_sort"
-            aria-label="${headers[i].name}, sortable">${headers[i].name}
+          <button type="button" class="btn_leaf_grid_sort"${ariaAttr}>${headers[i].name}
             <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
           </button>
         </th>`

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -375,11 +375,11 @@ var LeafFormGrid = function (containerID, options) {
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", ascending.");
       $(headerSelector).attr("aria-sort", "ascending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true">▲</span>');
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", descending.");
       $(headerSelector).attr("aria-sort", "descending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true">▼</span>')
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>')
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];
@@ -946,7 +946,7 @@ var LeafFormGrid = function (containerID, options) {
       let output = [];
       let headers = [];
       //removes triangle symbols so that ascii chars are not present in exported headers.
-      $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
+      $("#" + prefixID + "thead .sort_icon_span").each(function (idx, val) {
         $(val).html("");
       });
       $("#" + prefixID + "thead>tr>th").each(function (idx, val) {

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -220,9 +220,8 @@ var LeafFormGrid = function (containerID, options) {
     let virtualHeader = `<tr id="${prefixID}tVirt_tr">`;
     if (showIndex) {
       temp +=
-        `<th scope="col"
-          id="${prefixID}header_UID" style="text-align:center">
-          <button type="button" class="btn_leaf_grid_sort"
+        `<th scope="col" style="text-align:center">
+          <button id="${prefixID}header_UID" type="button" class="btn_leaf_grid_sort"
             aria-label="unique ID, sortable">UID<span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
           </button>
         </th>`;
@@ -257,14 +256,13 @@ var LeafFormGrid = function (containerID, options) {
         divFilter.innerHTML = headers[i].name || '';
         const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
         const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
-        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+        thInnerContent = `<button type="button" id="${prefixID}header_${headers[i].indicatorID}" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
           </button>`;
       } else {
-        thInnerContent = `<div tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
+        thInnerContent = `<div tabindex="0" id="${prefixID}header_${headers[i].indicatorID}" style="padding:2px;">${headers[i].name}</div>`;
       }
       $("#" + prefixID + "thead_tr").append(
-        `<th scope="col"
-          id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">
+        `<th scope="col" style="text-align:${align}">
             ${thInnerContent}
         </th>`
       );
@@ -281,7 +279,7 @@ var LeafFormGrid = function (containerID, options) {
           "cursor",
           "pointer"
         );
-        $("#" + prefixID + "header_" + headers[i].indicatorID + ' > button').on(
+        $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click",
           null,
           headers[i].indicatorID,

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -245,17 +245,15 @@ var LeafFormGrid = function (containerID, options) {
         renderBody(0, Infinity);
       });
     }
-
+    let divFilter = document.createElement('div');
     for (let i in headers) {
       if (headers[i].visible == false) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      let headerName = '';
-      if(typeof XSSHelpers !== 'undefined') {
-        headerName = XSSHelpers.stripAllTags(headers[i].name || '').trim();
-      }
-      const ariaAttr = headerName !== '' ? ` aria-label="${headerName}, sortable"` : "";
+      divFilter.innerHTML = headers[i].name || '';
+      const textName = divFilter.textContent.trim();
+      const ariaAttr = textName !== '' ? ` aria-label="${textName}, sortable"` : "";
       $("#" + prefixID + "thead_tr").append(
         `<th scope="col"
           id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -223,8 +223,7 @@ var LeafFormGrid = function (containerID, options) {
         `<th scope="col"
           id="${prefixID}header_UID" style="text-align:center">
           <button type="button" class="btn_leaf_grid_sort"
-            aria-label="unique ID, sortable">UID
-            <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
+            aria-label="unique ID, sortable">UID<span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
           </button>
         </th>`;
       virtualHeader +=
@@ -258,12 +257,10 @@ var LeafFormGrid = function (containerID, options) {
         divFilter.innerHTML = headers[i].name || '';
         const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
         const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
-        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">
-            ${headers[i].name}
-            <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
           </button>`;
       } else {
-        thInnerContent = `<div  tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
+        thInnerContent = `<div tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
       }
       $("#" + prefixID + "thead_tr").append(
         `<th scope="col"
@@ -378,11 +375,11 @@ var LeafFormGrid = function (containerID, options) {
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", ascending.");
       $(headerSelector).attr("aria-sort", "ascending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true"> ▲</span>');
+      $(headerSelector + "_sort").html('<span aria-hidden="true">▲</span>');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", descending.");
       $(headerSelector).attr("aria-sort", "descending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true"> ▼</span>')
+      $(headerSelector + "_sort").html('<span aria-hidden="true">▼</span>')
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -375,11 +375,11 @@ var LeafFormGrid = function (containerID, options) {
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", ascending.");
       $(headerSelector).attr("aria-sort", "ascending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true">▲</span>');
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", descending.");
       $(headerSelector).attr("aria-sort", "descending");
-      $(headerSelector + "_sort").html('<span aria-hidden="true">▼</span>')
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>')
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];
@@ -946,7 +946,7 @@ var LeafFormGrid = function (containerID, options) {
       let output = [];
       let headers = [];
       //removes triangle symbols so that ascii chars are not present in exported headers.
-      $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
+      $("#" + prefixID + "thead .sort_icon_span").each(function (idx, val) {
         $(val).html("");
       });
       $("#" + prefixID + "thead>tr>th").each(function (idx, val) {

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -251,15 +251,24 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      divFilter.innerHTML = headers[i].name || '';
-      const textName = divFilter.textContent.trim();
-      const ariaAttr = textName !== '' ? ` aria-label="${textName}, sortable"` : "";
+
+      const canSort = headers[i].sortable == undefined || headers[i].sortable == true;
+      let thInnerContent = "";
+      if(canSort) {
+        divFilter.innerHTML = headers[i].name || '';
+        const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
+        const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
+        thInnerContent = `<button type="button" class="btn_leaf_grid_sort" aria-label="${ariaAttr}">
+            ${headers[i].name}
+            <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+          </button>`;
+      } else {
+        thInnerContent = `<div  tabindex="0" style="padding:2px;">${headers[i].name}</div>`;
+      }
       $("#" + prefixID + "thead_tr").append(
         `<th scope="col"
           id="${prefixID}header_${headers[i].indicatorID}" style="text-align:${align}">
-          <button type="button" class="btn_leaf_grid_sort"${ariaAttr}>${headers[i].name}
-            <span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
-          </button>
+            ${thInnerContent}
         </th>`
       );
       virtualHeader +=
@@ -297,7 +306,7 @@ var LeafFormGrid = function (containerID, options) {
 
     $("#" + prefixID + "table>thead>tr>th").css({
       border: "1px solid black",
-      padding: "0",
+      padding: "2px",
       "font-size": "12px",
     });
 


### PR DESCRIPTION
This update resolves some display issues caused by the introduction of a button related to header sorting.
The name value used to construct the aria-label will have html removed, and double quotes removed.
Also, not all headers are sortable: Those that are not will not contain a button element.

CSS targeting the new button has also been more broadly applied to resolve unintended style changes to the formGrid headers.  This update also syncs/brings up to date the version of formGrid in the app dir with the one in the portal/js dir, so the diff for the app file will show some additional changes.




**Impact**

Headers for formGrid specific output.  Some examples include the homepage search results, Report Builder reports, built-in LEAF secure form display, portal/admin Account Updater page, Nexus Summary page (lower most table)

Primary issue uncovered can be reproduced on the homepage by adding the following header line to a custom view_search template (function renderResult):

{name: '<input type="checkbox">', indicatorID: 'test code', editable: false},

Related styling issues can be reproduced or noticed by setting Report Builder label colors or visiting the Account Updater or Nexus Summary page

**Testing**

Fixes:
-buttons should not exist at all on non-sortable headers (Account Updater) but headers should still tab
-aria-label should not be truncated (dev tools -> header button element attribute),
-button (active sorting element) should have the same height as the header th
-buttons should inherit their color, background color and font size (Report Builder edit labels)
-Report Builder Virtual headers (fixed scrolling headers) should be aligned with the table cells

