### PR TITLE
Leaf 4291 - display workflow on creation

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -79,7 +79,10 @@
             let workflowID;
 
             postWorkflow(function(workflow_id) {
-                loadWorkflowList(workflow_id);
+                let url = new URL(window.location.href);
+                url.searchParams.set('workflowID', workflow_id);
+                window.history.replaceState(null, null, url.toString());
+                loadWorkflowList();
                 dialog.hide();
             });
         });
@@ -1515,7 +1518,7 @@
             </li>`;
             output += '</ul></div>';
             output +=
-                `<hr /><div style="padding: 4px"><button type="button" class="buttonNorm" 
+                `<hr /><div style="padding: 4px"><button type="button" class="buttonNorm"
                     onclick="removeAction('${currentWorkflow}', '${stepID}', '${params.nextStepID}', '${params.action}', ${reopenStepID})">Remove Action</button></div>`;
             $('#stepInfo_' + stepID).html(output);
             $('#stepInfo_' + stepID).show('slide', 200, () => modalSetup(stepID));
@@ -1755,7 +1758,7 @@
         }
     }
 
-    /** 
+    /**
     * close the step or action info modal.
     * @param {string} stepID - active modal step
     * @param {string} reopenStepID - used to reopen the stepinfo modal if viewing actions via the stepinfo modal
@@ -1843,7 +1846,7 @@
             if(stepID !== -1) {
                 routeOptions += `<option value="-1">Requestor</option>`;
                 routeOptions += `<option value="${stepID}">Self</option>`;
-            }  
+            }
             routeOptions += `${step_options}</select><div>`;
         }
         const actionList = buildRoutesList(+stepID, +currentWorkflow);
@@ -2034,7 +2037,7 @@
                     cache: false
                 });
                 break;
-        } 
+        }
     }
 
     var endPoints = [];
@@ -2292,7 +2295,7 @@
         });
     }
 
-    function loadWorkflowList(workflowID) {
+    function loadWorkflowList() {
         $.ajax({
             async: false,
             type: 'GET',
@@ -2489,7 +2492,11 @@
                         alert("Prerequisite action needed:\n\n" + res);
                         dialog.hide();
                     } else {
-                        loadWorkflowList(res);
+                        let url = new URL(window.location.href);
+                        url.searchParams.set('workflowID', res);
+                        window.history.replaceState(null, null, url.toString());
+
+                        loadWorkflowList();
                         workflowDescription = $('#workflow_rename').val();
                         dialog.hide();
                     }
@@ -2582,7 +2589,12 @@
 
             updateRoutes(workflowID, old_steps);
             updateRouteEvents(currentWorkflow, workflowID, old_steps);
-            loadWorkflowList(workflowID);
+
+            let url = new URL(window.location.href);
+            url.searchParams.set('workflowID', workflowID);
+            window.history.replaceState(null, null, url.toString());
+
+            loadWorkflowList();
         });
         dialog.show();
     }


### PR DESCRIPTION
**Summary:**

Create a workflow, the workflow that should be shown to the user should be the one created. Currently it will redirect to the first workflow in the list.

There was a change made to deal with the vue version of the workflow editor where url params are used to navigate to workflows. But with the current workflow editor the workflowID is passed to a function.




**Potential Impact:**

when the url param was introduced creating a new workflow, duplicating and renaming the workflow broke the display after save. It would always go back to the first workflow listed because the workflowID was not passed in the url. This ticket should fix that and pass the workflowID as a url param.




**Testing:

New workflow**

Navigate to the workflow editor

click New Workflow

supply a name for this workflow

click save

the workflow that is displayed should be the one just created. (check the dropdown to ensure that it is correct)




**Rename Workflow**

Navigate to the workflow editor

select a workflow to rename (preferably not the first one listed)

click Rename Workflow

change the name

click save

the same workflow should be displayed only the name should have changed (check the dropdown to ensure that it is correct)




**Copy Workflow**

Navigate to the workflow editor

select a workflow from the dropdown to copy

click Copy Workflow

supply a name for this workflow

click save

the workflow that is displayed should be the one just created. (check the dropdown to ensure that it is correct)