### PR TITLE
LEAF 4299 unrepresented characters in email templates

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1651,7 +1651,7 @@ class FormWorkflow
                 default:
                 break;
             }
-
+            $data = iconv('UTF-8', 'ASCII//TRANSLIT', $data);
             $formattedFields["content"][$field['indicatorID']] = $data !== "" ? $data : $field["default"];
             $formattedFields["to_cc_content"][$field['indicatorID']] = $emailValue;
         }

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1651,7 +1651,7 @@ class FormWorkflow
                 default:
                 break;
             }
-            $data = iconv('UTF-8', 'ASCII//TRANSLIT', $data);
+            $data = iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $data);
             $formattedFields["content"][$field['indicatorID']] = $data !== "" ? $data : $field["default"];
             $formattedFields["to_cc_content"][$field['indicatorID']] = $emailValue;
         }


### PR DESCRIPTION
Replaces Microsoft Smart Quotes (curly quotes) with normal quotes and some other unrepresented characters with equivalents to avoid character display issues in email content.