### PR TITLE
LEAF-4273 - Fix broken QR code

### DIFF
--- a/LEAF_Request_Portal/qrcode/index.php
+++ b/LEAF_Request_Portal/qrcode/index.php
@@ -14,7 +14,7 @@ if(isset($_GET['encode'])) {
 
     $len = strlen($_GET['encode']);
     if($len > 0 && $len < 4000) { // check QR container limits
-        $encode = $input;
+        $encode = str_replace('&amp;', '&', $input);
     }
 
     // TODO: Replace this with centrally managed server config variable


### PR DESCRIPTION
QR codes aren't working due to a HTML entity encoding issue.

Steps to reproduce the issue:
1. Navigate to a record
2. Print preview
3. Note that the QR code resolves to a non-working URL because it includes \&amp; when we expect to have &

### Potential Impact
- No other dependencies

### Testing
- [ ] The issue can no-longer be reproduced