### PR TITLE
Leaf 4319 - Report Builder: Default option to reduce metadata for JSON exports

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -807,8 +807,8 @@ function sortHeaders(a, b) {
 }
 
 function openShareDialog() {
-    var pwd = document.URL.substr(0,document.URL.lastIndexOf('index.php'));
-    var reportLink = document.URL.substr(document.URL.lastIndexOf('?'));
+    var pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
+    var reportLink = document.URL.substr(document.URL.lastIndexOf('?') - 1);
 
     dialog_message.setTitle('Share Report');
     dialog_message.setContent('<p>This link can be shared to provide a live view into this report.</p>'
@@ -836,7 +836,7 @@ function openShareDialog() {
 }
 
 function showJSONendpoint() {
-    let pwd = document.URL.substr(0,document.URL.lastIndexOf('index.php'));
+    let pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
     leafSearch.getLeafFormQuery().setLimit(0, 10000);
     let queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
     let jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString + '&x-filterData=recordID,'+ Object.keys(filterData).join(',');

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1169,6 +1169,8 @@ $(function() {
     var extendedToolbar = false;
     $('#generateReport').off();
     $('#generateReport').on('click', function() {
+        filterData = {}; // reset x-filterData params
+
         $('#results').fadeIn(700);
         $('#saveLinkContainer').fadeIn(700);
         $('#step_2').slideUp(700);

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -807,8 +807,8 @@ function sortHeaders(a, b) {
 }
 
 function openShareDialog() {
-    var pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
-    var reportLink = document.URL.substr(document.URL.lastIndexOf('?') - 1);
+    var pwd = document.URL.substr(0,document.URL.lastIndexOf('/') + 1);
+    var reportLink = document.URL.substr(document.URL.lastIndexOf('?'));
 
     dialog_message.setTitle('Share Report');
     dialog_message.setContent('<p>This link can be shared to provide a live view into this report.</p>'
@@ -836,7 +836,7 @@ function openShareDialog() {
 }
 
 function showJSONendpoint() {
-    let pwd = document.URL.substr(0,document.URL.lastIndexOf('index.php'));
+    let pwd = document.URL.substr(0,document.URL.lastIndexOf('/') + 1);
     leafSearch.getLeafFormQuery().setLimit(0, 10000);
     let queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
     let jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString + '&x-filterData=recordID,'+ Object.keys(filterData).join(',');
@@ -1169,8 +1169,6 @@ $(function() {
     var extendedToolbar = false;
     $('#generateReport').off();
     $('#generateReport').on('click', function() {
-        filterData = {}; // reset x-filterData params
-
         $('#results').fadeIn(700);
         $('#saveLinkContainer').fadeIn(700);
         $('#step_2').slideUp(700);
@@ -1359,6 +1357,7 @@ $(function() {
 
 
             $('#editReport').on('click', function() {
+                filterData = {}; // reset x-filterData params
                 grid.stop();
                 isNewQuery = true;
                 $('#reportTitleDisplay').css('display', 'none');

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -807,7 +807,7 @@ function sortHeaders(a, b) {
 }
 
 function openShareDialog() {
-    var pwd = document.URL.substr(0,document.URL.lastIndexOf('/') + 1);
+    var pwd = document.URL.substr(0,document.URL.lastIndexOf('index.php'));
     var reportLink = document.URL.substr(document.URL.lastIndexOf('?'));
 
     dialog_message.setTitle('Share Report');
@@ -836,7 +836,7 @@ function openShareDialog() {
 }
 
 function showJSONendpoint() {
-    let pwd = document.URL.substr(0,document.URL.lastIndexOf('/') + 1);
+    let pwd = document.URL.substr(0,document.URL.lastIndexOf('index.php'));
     leafSearch.getLeafFormQuery().setLimit(0, 10000);
     let queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
     let jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString + '&x-filterData=recordID,'+ Object.keys(filterData).join(',');

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -836,11 +836,11 @@ function openShareDialog() {
 }
 
 function showJSONendpoint() {
-    var pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
+    let pwd = document.URL.substr(0,document.URL.lastIndexOf('index.php'));
     leafSearch.getLeafFormQuery().setLimit(0, 10000);
-    var queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
-    var jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString;
-    var powerQueryURL = '<!--{$powerQueryURL}-->' + window.location.pathname;
+    let queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
+    let jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString + '&x-filterData=recordID,'+ Object.keys(filterData).join(',');
+    let powerQueryURL = '<!--{$powerQueryURL}-->' + window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/'));
 
     dialog_message.setTitle('Data Endpoints');
     dialog_message.setContent('<p>This provides a live data source for custom dashboards or automated programs.</p><p><b>A configurable limit of 10,000 records has been preset</b>.</p><br />'
@@ -914,10 +914,10 @@ function showJSONendpoint() {
                 CSRFToken: CSRFToken}
         })
         .then(function(res) {
-            $('#exportPath').html(pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/open/form/query/_' + res);
+            $('#exportPath').html(pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/open/form/query/_' + res + '?x-filterData=recordID,'+ Object.keys(filterData).join(','));
            if($('#msCompatMode').is(':checked')) {
                 $('#expandLink').css('display', 'none');
-                $('#exportPath').html(powerQueryURL + 'api/open/form/query/_' + res);
+                $('#exportPath').html(powerQueryURL + '/api/open/form/query/_' + res + '&x-filterData=recordID,'+ Object.keys(filterData).join(','));
             }
             else {
                 $('#expandLink').css('display', 'inline');

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -840,7 +840,7 @@ function showJSONendpoint() {
     leafSearch.getLeafFormQuery().setLimit(0, 10000);
     let queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
     let jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString + '&x-filterData=recordID,'+ Object.keys(filterData).join(',');
-    let powerQueryURL = '<!--{$powerQueryURL}-->' + window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/'));
+    let powerQueryURL = '<!--{$powerQueryURL}-->' + window.location.pathname;
 
     dialog_message.setTitle('Data Endpoints');
     dialog_message.setContent('<p>This provides a live data source for custom dashboards or automated programs.</p><p><b>A configurable limit of 10,000 records has been preset</b>.</p><br />'
@@ -917,7 +917,7 @@ function showJSONendpoint() {
             $('#exportPath').html(pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/open/form/query/_' + res + '?x-filterData=recordID,'+ Object.keys(filterData).join(','));
            if($('#msCompatMode').is(':checked')) {
                 $('#expandLink').css('display', 'none');
-                $('#exportPath').html(powerQueryURL + '/api/open/form/query/_' + res + '&x-filterData=recordID,'+ Object.keys(filterData).join(','));
+                $('#exportPath').html(powerQueryURL + 'api/open/form/query/_' + res + '&x-filterData=recordID,'+ Object.keys(filterData).join(','));
             }
             else {
                 $('#expandLink').css('display', 'inline');


### PR DESCRIPTION
When using the JSON export option in the Report Builder, this reduces metadata that users have not explicitly asked for.

### Potential Impact
- JSON exports from the Report Builder don't include metadata that aren't explicitly requested. If power-users want all metadata, they can remove the x-filterData parameter in the URL.

### Testing
- [ ] Generate a report, only selecting Title as a data column. The JSON export should only include the Record ID and the Title.
