### PR TITLE
LEAF 4311 form grid 508, take 2

### DIFF
--- a/LEAF_Nexus/css/style.css
+++ b/LEAF_Nexus/css/style.css
@@ -438,6 +438,20 @@ table#tform {
     empty-cells: show;
     text-align: left;
 }
+table {
+    height: 1px; /* table will ignore, needed to set other content to 100% height */
+}
+table .btn_leaf_grid_sort {
+    cursor: pointer;
+    margin: 0;
+    padding: 4px;
+    border: 0;
+    width: 100%;
+    height: 100%;
+    background-color: inherit;
+    color: inherit;
+    font-size: inherit;
+}
 
 table#tform th {
     border: 0;

--- a/LEAF_Request_Portal/admin/css/style.css
+++ b/LEAF_Request_Portal/admin/css/style.css
@@ -13,7 +13,20 @@
   left: 0;
   z-index: 100;
 }
-
+table {
+  height: 1px; /* table will ignore, needed to set other content to 100% height */
+}
+table .btn_leaf_grid_sort {
+  cursor: pointer;
+  margin: 0;
+  padding: 4px;
+  border: 0;
+  width: 100%;
+  height: 100%;
+  background-color: inherit;
+  color: inherit;
+  font-size: inherit;
+}
 .link {
   text-decoration: underline;
   cursor: pointer;

--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -231,15 +231,19 @@ span#headerMenu {
   font-size: 12px;
   font-weight: normal;
 }
-
+table {
+  height: 1px;  /* table will ignore, needed to set other content to 100% height */
+}
 table .btn_leaf_grid_sort {
   cursor: pointer;
-  padding: 4px;
   margin: 0;
+  padding: 4px;
   border: 0;
   width: 100%;
   height: 100%;
-  background-color: transparent;
+  background-color: inherit;
+  color: inherit;
+  font-size: inherit;
 }
 
 /* menu.tpl elements include nav and 1st level ul */

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -35,10 +35,10 @@ var LeafFormGrid = function (containerID, options) {
     </div>
     <div id="${prefixID}table_stickyHeader" style="display: none"></div>
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
-      aria-label="" aria-live="assertive">
+      aria-label="Headers with buttons are sortable" aria-live="assertive">
     </span>
     <table id="${prefixID}table" class="leaf_grid">
-      <thead id="${prefixID}thead" aria-label="Search Results"></thead>
+      <thead id="${prefixID}thead" aria-label="Search Results. Headers with buttons are sortable."></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot"></tfoot>
     </table>`
@@ -243,7 +243,7 @@ var LeafFormGrid = function (containerID, options) {
         renderBody(0, Infinity);
       });
     }
-    let divFilter = document.createElement('div');
+
     for (let i in headers) {
       if (headers[i].visible == false) {
         continue;
@@ -253,11 +253,8 @@ var LeafFormGrid = function (containerID, options) {
       const canSort = headers[i].sortable == undefined || headers[i].sortable == true;
       let thInnerContent = "";
       if(canSort) {
-        divFilter.innerHTML = headers[i].name || '';
-        const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
-        const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
         thInnerContent = `<button type="button" id="${prefixID}header_${headers[i].indicatorID}"
-            class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span
+            class="btn_leaf_grid_sort">${headers[i].name}<span
                 id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
           </button>`;
       } else {
@@ -276,7 +273,7 @@ var LeafFormGrid = function (containerID, options) {
         '">' +
         headers[i].name +
         "</th>";
-      if (headers[i].sortable == undefined || headers[i].sortable == true) {
+      if (canSort) {
         $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click",
           null,
@@ -366,15 +363,13 @@ var LeafFormGrid = function (containerID, options) {
       renderBody(0, Infinity);
     }
     $("." + prefixID + "sort").css("display", "none");
-    $(`th[id^="${prefixID}header_]`).removeAttr('aria-sort');
     const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
-    if (order.toLowerCase() == "asc") {
-      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", ascending.");
-      $(headerSelector).attr("aria-sort", "ascending");
+    const headerText = document.querySelector(headerSelector)?.innerText || "";
+    if (order.toLowerCase() === "asc") {
+      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", ascending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
     } else {
-      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", descending.");
-      $(headerSelector).attr("aria-sort", "descending");
+      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", descending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>')
     }
     $(headerSelector + "_sort").css("display", "inline");
@@ -1130,5 +1125,3 @@ var LeafFormGrid = function (containerID, options) {
     },
   };
 };
-
-

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -25,27 +25,23 @@ var LeafFormGrid = function (containerID, options) {
   let renderHistory = {}; // index of rendered recordIDs
 
   $("#" + containerID).html(
-    '<div id="' +
-      prefixID +
-      'grid"></div><div id="' +
-      prefixID +
-      'form" style="display: none"></div>'
+    `<div id="${prefixID}grid"></div>
+    <div id="${prefixID}form" style="display: none"></div>`
   );
 
   $("#" + prefixID + "grid").html(
-    '<div style="position: relative"><div id="' +
-      prefixID +
-      'gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div></div><div id="' +
-      prefixID +
-      'table_stickyHeader" style="display: none"></div><table id="' +
-      prefixID +
-      'table" class="leaf_grid"><thead id="' +
-      prefixID +
-      'thead" aria-label="Search Results"></thead><tbody id="' +
-      prefixID +
-      'tbody"></tbody><tfoot id="' +
-      prefixID +
-      'tfoot"></tfoot></table>'
+    `<div style="position: relative">
+      <div id="${prefixID}gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div>
+    </div>
+    <div id="${prefixID}table_stickyHeader" style="display: none"></div>
+    <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
+      aria-label="" aria-live="assertive">
+    </span>
+    <table id="${prefixID}table" class="leaf_grid">
+      <thead id="${prefixID}thead" aria-label="Search Results"></thead>
+      <tbody id="${prefixID}tbody"></tbody>
+      <tfoot id="${prefixID}tfoot"></tfoot>
+    </table>`
   );
 
   if (options == undefined) {
@@ -62,11 +58,10 @@ var LeafFormGrid = function (containerID, options) {
 
   /**
    * @param values (required) object of cells and names to generate grid
-   * @param showScriptTags (default false) whether to display script tags
    * @memberOf LeafFormGrid
    * Returns copy of values with cells property html entities decoded
    */
-  function decodeCellHTMLEntities(values, showScriptTags = false) {
+  function decodeCellHTMLEntities(values) {
     let gridInfo = { ...values };
     if (gridInfo?.cells) {
       let cells = gridInfo.cells.slice();
@@ -77,11 +72,10 @@ var LeafFormGrid = function (containerID, options) {
           let elDiv = document.createElement("div");
           elDiv.innerHTML = v;
           let text = elDiv.innerText;
-          if (showScriptTags !== true)
-            text = text.replaceAll(
-              /(<script[\s\S]*?>)|(<\/script[\s\S]*?>)/gi,
-              ""
-            );
+          text = text.replaceAll(
+            /(<script[\s\S]*?>)|(<\/script[\s\S]*?>)/gi,
+            ""
+          );
           return text;
         });
         cells[ci] = arrRowVals.slice();
@@ -122,20 +116,18 @@ var LeafFormGrid = function (containerID, options) {
     }
 
     //populates table
-    for (var i = 0; i < rows; i++) {
-      var gridRow = "<tr>";
-      var rowBuffer = [];
-
+    for (let i = 0; i < rows; i++) {
       //makes array of cells
-      for (var j = 0; j < columns; j++) {
+      let rowBuffer = [];
+      for (let j = 0; j < columns; j++) {
         rowBuffer.push('<td style="width:100px"></td>');
       }
 
       //for all values with matching column id, replaces cell with value
-      for (var j = 0; j < values.columns.length; j++) {
+      for (let j = 0; j < values.columns.length; j++) {
         tDelim = j == values.columns.length - 1 ? "" : delim;
         if (columnOrder.indexOf(values.columns[j]) !== -1) {
-          var value =
+          let value =
             values.cells[i] === undefined || values.cells[i][j] === undefined
               ? ""
               : values.cells[i][j];
@@ -148,21 +140,19 @@ var LeafFormGrid = function (containerID, options) {
       }
 
       //combines cells into html and pushes row to body buffer
-      gridRow += rowBuffer.join("") + delimLF + "</tr>";
+      const gridRow = "<tr>" + rowBuffer.join("") + delimLF + "</tr>";
       gridBodyBuffer += gridRow;
     }
     return (
-      '<table class="table" style="word-wrap:break-word; max-width: 100%; padding: 20px; text-align: center; table-layout: fixed;"><thead>' +
-      gridHeadBuffer +
-      delimLF +
-      "</thead><tbody>" +
-      gridBodyBuffer +
-      "</tbody></table>"
+      `<table class="table" style="word-wrap:break-word; max-width: 100%; padding: 20px; text-align: center; table-layout: fixed;">
+        <thead>${gridHeadBuffer}${delimLF}</thead>
+        <tbody>${gridBodyBuffer}</tbody>
+      </table>`
     );
   }
 
   /**
-   * @memberOf LeafFormGrid
+   * @memberOf LeafFormGrid - add data to td elements
    */
   function getIndicator(indicatorID, series) {
     $.ajax({
@@ -226,21 +216,23 @@ var LeafFormGrid = function (containerID, options) {
    */
   function setHeaders(headersIn) {
     headers = headersIn;
-    var temp = '<tr id="' + prefixID + "thead_tr" + '">';
-    var virtualHeader = '<tr id="' + prefixID + "tVirt_tr" + '">';
+    let temp = `<tr id="${prefixID}thead_tr">`;
+    let virtualHeader = `<tr id="${prefixID}tVirt_tr">`;
     if (showIndex) {
       temp +=
-        '<th tabindex="0" id="' +
-        prefixID +
-        'header_UID" style="text-align: center">UID</th>';
+        `<th scope="col" style="text-align:center">
+          <button id="${prefixID}header_UID" type="button"
+            class="btn_leaf_grid_sort" aria-label="unique ID, sortable">UID<span
+                id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
+          </button>
+        </th>`;
       virtualHeader +=
-        '<th id="Vheader_UID" style="text-align: center">UID</th>';
+        '<th id="Vheader_UID" style="text-align:center">UID</th>';
     }
     $("#" + prefixID + "thead").html(temp);
 
     if (showIndex) {
-      $("#" + prefixID + "header_UID").css("cursor", "pointer");
-      $("#" + prefixID + "header_UID").on("click", null, null, function (data) {
+      $("button#" + prefixID + "header_UID").on("click", null, null, function () {
         if (headerToggle == 0) {
           sort("recordID", "asc", postSortRequestFunc);
           headerToggle = 1;
@@ -251,28 +243,30 @@ var LeafFormGrid = function (containerID, options) {
         renderBody(0, Infinity);
       });
     }
-
-    for (var i in headers) {
+    let divFilter = document.createElement('div');
+    for (let i in headers) {
       if (headers[i].visible == false) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
+
+      const canSort = headers[i].sortable == undefined || headers[i].sortable == true;
+      let thInnerContent = "";
+      if(canSort) {
+        divFilter.innerHTML = headers[i].name || '';
+        const textName = (divFilter.textContent.trim()).replace(/"/g, "'");
+        const ariaAttr = textName !== '' ? `${textName}, sortable` : "sortable";
+        thInnerContent = `<button type="button" id="${prefixID}header_${headers[i].indicatorID}"
+            class="btn_leaf_grid_sort" aria-label="${ariaAttr}">${headers[i].name}<span
+                id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+          </button>`;
+      } else {
+        thInnerContent = `<div tabindex="0" id="${prefixID}header_${headers[i].indicatorID}" style="padding:4px;">${headers[i].name}</div>`;
+      }
       $("#" + prefixID + "thead_tr").append(
-        '<th id="' +
-          prefixID +
-          "header_" +
-          headers[i].indicatorID +
-          '" tabindex="0"  style="text-align:' +
-          align +
-          '">' +
-          headers[i].name +
-          '<span id="' +
-          prefixID +
-          "header_" +
-          headers[i].indicatorID +
-          '_sort" class="' +
-          prefixID +
-          'sort"></span></th>'
+        `<th scope="col" style="text-align:${align}">
+            ${thInnerContent}
+        </th>`
       );
       virtualHeader +=
         '<th id="Vheader_' +
@@ -283,41 +277,19 @@ var LeafFormGrid = function (containerID, options) {
         headers[i].name +
         "</th>";
       if (headers[i].sortable == undefined || headers[i].sortable == true) {
-        $("#" + prefixID + "header_" + headers[i].indicatorID).css(
-          "cursor",
-          "pointer"
-        );
         $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click",
           null,
           headers[i].indicatorID,
-          function (data) {
+          function (event) {
             if (headerToggle == 0) {
-              sort(data.data, "asc", postSortRequestFunc);
+              sort(event.data, "asc", postSortRequestFunc);
               headerToggle = 1;
             } else {
-              sort(data.data, "desc", postSortRequestFunc);
+              sort(event.data, "desc", postSortRequestFunc);
               headerToggle = 0;
             }
             renderBody(0, Infinity);
-          }
-        );
-        //using enter key to sort the the table heads for 508 compliance
-        $("#" + prefixID + "header_" + headers[i].indicatorID).on(
-          "keydown",
-          null,
-          headers[i].indicatorID,
-          function (data) {
-            if (data.keyCode == 13) {
-              if (headerToggle == 0) {
-                sort(data.data, "asc", postSortRequestFunc);
-                headerToggle = 1;
-              } else {
-                sort(data.data, "desc", postSortRequestFunc);
-                headerToggle = 0;
-              }
-              renderBody(0, Infinity);
-            }
           }
         );
       }
@@ -325,9 +297,9 @@ var LeafFormGrid = function (containerID, options) {
     $("#" + prefixID + "thead").append("</tr>");
     virtualHeader += "</tr>";
 
-    $("#" + prefixID + "table>thead>tr>th").css({
+    $("#" + prefixID + "table > thead > tr > th").css({
       border: "1px solid black",
-      padding: "4px 2px 4px 2px",
+      padding: "0",
       "font-size": "12px",
     });
 
@@ -393,42 +365,19 @@ var LeafFormGrid = function (containerID, options) {
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
-
     $("." + prefixID + "sort").css("display", "none");
+    $(`th[id^="${prefixID}header_]`).removeAttr('aria-sort');
+    const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
     if (order.toLowerCase() == "asc") {
-      $("#" + prefixID + "header_" + key).attr("aria-live", "assertive");
-      $("#" + prefixID + "header_" + key).attr(
-        "aria-label",
-        "Sorting by ascending " + key
-      );
-      $("#" + prefixID + "header_" + key + "_sort").html(
-        '<div style="position: absolute" aria-label="Sorting by ascending ' +
-          key +
-          '"></div>' +
-          " &#9650;"
-      );
-      $("#" + prefixID + "header_" + key + "_sort").css(
-        "vertical-align",
-        "super"
-      );
+      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", ascending.");
+      $(headerSelector).attr("aria-sort", "ascending");
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
     } else {
-      $("#" + prefixID + "header_" + key).attr("aria-live", "assertive");
-      $("#" + prefixID + "header_" + key).attr(
-        "aria-label",
-        "Sorting by descending " + key
-      );
-      $("#" + prefixID + "header_" + key + "_sort").html(
-        '<div style="position: absolute" aria-label="Sorting by descending ' +
-          key +
-          '"></div>' +
-          " &#9660;"
-      );
-      $("#" + prefixID + "header_" + key + "_sort").css(
-        "vertical-align",
-        "sub"
-      );
+      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : key) + ", descending.");
+      $(headerSelector).attr("aria-sort", "descending");
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>')
     }
-    $("#" + prefixID + "header_" + key + "_sort").css("display", "inline");
+    $(headerSelector + "_sort").css("display", "inline");
     var array = [];
     var isIndicatorID = $.isNumeric(key);
     var isDate = false;
@@ -584,7 +533,7 @@ var LeafFormGrid = function (containerID, options) {
       function (idx) {
         $(this).css({
           width: virtHeaderSizes[idx],
-          padding: "2px",
+          padding: "0",
           "font-weight": "normal",
         });
       }
@@ -762,26 +711,13 @@ var LeafFormGrid = function (containerID, options) {
                                            }"
                                            data-indicator-id="${
                                              headers[j].indicatorID
-                                           }"
-                                           data-format="${
-                                             currentData[i].s1[
-                                               "id" +
-                                                 headers[j].indicatorID +
-                                                 "_format"
-                                             ]
                                            }">
                                             ${data.data}</td>`;
             }
           } else if (headers[j].callback != undefined) {
             buffer +=
-              '<td id="' +
-              prefixID +
-              currentData[i].recordID +
-              "_" +
-              headers[j].indicatorID +
-              '" data-clickable="' +
-              editable +
-              '"></td>';
+              `<td id="${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}"
+                data-clickable="${editable}"></td>`;
           } else {
             buffer +=
               '<td id="' +
@@ -875,7 +811,6 @@ var LeafFormGrid = function (containerID, options) {
    */
   function announceResults() {
     let term = $('[name="searchtxt"]').val();
-
     if (currentData.length == 0) {
       $(".status").text("No results found for term " + term);
     } else {
@@ -886,6 +821,7 @@ var LeafFormGrid = function (containerID, options) {
   }
 
   /**
+   * @deprecated See example.tpl for more efficient formGrid usage.
    * @memberOf LeafFormGrid
    */
   function loadData(recordIDs, callback) {
@@ -992,14 +928,21 @@ var LeafFormGrid = function (containerID, options) {
         'dynicons/?img=x-office-spreadsheet.svg&w=16" alt="" /> Export</button>'
     );
 
-    $("#" + prefixID + "getExcel").on("click", function () {
+    $("#" + prefixID + "getExcel").on("click", async function () {
+      // get indicator formats in case they need special handling (e.g. dates)
+      let iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format").then(res => res.json());
+      let indicatorFormats = {};
+      iFormatData.forEach(i => {
+        indicatorFormats[i.indicatorID] = i.format;
+      });
+
       if (currentRenderIndex != currentData.length) {
         renderBody(0, Infinity);
       }
       let output = [];
       let headers = [];
       //removes triangle symbols so that ascii chars are not present in exported headers.
-      $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
+      $("#" + prefixID + "thead .sort_icon_span").each(function (idx, val) {
         $(val).html("");
       });
       $("#" + prefixID + "thead>tr>th").each(function (idx, val) {
@@ -1021,8 +964,8 @@ var LeafFormGrid = function (containerID, options) {
 
           let trimmedText = val.innerText.trim();
           line[i] = trimmedText;
-          //prevent some values from being interpretted as dates by excel
-          const dataFormat = val.getAttribute("data-format");
+          //prevent some values from being interpreted as dates by excel
+          const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
           const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
           const isNumber = /^\d+$/;
 
@@ -1187,3 +1130,5 @@ var LeafFormGrid = function (containerID, options) {
     },
   };
 };
+
+

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -25,27 +25,23 @@ var LeafFormGrid = function (containerID, options) {
   let renderHistory = {}; // index of rendered recordIDs
 
   $("#" + containerID).html(
-    '<div id="' +
-      prefixID +
-      'grid"></div><div id="' +
-      prefixID +
-      'form" style="display: none"></div>'
+    `<div id="${prefixID}grid"></div>
+    <div id="${prefixID}form" style="display: none"></div>`
   );
 
   $("#" + prefixID + "grid").html(
-    '<div style="position: relative"><div id="' +
-      prefixID +
-      'gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div></div><div id="' +
-      prefixID +
-      'table_stickyHeader" style="display: none"></div><table id="' +
-      prefixID +
-      'table" class="leaf_grid"><thead id="' +
-      prefixID +
-      'thead" aria-label="Search Results"></thead><tbody id="' +
-      prefixID +
-      'tbody"></tbody><tfoot id="' +
-      prefixID +
-      'tfoot"></tfoot></table>'
+    `<div style="position: relative">
+      <div id="${prefixID}gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div>
+    </div>
+    <div id="${prefixID}table_stickyHeader" style="display: none"></div>
+    <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
+      aria-label="Headers with buttons are sortable" aria-live="assertive">
+    </span>
+    <table id="${prefixID}table" class="leaf_grid">
+      <thead id="${prefixID}thead" aria-label="Search Results. Headers with buttons are sortable."></thead>
+      <tbody id="${prefixID}tbody"></tbody>
+      <tfoot id="${prefixID}tfoot"></tfoot>
+    </table>`
   );
 
   if (options == undefined) {
@@ -62,11 +58,10 @@ var LeafFormGrid = function (containerID, options) {
 
   /**
    * @param values (required) object of cells and names to generate grid
-   * @param showScriptTags (default false) whether to display script tags
    * @memberOf LeafFormGrid
    * Returns copy of values with cells property html entities decoded
    */
-  function decodeCellHTMLEntities(values, showScriptTags = false) {
+  function decodeCellHTMLEntities(values) {
     let gridInfo = { ...values };
     if (gridInfo?.cells) {
       let cells = gridInfo.cells.slice();
@@ -77,11 +72,10 @@ var LeafFormGrid = function (containerID, options) {
           let elDiv = document.createElement("div");
           elDiv.innerHTML = v;
           let text = elDiv.innerText;
-          if (showScriptTags !== true)
-            text = text.replaceAll(
-              /(<script[\s\S]*?>)|(<\/script[\s\S]*?>)/gi,
-              ""
-            );
+          text = text.replaceAll(
+            /(<script[\s\S]*?>)|(<\/script[\s\S]*?>)/gi,
+            ""
+          );
           return text;
         });
         cells[ci] = arrRowVals.slice();
@@ -122,20 +116,18 @@ var LeafFormGrid = function (containerID, options) {
     }
 
     //populates table
-    for (var i = 0; i < rows; i++) {
-      var gridRow = "<tr>";
-      var rowBuffer = [];
-
+    for (let i = 0; i < rows; i++) {
       //makes array of cells
-      for (var j = 0; j < columns; j++) {
+      let rowBuffer = [];
+      for (let j = 0; j < columns; j++) {
         rowBuffer.push('<td style="width:100px"></td>');
       }
 
       //for all values with matching column id, replaces cell with value
-      for (var j = 0; j < values.columns.length; j++) {
+      for (let j = 0; j < values.columns.length; j++) {
         tDelim = j == values.columns.length - 1 ? "" : delim;
         if (columnOrder.indexOf(values.columns[j]) !== -1) {
-          var value =
+          let value =
             values.cells[i] === undefined || values.cells[i][j] === undefined
               ? ""
               : values.cells[i][j];
@@ -148,21 +140,19 @@ var LeafFormGrid = function (containerID, options) {
       }
 
       //combines cells into html and pushes row to body buffer
-      gridRow += rowBuffer.join("") + delimLF + "</tr>";
+      const gridRow = "<tr>" + rowBuffer.join("") + delimLF + "</tr>";
       gridBodyBuffer += gridRow;
     }
     return (
-      '<table class="table" style="word-wrap:break-word; max-width: 100%; padding: 20px; text-align: center; table-layout: fixed;"><thead>' +
-      gridHeadBuffer +
-      delimLF +
-      "</thead><tbody>" +
-      gridBodyBuffer +
-      "</tbody></table>"
+      `<table class="table" style="word-wrap:break-word; max-width: 100%; padding: 20px; text-align: center; table-layout: fixed;">
+        <thead>${gridHeadBuffer}${delimLF}</thead>
+        <tbody>${gridBodyBuffer}</tbody>
+      </table>`
     );
   }
 
   /**
-   * @memberOf LeafFormGrid
+   * @memberOf LeafFormGrid - add data to td elements
    */
   function getIndicator(indicatorID, series) {
     $.ajax({
@@ -226,21 +216,23 @@ var LeafFormGrid = function (containerID, options) {
    */
   function setHeaders(headersIn) {
     headers = headersIn;
-    var temp = '<tr id="' + prefixID + "thead_tr" + '">';
-    var virtualHeader = '<tr id="' + prefixID + "tVirt_tr" + '">';
+    let temp = `<tr id="${prefixID}thead_tr">`;
+    let virtualHeader = `<tr id="${prefixID}tVirt_tr">`;
     if (showIndex) {
       temp +=
-        '<th tabindex="0" id="' +
-        prefixID +
-        'header_UID" style="text-align: center">UID</th>';
+        `<th scope="col" style="text-align:center">
+          <button id="${prefixID}header_UID" type="button"
+            class="btn_leaf_grid_sort" aria-label="unique ID, sortable">UID<span
+                id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
+          </button>
+        </th>`;
       virtualHeader +=
-        '<th id="Vheader_UID" style="text-align: center">UID</th>';
+        '<th id="Vheader_UID" style="text-align:center">UID</th>';
     }
     $("#" + prefixID + "thead").html(temp);
 
     if (showIndex) {
-      $("#" + prefixID + "header_UID").css("cursor", "pointer");
-      $("#" + prefixID + "header_UID").on("click", null, null, function (data) {
+      $("button#" + prefixID + "header_UID").on("click", null, null, function () {
         if (headerToggle == 0) {
           sort("recordID", "asc", postSortRequestFunc);
           headerToggle = 1;
@@ -252,27 +244,26 @@ var LeafFormGrid = function (containerID, options) {
       });
     }
 
-    for (var i in headers) {
+    for (let i in headers) {
       if (headers[i].visible == false) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
+
+      const canSort = headers[i].sortable == undefined || headers[i].sortable == true;
+      let thInnerContent = "";
+      if(canSort) {
+        thInnerContent = `<button type="button" id="${prefixID}header_${headers[i].indicatorID}"
+            class="btn_leaf_grid_sort">${headers[i].name}<span
+                id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+          </button>`;
+      } else {
+        thInnerContent = `<div tabindex="0" id="${prefixID}header_${headers[i].indicatorID}" style="padding:4px;">${headers[i].name}</div>`;
+      }
       $("#" + prefixID + "thead_tr").append(
-        '<th id="' +
-          prefixID +
-          "header_" +
-          headers[i].indicatorID +
-          '" tabindex="0"  style="text-align:' +
-          align +
-          '">' +
-          headers[i].name +
-          '<span id="' +
-          prefixID +
-          "header_" +
-          headers[i].indicatorID +
-          '_sort" class="' +
-          prefixID +
-          'sort"></span></th>'
+        `<th scope="col" style="text-align:${align}">
+            ${thInnerContent}
+        </th>`
       );
       virtualHeader +=
         '<th id="Vheader_' +
@@ -282,42 +273,20 @@ var LeafFormGrid = function (containerID, options) {
         '">' +
         headers[i].name +
         "</th>";
-      if (headers[i].sortable == undefined || headers[i].sortable == true) {
-        $("#" + prefixID + "header_" + headers[i].indicatorID).css(
-          "cursor",
-          "pointer"
-        );
+      if (canSort) {
         $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click",
           null,
           headers[i].indicatorID,
-          function (data) {
+          function (event) {
             if (headerToggle == 0) {
-              sort(data.data, "asc", postSortRequestFunc);
+              sort(event.data, "asc", postSortRequestFunc);
               headerToggle = 1;
             } else {
-              sort(data.data, "desc", postSortRequestFunc);
+              sort(event.data, "desc", postSortRequestFunc);
               headerToggle = 0;
             }
             renderBody(0, Infinity);
-          }
-        );
-        //using enter key to sort the the table heads for 508 compliance
-        $("#" + prefixID + "header_" + headers[i].indicatorID).on(
-          "keydown",
-          null,
-          headers[i].indicatorID,
-          function (data) {
-            if (data.keyCode == 13) {
-              if (headerToggle == 0) {
-                sort(data.data, "asc", postSortRequestFunc);
-                headerToggle = 1;
-              } else {
-                sort(data.data, "desc", postSortRequestFunc);
-                headerToggle = 0;
-              }
-              renderBody(0, Infinity);
-            }
           }
         );
       }
@@ -325,9 +294,9 @@ var LeafFormGrid = function (containerID, options) {
     $("#" + prefixID + "thead").append("</tr>");
     virtualHeader += "</tr>";
 
-    $("#" + prefixID + "table>thead>tr>th").css({
+    $("#" + prefixID + "table > thead > tr > th").css({
       border: "1px solid black",
-      padding: "4px 2px 4px 2px",
+      padding: "0",
       "font-size": "12px",
     });
 
@@ -393,42 +362,17 @@ var LeafFormGrid = function (containerID, options) {
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
-
     $("." + prefixID + "sort").css("display", "none");
-    if (order.toLowerCase() == "asc") {
-      $("#" + prefixID + "header_" + key).attr("aria-live", "assertive");
-      $("#" + prefixID + "header_" + key).attr(
-        "aria-label",
-        "Sorting by ascending " + key
-      );
-      $("#" + prefixID + "header_" + key + "_sort").html(
-        '<div style="position: absolute" aria-label="Sorting by ascending ' +
-          key +
-          '"></div>' +
-          " &#9650;"
-      );
-      $("#" + prefixID + "header_" + key + "_sort").css(
-        "vertical-align",
-        "super"
-      );
+    const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
+    const headerText = document.querySelector(headerSelector)?.innerText || "";
+    if (order.toLowerCase() === "asc") {
+      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", ascending.");
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
     } else {
-      $("#" + prefixID + "header_" + key).attr("aria-live", "assertive");
-      $("#" + prefixID + "header_" + key).attr(
-        "aria-label",
-        "Sorting by descending " + key
-      );
-      $("#" + prefixID + "header_" + key + "_sort").html(
-        '<div style="position: absolute" aria-label="Sorting by descending ' +
-          key +
-          '"></div>' +
-          " &#9660;"
-      );
-      $("#" + prefixID + "header_" + key + "_sort").css(
-        "vertical-align",
-        "sub"
-      );
+      $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", descending.");
+      $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>')
     }
-    $("#" + prefixID + "header_" + key + "_sort").css("display", "inline");
+    $(headerSelector + "_sort").css("display", "inline");
     var array = [];
     var isIndicatorID = $.isNumeric(key);
     var isDate = false;
@@ -584,7 +528,7 @@ var LeafFormGrid = function (containerID, options) {
       function (idx) {
         $(this).css({
           width: virtHeaderSizes[idx],
-          padding: "2px",
+          padding: "0",
           "font-weight": "normal",
         });
       }
@@ -762,26 +706,13 @@ var LeafFormGrid = function (containerID, options) {
                                            }"
                                            data-indicator-id="${
                                              headers[j].indicatorID
-                                           }"
-                                           data-format="${
-                                             currentData[i].s1[
-                                               "id" +
-                                                 headers[j].indicatorID +
-                                                 "_format"
-                                             ]
                                            }">
                                             ${data.data}</td>`;
             }
           } else if (headers[j].callback != undefined) {
             buffer +=
-              '<td id="' +
-              prefixID +
-              currentData[i].recordID +
-              "_" +
-              headers[j].indicatorID +
-              '" data-clickable="' +
-              editable +
-              '"></td>';
+              `<td id="${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}"
+                data-clickable="${editable}"></td>`;
           } else {
             buffer +=
               '<td id="' +
@@ -875,7 +806,6 @@ var LeafFormGrid = function (containerID, options) {
    */
   function announceResults() {
     let term = $('[name="searchtxt"]').val();
-
     if (currentData.length == 0) {
       $(".status").text("No results found for term " + term);
     } else {
@@ -886,6 +816,7 @@ var LeafFormGrid = function (containerID, options) {
   }
 
   /**
+   * @deprecated See example.tpl for more efficient formGrid usage.
    * @memberOf LeafFormGrid
    */
   function loadData(recordIDs, callback) {
@@ -992,14 +923,21 @@ var LeafFormGrid = function (containerID, options) {
         'dynicons/?img=x-office-spreadsheet.svg&w=16" alt="" /> Export</button>'
     );
 
-    $("#" + prefixID + "getExcel").on("click", function () {
+    $("#" + prefixID + "getExcel").on("click", async function () {
+      // get indicator formats in case they need special handling (e.g. dates)
+      let iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format").then(res => res.json());
+      let indicatorFormats = {};
+      iFormatData.forEach(i => {
+        indicatorFormats[i.indicatorID] = i.format;
+      });
+
       if (currentRenderIndex != currentData.length) {
         renderBody(0, Infinity);
       }
       let output = [];
       let headers = [];
       //removes triangle symbols so that ascii chars are not present in exported headers.
-      $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
+      $("#" + prefixID + "thead .sort_icon_span").each(function (idx, val) {
         $(val).html("");
       });
       $("#" + prefixID + "thead>tr>th").each(function (idx, val) {
@@ -1021,8 +959,8 @@ var LeafFormGrid = function (containerID, options) {
 
           let trimmedText = val.innerText.trim();
           line[i] = trimmedText;
-          //prevent some values from being interpretted as dates by excel
-          const dataFormat = val.getAttribute("data-format");
+          //prevent some values from being interpreted as dates by excel
+          const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
           const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
           const isNumber = /^\d+$/;
 


### PR DESCRIPTION
Follow-up to 4269, which had some 508 updates to formGrid tables that were reverted due to some unintended effects.

This update adds buttons to sortable column headers to prevent breaking table navigation when sorting the headers, as well as to prevent garbled reader text due to a JAWS version issue (<2024).  Some aria labels and aria status elements are also updated.

Changes include some additional styles to better account for buttons in sortable column headers, and syncing the (currently unused) version of formGrid in the app folder.


**Testing / Impact**

_Any pages using the LEAF formGrid.js class for table display and export functionality_.
Some pages include: the portal homepage (view_search subsection), report builder, portal admin New Account Updater, possible custom report pages, LEAF secure form request, Nexus Summary page (bottom table)

-triangle sorting icon should always be removed and (if present) UID link should remain functional on export
-headers are sortable unless explicitly defined otherwise (including headers added by callbacks) and header content appears as expected
-display of both table and its virtual (scrolling) headers should appear as expected.

