### PR TITLE
Leaf 4323 - Data Visualizer: Cleanup layout

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
@@ -100,8 +100,11 @@ function isNumeric(x) {
 }
 
 function scrubHTML(input) {
-        let t = new DOMParser().parseFromString(input, 'text/html').body;
-        return t.textContent;
+    if(input == undefined) {
+        return '';
+    }
+    let t = new DOMParser().parseFromString(input, 'text/html').body;
+    return t.textContent;
 }
 
 // Update window title

--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
@@ -166,7 +166,7 @@ function buildFacts(fields, data) {
 
         // assign user-defined fields
         fields.forEach(field => {
-        	temp[field.indicatorID] = data[i].s1?.['id' + field.indicatorID];
+        	temp[field.indicatorID] = scrubHTML(data[i].s1?.['id' + field.indicatorID]);
             if(temp[field.indicatorID] == null || temp[field.indicatorID] == '') {
                 temp[field.indicatorID] = 'Blank';
             }

--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
@@ -11,6 +11,10 @@
 .table td {
     font-size: 12pt;
 }
+.table th {
+    border: 1px solid black;
+    padding: 4px;
+}
 
 .dc-chart g.row text {
     fill: black;
@@ -546,19 +550,19 @@ async function selectForm() {
             }
         );
 
-        activityCharts[form.categoryID] = dc.barChart(`#activity_${form.categoryID}`, 'activity');
+        activityCharts[form.categoryID] = dc.lineChart(`#activity_${form.categoryID}`, 'activity');
 
         activityCharts[form.categoryID]
             .width(100)
             .height(24)
             .dimension(dimActivityTime)
             .group(groupActivity[form.categoryID])
-            .valueAccessor(d => d.value[form.categoryID])
+            .valueAccessor(d => d.value[form.categoryID] == undefined ? 0 : d.value[form.categoryID])
             .brushOn(false)
             .margins({left: 0, top: 4, right: 0, bottom: 0})
             .x(d3.scaleTime().domain([minDate, maxDate]))
             .xUnits(() => 16)
-        	.gap(2);
+            .title(d => d.key.toLocaleDateString('en-us') + ': ' + d.value[form.categoryID] + ' request(s)');
         document.querySelector(`#activity_${form.categoryID}`).innerHTML = '';
     });
 
@@ -635,6 +639,7 @@ async function getDataBuildCharts(categoryID, customSearch) {
     	if(field.description != '') {
             t.name = field.description;
         }
+        t.name = scrubHTML(t.name);
         exportFields.push(t);
     });
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
@@ -192,6 +192,8 @@ function buildFacts(fields, data) {
                 }
                 temp[field.indicatorID] = date;
             }
+
+            temp[field.indicatorID] = scrubHTML(temp[field.indicatorID]);
         });
         parsed.push(temp);
     }


### PR DESCRIPTION
This cleans up some visual design quirks on the first "select a form" page:
- Table header border
- Streamlined date tooltip in the sparkline
- Switched to line charts for the sparklines
- HTML syntax is stripped when exporting to the Report Builder

### Potential Impact
- No dependencies

### Testing
- [ ] For fields that contain HTML syntax, the exported Report Builder view should not show HTML syntax in the headings.
