### PR TITLE
Leaf 2836 - Hide edit buttons inside inbox and open UID link in new tab

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -36,7 +36,7 @@
                     indicatorID: 'uid',
                     editable: false,
                     callback: function(data, blob) {
-                        $('#' + data.cellContainerID).html('<a href="' + site.url + '?a=printview&recordID=' +
+                        $('#' + data.cellContainerID).html('<a target="_blank" href="' + site.url + '?a=printview&recordID=' +
                             data.recordID + '">' + data.recordID + '</a>');
                     }
                 }
@@ -97,6 +97,8 @@
                                             .slideDown();
                                         $('#requestTitle').attr('tabindex', '0');
                                         $('#requestInfo').attr('tabindex', '0');
+                                        $('.printmainform > div > img[role="button"]').css('display','none');
+                                        $('button[title^="Edit"]').css('display','none');
                                     },
                                     error: function() {
                                         triggerGenericLoadError();


### PR DESCRIPTION
This hides buttons intended to edit the form that currently don't work. It also opens the UID link in a new tab when clicked.

Potential Impact
No dependencies

Testing
Navigate to the combined inbox. Click any Quick View button. See that there are no edit buttons.

In inbox, click any UID link and it will open in a new tab.