### PR TITLE
LEAF 4315 checkpoint date headers edgecase

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -547,12 +547,12 @@ function loadSearchPrereqs() {
             //toggle all subcheckboxes with parent indicator checkbox
             $('.indicatorOption > label > input').on('change', function() {
                 const indicatorIsChecked = this.checked;
-                $(`input[id^="indicators_${this.value}_columns"`).prop('checked', indicatorIsChecked);
+                $(`input[id^="indicators_${this.value}_columns"]`).prop('checked', indicatorIsChecked);
             });
             //check parent if any subcheckbox is checked, uncheck if none are checked
             $('.subIndicatorOption > label > input').on('change', function() {
                 const indicatorID = this.getAttribute('gridparent');
-                const siblings = Array.from($(`input[id^="indicators_${indicatorID}_columns"`));
+                const siblings = Array.from($(`input[id^="indicators_${indicatorID}_columns"]`));
                 const atLeastOneChecked = siblings.some(sib => sib.checked === true);
                 if(atLeastOneChecked) {
                     $(`#indicators_${indicatorID}`).prop('checked', true);

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1342,7 +1342,7 @@ $(function() {
                 if(tStepHeader.some(ele => ele === 0)) {
                     $.ajax({
                         type: 'GET',
-                        url: './api/workflow/steps',
+                        url: './api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description',
                         dataType: 'json',
                         success: (res) => {
                             let div = document.createElement('div');

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1338,6 +1338,27 @@ $(function() {
                 }
                 $('#reportStats').html(`${Object.keys(queryResult).length} records${partialLoad}`);
                 renderGrid(queryResult);
+                //update Checkpoint Date Step header text if still needed (should be rare)
+                if(tStepHeader.some(ele => ele === 0)) {
+                    $.ajax({
+                        type: 'GET',
+                        url: './api/workflow/steps',
+                        dataType: 'json',
+                        success: (res) => {
+                            let div = document.createElement('div');
+                            res.forEach(step => {
+                                if(tStepHeader[step.stepID] === 0) {
+                                    const title = XSSHelpers.stripAllTags($(div).html(step.stepTitle || "").text());
+                                    $('#' + grid.getPrefixID() + 'header_stepID_' + step.stepID).text(title);
+                                    $('#Vheader_stepID_' + step.stepID).text(title);
+                                    tStepHeader[step.stepID] = 1;
+                                }
+                            });
+
+                        },
+                        error: (err) => console.log(err),
+                    });
+                }
             }
         });
 


### PR DESCRIPTION
Covers an edge case in Report Builder where headers associated with Step fulfillment dates (Checkpoint Dates) continue to display the generic 'Checkpoint Date' text.

It adds a call to /steps to get the information if it's still needed after grid render.
However, this call should not typically be needed (the issue occurs if data for that step does not exist for any records returned by the query), so it should not make much impact.

**Impact/Testing**
Report Builder field selection.
Step 2, top right column, select options for Checkpoint Dates.
Headers should update to show the step name after generating a new report, or after opening an existing report using a short url (this is obtained by clicking the 'share report' button).