### PR TITLE
Fix MS Compat URL issue

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -900,7 +900,7 @@ function showJSONendpoint() {
             $('#exportPath').html(pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/open/form/query/_' + res + '?x-filterData=recordID,'+ Object.keys(filterData).join(','));
            if($('#msCompatMode').is(':checked')) {
                 $('#expandLink').css('display', 'none');
-                $('#exportPath').html(powerQueryURL + 'api/open/form/query/_' + res + '&x-filterData=recordID,'+ Object.keys(filterData).join(','));
+                $('#exportPath').html(powerQueryURL + 'api/open/form/query/_' + res + '?x-filterData=recordID,'+ Object.keys(filterData).join(','));
             }
             else {
                 $('#expandLink').css('display', 'inline');


### PR DESCRIPTION
This resolves a typo where MS Compatibility mode URLs ignore URL parameters.

Steps to reproduce issue:
1. Generate a report in the Report Builder
2. Click on JSON and access the standard URL
3. Click on "Use compatibility mode" and access it
4. Note that data returned from both URLs is different. The standard URL contains the correct output.

### Potential Impact
- No dependencies

### Testing
- [ ] The issue cannot be reproduced
