### PR TITLE
LEAF 4331 remove codemirror style sizer override

### DIFF
--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -47,9 +47,6 @@
     text-align: center;
     color: #707074;
 }
-.CodeMirror-sizer {
-    margin-left: 30px !important;
-}
 
 
 .leaf-center-content {


### PR DESCRIPTION
Removes a prior style override that can cause issues with templates / reports that are over 999 lines.

Impact / Testing
Style is specific to Template Editor, Email Template Editor, LEAF Programmer pages.
Margin-left value of the sizer element associated with code line numbers should scale as needed (this is calculated by CodeMirror lib) and left side of code should consistently be completely within view.

Please test with Edge and Chrome, in both code editor and code comparison views.  Confirm display remains consistent after horizonal and vertical screen resize and page scrolling.
  