### PR TITLE
LEAF-4335 Resolve issues with integrated forms

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1403,8 +1403,9 @@ class Form
                         LEFT JOIN workflow_steps USING (workflowID)
                         LEFT JOIN step_dependencies USING (stepID)
                         WHERE recordID=:recordID
-                        AND count > 0
-                        AND workflowID > 0';
+                            AND count > 0
+                            AND workflowID != 0
+                        GROUP BY dependencyID';
 
                 $res = $this->db->prepared_query($sql, $vars);
 

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -182,16 +182,27 @@ class Workflow
         return $res;
     }
 
+    // getAllCategories returns all active user-created forms
+    // Optional GET parameter "includeStandardLEAF" also returns built-in standardized LEAF forms
     public function getAllCategories()
     {
-        $res = $this->db->prepared_query("SELECT * FROM categories
-                                                WHERE workflowID>0 AND parentID=''
-        											AND disabled = 0
-        										ORDER BY categoryName", null);
+        if(!isset($_GET['includeStandardLEAF'])) {
+            $res = $this->db->prepared_query("SELECT * FROM categories
+                                                WHERE workflowID > 0 AND parentID=''
+                                                    AND disabled = 0
+                                                ORDER BY categoryName", null);
+        }
+        else {
+            $res = $this->db->prepared_query("SELECT * FROM categories
+                                                WHERE workflowID != 0 AND parentID=''
+                                                    AND disabled = 0
+                                                ORDER BY categoryName", null);
+        }
 
         return $res;
     }
 
+    // getAllCategories returns all user-created forms, including ones without an assigned workflow
     public function getAllCategoriesUnabridged()
     {
         $res = $this->db->prepared_query("SELECT * FROM categories

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -299,7 +299,7 @@
             // index by roles
             for(let depID in dataInboxes[sites[i].url][j].unfilledDependencyData) {
                 let uDD = dataInboxes[sites[i].url][j].unfilledDependencyData[depID];
-                let roleID = depID.concat(dataInboxes[sites[i].url][j].stepID).toString();
+                let roleID = String(depID) + dataInboxes[sites[i].url][j].stepID;
                 let description = uDD.description;
                 if(roleID < 0 && uDD.approverUID != undefined) { // handle "smart requirements"
                     roleID = Sha1.hash(uDD.approverUID);

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -299,7 +299,7 @@
             // index by roles
             for(let depID in dataInboxes[sites[i].url][j].unfilledDependencyData) {
                 let uDD = dataInboxes[sites[i].url][j].unfilledDependencyData[depID];
-                let roleID = depID;
+                let roleID = depID + dataInboxes[sites[i].url][j].stepID;
                 let description = uDD.description;
                 if(roleID < 0 && uDD.approverUID != undefined) { // handle "smart requirements"
                     roleID = Sha1.hash(uDD.approverUID);
@@ -675,7 +675,7 @@
     function buildWorkflowCategoryCache(site) {
         return $.ajax({
             type: 'GET',
-            url: site.url + 'api/workflow/categories?x-filterData=categoryID',
+            url: site.url + 'api/workflow/categories?includeStandardLEAF&x-filterData=categoryID',
             success: function(res) {
                 res.forEach(w => {
                     dataWorkflowCategories[w.categoryID] = 1;

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -299,7 +299,7 @@
             // index by roles
             for(let depID in dataInboxes[sites[i].url][j].unfilledDependencyData) {
                 let uDD = dataInboxes[sites[i].url][j].unfilledDependencyData[depID];
-                let roleID = depID + dataInboxes[sites[i].url][j].stepID;
+                let roleID = depID.concat(dataInboxes[sites[i].url][j].stepID).toString();
                 let description = uDD.description;
                 if(roleID < 0 && uDD.approverUID != undefined) { // handle "smart requirements"
                     roleID = Sha1.hash(uDD.approverUID);


### PR DESCRIPTION
This resolves a few issues with integrated forms, such as the LEAF-S Certification form.

Issue 1: The records_dependency table wasn't being updated correctly because integrated forms have a negative workflow ID, which prevented the record from showing up in the Inbox
Issue 2: The Inbox wasn't retrieving form labels correctly because it didn't include forms that were associated with a negative workflow ID.

The new GET parameter `includeStandardLEAF` was added to ./api/workflow/categories, which includes standard integrated forms in its output.

This also slightly improves organization of the Inbox's "Organize by Roles" view, so that sections are organized by a unique identifier that combines the dependencyID and stepID.

### Potential Impact
- Submitting new records

### Testing
- [ ] There are no issues submitting records
- [ ] Submitted records show up correctly for reviewers
- [ ] This Procedure works:
  1. Navigate to Admin Panel -> Site settings
  3. Submit a LEAF-S Certification
  4. Navigate to the Inbox
  5. The Certification request should show up in the Inbox