### PR TITLE
LEAF-4343 - Form workflow error handling

### DIFF
--- a/LEAF_Request_Portal/api/controllers/FormWorkflowController.php
+++ b/LEAF_Request_Portal/api/controllers/FormWorkflowController.php
@@ -76,7 +76,8 @@ class FormWorkflowController extends RESTfulResponse
             if(is_numeric($_POST['dependencyID'])) {
                 return $formWorkflow->handleAction($_POST['dependencyID'], XSSHelpers::xscrub($_POST['actionType']), $_POST['comment']);
             } else {
-                return array('status' => 0, 'errors' => array('Requirement from current step is missing<br/> Please contact administrator to add requirement to current step'));
+                http_response_code(400);
+                return 'The configuration for this workflow is incomplete. Please contact the administrator (missing requirement).';
             }
         });
 

--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -187,11 +187,13 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                 error: function (response) {
                     if (data["dependencyID"] === null) {
                         $("#workflowbox_dep" + data["dependencyID"]).html(
-                            '<div style="border: 2px solid black; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; width: 95%">Error: Requirement from current step is missing<br/> Please contact administrator to add requirement to current step</div>'
+                            `<div style="border: 2px solid red; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; width: 95%">Error ${response.status}: ${response.responseText}</div>`
                         );
                     } else {
                         $("#workflowbox_dep" + data["dependencyID"]).html(
-                            '<div style="border: 2px solid black; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; width: 95%">Error: Workflow Events may not have triggered</div>'
+                            `<div style="border: 2px solid red; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; width: 95%">Error ${response.status}: ${response.responseText}
+                                <p>Workflow Events may not have triggered</p>
+                            </div>`
                         );
                     }
                 },
@@ -207,7 +209,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
         // draw frame and header
         let stepDescription =
             step.description == null
-                ? "Your workflow is missing a requirement. Please check your workflow."
+                ? "Error: The configuration in the Workflow Editor is incomplete."
                 : step.description;
 
         $("#" + containerID).append(

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -811,20 +811,22 @@ class FormWorkflow
      * @param int $dependencyID
      * @param string $actionType
      * @param string (optional) $comment
-     * @return array {status(int), errors[string]}
+     * @return string|array {errors(array), comment(string)} Returns a string on client-side error, containing the error message
      */
-    public function handleAction(int $dependencyID, string $actionType, ?string $comment = ''): array
+    public function handleAction(int $dependencyID, string $actionType, ?string $comment = ''): string|array
     {
         if (!is_numeric($dependencyID))
         {
-            return array('status' => 0, 'errors' => array('Invalid ID: dependencyID'));
+            http_response_code(400);
+            return 'Invalid ID: dependencyID';
         }
 
         $errors = array();
 
         if ($_POST['CSRFToken'] != $_SESSION['CSRFToken'])
         {
-            return array('status' => 0, 'errors' => array('Invalid Token'));
+            http_response_code(400);
+            return 'Invalid Token';
         }
 
         $comment = XSSHelpers::sanitizeHTML($comment);
@@ -853,7 +855,8 @@ class FormWorkflow
                 case 1: // service chief
                     if (!$this->login->checkService($res[0]['serviceID']))
                     {
-                        return array('status' => 0, 'errors' => array('Your account is not registered as a Service Chief'));
+                        http_response_code(403);
+                        return 'Your account is not registered as a Service Chief';
                     }
 
                     break;
@@ -869,7 +872,8 @@ class FormWorkflow
 
                     if (count($resQuad) == 0)
                     {
-                        return array('status' => 0, 'errors' => array('Your account is not registered as an Executive Leadership Team member'));
+                        http_response_code(403);
+                        return 'Your account is not registered as an Executive Leadership Team member';
                     }
 
                     break;
@@ -889,7 +893,8 @@ class FormWorkflow
                     $userAuthorized = $this->checkEmployeeAccess($empUID);
 
                     if(!$userAuthorized){
-                        return array('status' => 0, 'errors' => array('User account does not match'));
+                        http_response_code(403);
+                        return 'User account does not match';
                     }
 
                     break;
@@ -909,7 +914,8 @@ class FormWorkflow
 
                         if (!$userAuthorized)
                         {
-                            return array('status' => 0, 'errors' => array('User account does not match'));
+                            http_response_code(403);
+                            return 'User account does not match';
                         }
                     }
 
@@ -929,12 +935,14 @@ class FormWorkflow
 
                     if (!$this->login->checkGroup($groupID))
                     {
-                        return array('status' => 0, 'errors' => array('User account is not part of the designated group'));
+                        http_response_code(403);
+                        return 'User account is not part of the designated group';
                     }
 
                     break;
                 default:
-                    return array('status' => 0, 'errors' => array('Invalid Operation'));
+                    http_response_code(400);
+                    return 'Invalid Operation';
 
                     break;
             }
@@ -953,7 +961,8 @@ class FormWorkflow
 
 
         if(count($res) == 0) {
-            return array('status' => 0, 'errors' => array('This page is out of date. Please refresh for the latest status.'));
+            http_response_code(409);
+            return 'This page is out of date. Please refresh for the latest status.';
         }
 
         $logCache = array();
@@ -1193,13 +1202,17 @@ class FormWorkflow
                     }
                 } // End update the record's workflow state
             }
+            else {
+                http_response_code(400);
+                return 'Invalid action and step combination';
+            }
         }
 
 
         $comment_post = array('date' => date('M j', $time), 'user_name' => $this->login->getName(), 'comment' => $comment, 'responder' => $resActionData[0]['actionTextPasttense'], 'nextStep' => $res2[0]['nextStepID']);
 
 
-        return array('status' => 1, 'errors' => $errors, 'comment' => $comment_post);
+        return array('errors' => $errors, 'comment' => $comment_post);
     }
 
 

--- a/x-test/API-tests/database/portal_test_db.sql
+++ b/x-test/API-tests/database/portal_test_db.sql
@@ -6273,7 +6273,7 @@ INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `prio
 (7,	1694021464,	0,	'tESTER',	'Requestor followup - Different Username case sensitivity',	0,	'Re-opened for editing',	0,	0,	1,	1),
 (8,	1694021464,	0,	'tester',	'Available for test case',	0,	'Approved',	1694021485,	0,	0,	1),
 (9,	1694021464,	0,	'tester',	'Available for test case',	0,	'Approved',	1694021485,	0,	0,	1),
-(10,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1),
+(10,	1694021465,	0,	'tester',	'TestFormWorkflow_ApplyAction',	0,	'Submitted',	1694021485,	0,	0,	1),
 (11,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1),
 (12,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1),
 (13,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1),

--- a/x-test/API-tests/database/portal_test_db.sql
+++ b/x-test/API-tests/database/portal_test_db.sql
@@ -3,6 +3,51 @@ SET time_zone = '+00:00';
 SET foreign_key_checks = 0;
 SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 
+DROP TABLE IF EXISTS `action_history`;
+CREATE TABLE `action_history` (
+  `actionID` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `recordID` mediumint unsigned NOT NULL,
+  `userID` varchar(50) NOT NULL,
+  `stepID` smallint NOT NULL DEFAULT '0',
+  `dependencyID` smallint NOT NULL,
+  `actionType` varchar(50) NOT NULL,
+  `actionTypeID` tinyint unsigned NOT NULL,
+  `time` int unsigned NOT NULL,
+  `comment` text,
+  PRIMARY KEY (`actionID`),
+  KEY `time` (`time`),
+  KEY `recordID` (`recordID`),
+  KEY `actionTypeID` (`actionTypeID`),
+  KEY `dependencyID` (`dependencyID`),
+  KEY `actionType` (`actionType`),
+  CONSTRAINT `action_history_ibfk_2` FOREIGN KEY (`actionTypeID`) REFERENCES `action_types` (`actionTypeID`),
+  CONSTRAINT `fk_records_action_history_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+INSERT INTO `action_history` (`actionID`, `recordID`, `userID`, `stepID`, `dependencyID`, `actionType`, `actionTypeID`, `time`, `comment`) VALUES
+(1,	958,	'tester',	0,	0,	'changeInitiator',	8,	1699055105,	'Initiator changed to Ollie Flatley'),
+(2,	530,	'tester',	0,	0,	'changeInitiator',	8,	1699056198,	'Initiator changed to Alysa Dare'),
+(3,	530,	'tester',	0,	0,	'move',	8,	1699056206,	'Moved to Requestor Followup step'),
+(4,	7,	'tester',	0,	0,	'move',	8,	1700253479,	'Moved to Requestor Followup step'),
+(5,	7,	'tester',	3,	-2,	'sendback',	8,	1700253822,	'');
+
+DROP TABLE IF EXISTS `action_types`;
+CREATE TABLE `action_types` (
+  `actionTypeID` tinyint unsigned NOT NULL AUTO_INCREMENT,
+  `actionTypeDesc` varchar(50) NOT NULL,
+  PRIMARY KEY (`actionTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+INSERT INTO `action_types` (`actionTypeID`, `actionTypeDesc`) VALUES
+(1,	'approved'),
+(2,	'disapproved'),
+(3,	'deferred'),
+(4,	'deleted'),
+(5,	'undeleted'),
+(6,	'filled dependency'),
+(7,	'unfilled dependency'),
+(8,	'Generic');
+
 DROP TABLE IF EXISTS `actions`;
 CREATE TABLE `actions` (
   `actionType` varchar(50) NOT NULL,
@@ -10,8 +55,8 @@ CREATE TABLE `actions` (
   `actionTextPasttense` varchar(50) NOT NULL,
   `actionIcon` varchar(50) NOT NULL,
   `actionAlignment` varchar(20) NOT NULL,
-  `sort` tinyint(4) NOT NULL,
-  `fillDependency` tinyint(4) NOT NULL,
+  `sort` tinyint NOT NULL,
+  `fillDependency` tinyint NOT NULL,
   `deleted` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`actionType`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -26,59 +71,14 @@ INSERT INTO `actions` (`actionType`, `actionText`, `actionTextPasttense`, `actio
 ('sign',	'Sign',	'Signed',	'application-certificate.svg',	'right',	0,	1,	0),
 ('submit',	'Submit',	'Submitted',	'gnome-emblem-default.svg',	'right',	0,	1,	0);
 
-DROP TABLE IF EXISTS `action_history`;
-CREATE TABLE `action_history` (
-  `actionID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `userID` varchar(50) NOT NULL,
-  `stepID` smallint(6) NOT NULL DEFAULT '0',
-  `dependencyID` smallint(6) NOT NULL,
-  `actionType` varchar(50) NOT NULL,
-  `actionTypeID` tinyint(3) unsigned NOT NULL,
-  `time` int(10) unsigned NOT NULL,
-  `comment` text,
-  PRIMARY KEY (`actionID`),
-  KEY `time` (`time`),
-  KEY `recordID` (`recordID`),
-  KEY `actionTypeID` (`actionTypeID`),
-  KEY `dependencyID` (`dependencyID`),
-  KEY `actionType` (`actionType`),
-  CONSTRAINT `action_history_ibfk_2` FOREIGN KEY (`actionTypeID`) REFERENCES `action_types` (`actionTypeID`),
-  CONSTRAINT `fk_records_action_history_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO `action_history` (`actionID`, `recordID`, `userID`, `stepID`, `dependencyID`, `actionType`, `actionTypeID`, `time`, `comment`) VALUES
-(1,	958,	'tester',	0,	0,	'changeInitiator',	8,	1699055105,	'Initiator changed to Ollie Flatley'),
-(2,	530,	'tester',	0,	0,	'changeInitiator',	8,	1699056198,	'Initiator changed to Alysa Dare'),
-(3,	530,	'tester',	0,	0,	'move',	8,	1699056206,	'Moved to Requestor Followup step'),
-(4,	7,	'tester',	0,	0,	'move',	8,	1700253479,	'Moved to Requestor Followup step'),
-(5,	7,	'tester',	3,	-2,	'sendback',	8,	1700253822,	'');
-
-DROP TABLE IF EXISTS `action_types`;
-CREATE TABLE `action_types` (
-  `actionTypeID` tinyint(3) unsigned NOT NULL AUTO_INCREMENT,
-  `actionTypeDesc` varchar(50) NOT NULL,
-  PRIMARY KEY (`actionTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO `action_types` (`actionTypeID`, `actionTypeDesc`) VALUES
-(1,	'approved'),
-(2,	'disapproved'),
-(3,	'deferred'),
-(4,	'deleted'),
-(5,	'undeleted'),
-(6,	'filled dependency'),
-(7,	'unfilled dependency'),
-(8,	'Generic');
-
 DROP TABLE IF EXISTS `approvals`;
 CREATE TABLE `approvals` (
-  `approvalID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `recordID` mediumint(8) unsigned NOT NULL,
+  `approvalID` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `recordID` mediumint unsigned NOT NULL,
   `userID` varchar(50) NOT NULL,
-  `groupID` mediumint(9) NOT NULL DEFAULT '0',
+  `groupID` mediumint NOT NULL DEFAULT '0',
   `approvalType` varchar(50) NOT NULL,
-  `time` int(10) unsigned NOT NULL,
+  `time` int unsigned NOT NULL,
   `comment` text,
   PRIMARY KEY (`approvalID`),
   KEY `time` (`time`),
@@ -86,7 +86,7 @@ CREATE TABLE `approvals` (
   KEY `groupID` (`groupID`),
   KEY `record_group` (`recordID`,`groupID`),
   KEY `record_time` (`recordID`,`time`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `categories`;
@@ -95,19 +95,19 @@ CREATE TABLE `categories` (
   `parentID` varchar(50) NOT NULL,
   `categoryName` varchar(50) NOT NULL,
   `categoryDescription` varchar(255) NOT NULL,
-  `workflowID` smallint(6) NOT NULL,
-  `sort` tinyint(3) NOT NULL DEFAULT '0',
-  `needToKnow` tinyint(4) NOT NULL DEFAULT '0',
-  `formLibraryID` smallint(6) DEFAULT NULL,
-  `visible` tinyint(4) NOT NULL DEFAULT '1',
-  `disabled` tinyint(4) NOT NULL DEFAULT '0',
+  `workflowID` smallint NOT NULL,
+  `sort` tinyint NOT NULL DEFAULT '0',
+  `needToKnow` tinyint NOT NULL DEFAULT '0',
+  `formLibraryID` smallint DEFAULT NULL,
+  `visible` tinyint NOT NULL DEFAULT '1',
+  `disabled` tinyint NOT NULL DEFAULT '0',
   `type` varchar(50) NOT NULL DEFAULT '',
-  `destructionAge` mediumint(8) unsigned DEFAULT NULL,
-  `lastModified` int(10) unsigned NOT NULL DEFAULT '0',
+  `destructionAge` mediumint unsigned DEFAULT NULL,
+  `lastModified` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`categoryID`),
   KEY `parentID` (`parentID`),
   KEY `destructionAge` (`destructionAge`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `categories` (`categoryID`, `parentID`, `categoryName`, `categoryDescription`, `workflowID`, `sort`, `needToKnow`, `formLibraryID`, `visible`, `disabled`, `type`, `destructionAge`, `lastModified`) VALUES
 ('form_2ca98',	'',	'Complex Form',	'',	1,	0,	0,	NULL,	1,	0,	'',	NULL,	1695395465),
@@ -123,14 +123,14 @@ INSERT INTO `categories` (`categoryID`, `parentID`, `categoryName`, `categoryDes
 
 DROP TABLE IF EXISTS `category_count`;
 CREATE TABLE `category_count` (
-  `recordID` mediumint(8) unsigned NOT NULL,
+  `recordID` mediumint unsigned NOT NULL,
   `categoryID` varchar(20) NOT NULL,
-  `count` tinyint(3) unsigned NOT NULL,
+  `count` tinyint unsigned NOT NULL,
   PRIMARY KEY (`recordID`,`categoryID`),
   KEY `categoryID` (`categoryID`),
   CONSTRAINT `category_count_ibfk_1` FOREIGN KEY (`categoryID`) REFERENCES `categories` (`categoryID`),
   CONSTRAINT `fk_records_category_count_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `category_count` (`recordID`, `categoryID`, `count`) VALUES
 (1,	'leaf_secure',	1),
@@ -1099,13 +1099,13 @@ INSERT INTO `category_count` (`recordID`, `categoryID`, `count`) VALUES
 DROP TABLE IF EXISTS `category_privs`;
 CREATE TABLE `category_privs` (
   `categoryID` varchar(20) NOT NULL,
-  `groupID` mediumint(9) NOT NULL,
-  `readable` tinyint(4) NOT NULL,
-  `writable` tinyint(4) NOT NULL,
+  `groupID` mediumint NOT NULL,
+  `readable` tinyint NOT NULL,
+  `writable` tinyint NOT NULL,
   UNIQUE KEY `categoryID` (`categoryID`,`groupID`),
   KEY `groupID` (`groupID`),
   CONSTRAINT `category_privs_ibfk_2` FOREIGN KEY (`categoryID`) REFERENCES `categories` (`categoryID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `category_staples`;
@@ -1115,23 +1115,23 @@ CREATE TABLE `category_staples` (
   UNIQUE KEY `category_stapled` (`categoryID`,`stapledCategoryID`),
   KEY `categoryID` (`categoryID`),
   CONSTRAINT `category_staples_ibfk_1` FOREIGN KEY (`categoryID`) REFERENCES `categories` (`categoryID`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `data`;
 CREATE TABLE `data` (
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `indicatorID` smallint(5) NOT NULL,
-  `series` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `recordID` mediumint unsigned NOT NULL,
+  `indicatorID` smallint NOT NULL,
+  `series` tinyint unsigned NOT NULL DEFAULT '1',
   `data` text NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL DEFAULT '0',
+  `timestamp` int unsigned NOT NULL DEFAULT '0',
   `userID` varchar(50) NOT NULL,
   UNIQUE KEY `unique` (`recordID`,`indicatorID`,`series`),
   KEY `indicator_series` (`indicatorID`,`series`),
   KEY `fastdata` (`indicatorID`,`data`(10)),
   FULLTEXT KEY `data` (`data`),
   CONSTRAINT `fk_records_data_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `data` (`recordID`, `indicatorID`, `series`, `data`, `timestamp`, `userID`) VALUES
 (1,	-4,	1,	'271',	1692287247,	'tester'),
@@ -5450,9 +5450,9 @@ INSERT INTO `data` (`recordID`, `indicatorID`, `series`, `data`, `timestamp`, `u
 DROP TABLE IF EXISTS `data_action_log`;
 CREATE TABLE `data_action_log` (
   `empUID` varchar(36) DEFAULT NULL,
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `action` varchar(45) DEFAULT NULL,
-  `userID` int(11) DEFAULT NULL,
+  `userID` int DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   `userDisplay` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
@@ -5465,17 +5465,17 @@ DROP TABLE IF EXISTS `data_cache`;
 CREATE TABLE `data_cache` (
   `cacheKey` varchar(32) NOT NULL,
   `data` text NOT NULL,
-  `timestamp` int(11) NOT NULL,
+  `timestamp` int NOT NULL,
   UNIQUE KEY `cacheKey` (`cacheKey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `data_extended`;
 CREATE TABLE `data_extended` (
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `indicatorID` smallint(6) NOT NULL,
+  `recordID` mediumint unsigned NOT NULL,
+  `indicatorID` smallint NOT NULL,
   `data` text NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL,
+  `timestamp` int unsigned NOT NULL,
   `userID` varchar(50) NOT NULL,
   KEY `recordID_indicatorID` (`recordID`,`indicatorID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -5483,16 +5483,16 @@ CREATE TABLE `data_extended` (
 
 DROP TABLE IF EXISTS `data_history`;
 CREATE TABLE `data_history` (
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `indicatorID` smallint(5) NOT NULL,
-  `series` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `recordID` mediumint unsigned NOT NULL,
+  `indicatorID` smallint NOT NULL,
+  `series` tinyint unsigned NOT NULL DEFAULT '1',
   `data` text NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL DEFAULT '0',
+  `timestamp` int unsigned NOT NULL DEFAULT '0',
   `userID` varchar(50) NOT NULL,
   KEY `recordID` (`recordID`,`indicatorID`,`series`),
   KEY `timestamp` (`timestamp`),
   CONSTRAINT `fk_records_data_history_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `data_history` (`recordID`, `indicatorID`, `series`, `data`, `timestamp`, `userID`) VALUES
 (530,	9,	1,	'205',	1699056186,	'tester'),
@@ -5500,7 +5500,7 @@ INSERT INTO `data_history` (`recordID`, `indicatorID`, `series`, `data`, `timest
 
 DROP TABLE IF EXISTS `data_log_items`;
 CREATE TABLE `data_log_items` (
-  `data_action_log_fk` int(11) NOT NULL,
+  `data_action_log_fk` int NOT NULL,
   `tableName` varchar(75) NOT NULL,
   `column` varchar(75) NOT NULL,
   `value` text NOT NULL,
@@ -6006,10 +6006,10 @@ INSERT INTO `data_log_items` (`data_action_log_fk`, `tableName`, `column`, `valu
 
 DROP TABLE IF EXISTS `dependencies`;
 CREATE TABLE `dependencies` (
-  `dependencyID` smallint(6) NOT NULL AUTO_INCREMENT,
+  `dependencyID` smallint NOT NULL AUTO_INCREMENT,
   `description` varchar(50) NOT NULL,
   PRIMARY KEY (`dependencyID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `dependencies` (`dependencyID`, `description`) VALUES
 (-3,	'Group Designated by the Requestor'),
@@ -6022,8 +6022,8 @@ INSERT INTO `dependencies` (`dependencyID`, `description`) VALUES
 
 DROP TABLE IF EXISTS `dependency_privs`;
 CREATE TABLE `dependency_privs` (
-  `dependencyID` smallint(6) NOT NULL,
-  `groupID` mediumint(9) NOT NULL,
+  `dependencyID` smallint NOT NULL,
+  `groupID` mediumint NOT NULL,
   UNIQUE KEY `dependencyID` (`dependencyID`,`groupID`),
   KEY `groupID` (`groupID`),
   CONSTRAINT `fk_privs_dependencyID` FOREIGN KEY (`dependencyID`) REFERENCES `dependencies` (`dependencyID`)
@@ -6034,9 +6034,9 @@ INSERT INTO `dependency_privs` (`dependencyID`, `groupID`) VALUES
 
 DROP TABLE IF EXISTS `destruction_log`;
 CREATE TABLE `destruction_log` (
-  `recordID` mediumint(8) unsigned NOT NULL,
+  `recordID` mediumint unsigned NOT NULL,
   `categoryID` varchar(20) NOT NULL,
-  `destructionTime` int(10) unsigned DEFAULT '0',
+  `destructionTime` int unsigned DEFAULT '0',
   PRIMARY KEY (`recordID`),
   KEY `destructionTime` (`destructionTime`),
   KEY `destructionForm` (`categoryID`)
@@ -6045,14 +6045,14 @@ CREATE TABLE `destruction_log` (
 
 DROP TABLE IF EXISTS `email_reminders`;
 CREATE TABLE `email_reminders` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `workflowID` smallint(6) NOT NULL,
-  `stepID` smallint(6) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `workflowID` smallint NOT NULL,
+  `stepID` smallint NOT NULL,
   `actionType` varchar(50) NOT NULL,
-  `frequency` smallint(5) NOT NULL,
-  `recipientGroupID` mediumint(9) NOT NULL,
+  `frequency` smallint NOT NULL,
+  `recipientGroupID` mediumint NOT NULL,
   `emailTemplate` text NOT NULL,
-  `startDateIndicatorID` smallint(5) NOT NULL,
+  `startDateIndicatorID` smallint NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `routeID` (`workflowID`,`stepID`,`actionType`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -6060,7 +6060,7 @@ CREATE TABLE `email_reminders` (
 
 DROP TABLE IF EXISTS `email_templates`;
 CREATE TABLE `email_templates` (
-  `emailTemplateID` mediumint(8) NOT NULL AUTO_INCREMENT,
+  `emailTemplateID` mediumint NOT NULL AUTO_INCREMENT,
   `label` varchar(255) NOT NULL,
   `emailTo` text,
   `emailCc` text,
@@ -6068,7 +6068,7 @@ CREATE TABLE `email_templates` (
   `body` text NOT NULL,
   PRIMARY KEY (`emailTemplateID`),
   UNIQUE KEY `label` (`label`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `email_templates` (`emailTemplateID`, `label`, `emailTo`, `emailCc`, `subject`, `body`) VALUES
 (-5,	'Automated Email Reminder',	'LEAF_automated_reminder_emailTo.tpl',	'LEAF_automated_reminder_emailCc.tpl',	'LEAF_automated_reminder_subject.tpl',	'LEAF_automated_reminder_body.tpl'),
@@ -6080,16 +6080,16 @@ INSERT INTO `email_templates` (`emailTemplateID`, `label`, `emailTo`, `emailCc`,
 
 DROP TABLE IF EXISTS `email_tracker`;
 CREATE TABLE `email_tracker` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `recordID` mediumint(8) unsigned NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `recordID` mediumint unsigned NOT NULL,
   `userID` varchar(50) DEFAULT NULL,
-  `timestamp` int(10) NOT NULL,
+  `timestamp` int NOT NULL,
   `recipients` text NOT NULL,
   `subject` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `recordID` (`recordID`),
   CONSTRAINT `fk_records_email_tracker_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `email_tracker` (`id`, `recordID`, `userID`, `timestamp`, `recipients`, `subject`) VALUES
 (1,	508,	NULL,	1697553997,	'Recipient(s): Tracy.O\'Hane0@fake-email.com, tester.tester@fake-email.com, Rhona.Goodwin@fake-email.com',	'Subject: RETURNED Test backup of initiator (#508) to AS - Service'),
@@ -6116,12 +6116,12 @@ INSERT INTO `events` (`eventID`, `eventDescription`, `eventType`, `eventData`) V
 
 DROP TABLE IF EXISTS `groups`;
 CREATE TABLE `groups` (
-  `groupID` mediumint(9) NOT NULL AUTO_INCREMENT,
-  `parentGroupID` mediumint(9) DEFAULT NULL,
+  `groupID` mediumint NOT NULL AUTO_INCREMENT,
+  `parentGroupID` mediumint DEFAULT NULL,
   `name` varchar(250) NOT NULL,
   `groupDescription` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`groupID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `groups` (`groupID`, `parentGroupID`, `name`, `groupDescription`) VALUES
 (-1,	NULL,	'Quadrad',	''),
@@ -6155,30 +6155,40 @@ INSERT INTO `groups` (`groupID`, `parentGroupID`, `name`, `groupDescription`) VA
 (205,	NULL,	'Office of Associate Director of Patient Care Services',	''),
 (206,	NULL,	'Group A',	'');
 
+DROP TABLE IF EXISTS `indicator_mask`;
+CREATE TABLE `indicator_mask` (
+  `indicatorID` smallint NOT NULL,
+  `groupID` mediumint NOT NULL,
+  UNIQUE KEY `indicatorID_2` (`indicatorID`,`groupID`),
+  KEY `indicatorID` (`indicatorID`),
+  KEY `groupID` (`groupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
 DROP TABLE IF EXISTS `indicators`;
 CREATE TABLE `indicators` (
-  `indicatorID` smallint(5) NOT NULL AUTO_INCREMENT,
+  `indicatorID` smallint NOT NULL AUTO_INCREMENT,
   `name` text NOT NULL,
   `format` text NOT NULL,
   `description` varchar(50) DEFAULT NULL,
   `default` text,
-  `parentID` smallint(6) DEFAULT NULL,
+  `parentID` smallint DEFAULT NULL,
   `categoryID` varchar(20) DEFAULT NULL,
   `html` text,
   `htmlPrint` text,
   `conditions` text,
   `jsSort` varchar(255) DEFAULT NULL,
-  `required` tinyint(4) NOT NULL DEFAULT '0',
-  `sort` tinyint(4) NOT NULL DEFAULT '1',
+  `required` tinyint NOT NULL DEFAULT '0',
+  `sort` tinyint NOT NULL DEFAULT '1',
   `timeAdded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `disabled` int(10) unsigned NOT NULL DEFAULT '0',
-  `is_sensitive` tinyint(4) NOT NULL DEFAULT '0',
+  `disabled` int unsigned NOT NULL DEFAULT '0',
+  `is_sensitive` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`indicatorID`),
   KEY `categoryID` (`categoryID`),
   KEY `parentID` (`parentID`),
   KEY `sort` (`sort`),
   CONSTRAINT `indicators_ibfk_1` FOREIGN KEY (`categoryID`) REFERENCES `categories` (`categoryID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `indicators` (`indicatorID`, `name`, `format`, `description`, `default`, `parentID`, `categoryID`, `html`, `htmlPrint`, `conditions`, `jsSort`, `required`, `sort`, `timeAdded`, `disabled`, `is_sensitive`) VALUES
 (-8,	'Approval Officials',	'',	NULL,	NULL,	NULL,	'leaf_devconsole',	NULL,	NULL,	NULL,	NULL,	0,	2,	'2019-12-13 17:09:58',	0,	0),
@@ -6205,63 +6215,53 @@ INSERT INTO `indicators` (`indicatorID`, `name`, `format`, `description`, `defau
 (14,	'Reviewer 1',	'orgchart_employee',	'',	'',	NULL,	'form_f8b95',	NULL,	NULL,	NULL,	NULL,	1,	0,	'2023-10-25 22:56:24',	0,	0),
 (15,	'Reviewer 2',	'orgchart_employee',	'',	'',	14,	'form_f8b95',	NULL,	NULL,	NULL,	NULL,	1,	0,	'2023-10-25 22:56:33',	0,	0);
 
-DROP TABLE IF EXISTS `indicator_mask`;
-CREATE TABLE `indicator_mask` (
-  `indicatorID` smallint(5) NOT NULL,
-  `groupID` mediumint(9) NOT NULL,
-  UNIQUE KEY `indicatorID_2` (`indicatorID`,`groupID`),
-  KEY `indicatorID` (`indicatorID`),
-  KEY `groupID` (`groupID`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-
 DROP TABLE IF EXISTS `notes`;
 CREATE TABLE `notes` (
-  `noteID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `recordID` mediumint(8) unsigned NOT NULL,
+  `noteID` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `recordID` mediumint unsigned NOT NULL,
   `note` text NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL DEFAULT '0',
+  `timestamp` int unsigned NOT NULL DEFAULT '0',
   `userID` varchar(50) NOT NULL,
-  `deleted` tinyint(4) DEFAULT NULL,
+  `deleted` tinyint DEFAULT NULL,
   PRIMARY KEY (`noteID`),
   KEY `recordID` (`recordID`),
   CONSTRAINT `fk_records_notes_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `process_query`;
 CREATE TABLE `process_query` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `userID` varchar(50) DEFAULT NULL,
   `url` text,
-  `lastProcess` int(10) unsigned NOT NULL,
+  `lastProcess` int unsigned NOT NULL,
   PRIMARY KEY (`id`),
   KEY `lastProcess` (`lastProcess`),
   FULLTEXT KEY `url` (`url`),
   FULLTEXT KEY `userid_url` (`userID`,`url`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `records`;
 CREATE TABLE `records` (
-  `recordID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `date` int(10) unsigned NOT NULL,
-  `serviceID` smallint(5) NOT NULL DEFAULT '0',
+  `recordID` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `date` int unsigned NOT NULL,
+  `serviceID` smallint NOT NULL DEFAULT '0',
   `userID` varchar(50) NOT NULL,
   `title` text,
-  `priority` tinyint(4) NOT NULL DEFAULT '0',
+  `priority` tinyint NOT NULL DEFAULT '0',
   `lastStatus` varchar(200) DEFAULT NULL,
-  `submitted` int(10) NOT NULL DEFAULT '0',
-  `deleted` int(10) NOT NULL DEFAULT '0',
-  `isWritableUser` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `isWritableGroup` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `submitted` int NOT NULL DEFAULT '0',
+  `deleted` int NOT NULL DEFAULT '0',
+  `isWritableUser` tinyint unsigned NOT NULL DEFAULT '1',
+  `isWritableGroup` tinyint unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`recordID`),
   KEY `date` (`date`),
   KEY `deleted` (`deleted`),
   KEY `serviceID` (`serviceID`),
   KEY `userID` (`userID`),
   KEY `submitted` (`submitted`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `priority`, `lastStatus`, `submitted`, `deleted`, `isWritableUser`, `isWritableGroup`) VALUES
 (1,	1692287010,	0,	'tester',	'LEAF Secure Certification',	0,	NULL,	0,	1692287465,	1,	1),
@@ -7225,16 +7225,16 @@ INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `prio
 
 DROP TABLE IF EXISTS `records_dependencies`;
 CREATE TABLE `records_dependencies` (
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `dependencyID` smallint(6) NOT NULL,
-  `filled` tinyint(3) NOT NULL DEFAULT '0',
-  `time` int(10) unsigned DEFAULT NULL,
+  `recordID` mediumint unsigned NOT NULL,
+  `dependencyID` smallint NOT NULL,
+  `filled` tinyint NOT NULL DEFAULT '0',
+  `time` int unsigned DEFAULT NULL,
   UNIQUE KEY `recordID` (`recordID`,`dependencyID`),
   KEY `filled` (`dependencyID`,`filled`),
   KEY `time` (`time`),
   CONSTRAINT `fk_records_dependencies_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE,
   CONSTRAINT `fk_records_dependencyID` FOREIGN KEY (`dependencyID`) REFERENCES `dependencies` (`dependencyID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `records_dependencies` (`recordID`, `dependencyID`, `filled`, `time`) VALUES
 (3,	-1,	0,	1692287493),
@@ -12004,12 +12004,12 @@ INSERT INTO `records_dependencies` (`recordID`, `dependencyID`, `filled`, `time`
 
 DROP TABLE IF EXISTS `records_step_fulfillment`;
 CREATE TABLE `records_step_fulfillment` (
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `stepID` smallint(6) NOT NULL,
-  `fulfillmentTime` int(10) unsigned NOT NULL,
+  `recordID` mediumint unsigned NOT NULL,
+  `stepID` smallint NOT NULL,
+  `fulfillmentTime` int unsigned NOT NULL,
   UNIQUE KEY `recordID` (`recordID`,`stepID`) USING BTREE,
   CONSTRAINT `fk_records_step_fulfillment_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `records_step_fulfillment` (`recordID`, `stepID`, `fulfillmentTime`) VALUES
 (3,	-3,	1692287493),
@@ -12026,9 +12026,9 @@ INSERT INTO `records_step_fulfillment` (`recordID`, `stepID`, `fulfillmentTime`)
 
 DROP TABLE IF EXISTS `records_workflow_state`;
 CREATE TABLE `records_workflow_state` (
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `stepID` smallint(6) NOT NULL,
-  `blockingStepID` tinyint(4) unsigned NOT NULL DEFAULT '0',
+  `recordID` mediumint unsigned NOT NULL,
+  `stepID` smallint NOT NULL,
+  `blockingStepID` tinyint unsigned NOT NULL DEFAULT '0',
   `lastNotified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `initialNotificationSent` tinyint(1) DEFAULT '0',
   UNIQUE KEY `recordID` (`recordID`,`stepID`),
@@ -12992,8 +12992,8 @@ INSERT INTO `records_workflow_state` (`recordID`, `stepID`, `blockingStepID`, `l
 
 DROP TABLE IF EXISTS `route_events`;
 CREATE TABLE `route_events` (
-  `workflowID` smallint(6) NOT NULL,
-  `stepID` smallint(6) NOT NULL,
+  `workflowID` smallint NOT NULL,
+  `stepID` smallint NOT NULL,
   `actionType` varchar(50) NOT NULL,
   `eventID` varchar(40) NOT NULL,
   UNIQUE KEY `workflowID_2` (`workflowID`,`stepID`,`actionType`,`eventID`),
@@ -13015,57 +13015,17 @@ INSERT INTO `route_events` (`workflowID`, `stepID`, `actionType`, `eventID`) VAL
 (-1,	-3,	'approve',	'std_email_notify_next_approver'),
 (-1,	-1,	'submit',	'std_email_notify_next_approver');
 
-DROP TABLE IF EXISTS `services`;
-CREATE TABLE `services` (
-  `serviceID` smallint(5) NOT NULL AUTO_INCREMENT,
-  `service` varchar(100) NOT NULL,
-  `abbreviatedService` varchar(25) NOT NULL,
-  `groupID` mediumint(9) DEFAULT NULL,
-  PRIMARY KEY (`serviceID`),
-  KEY `groupID` (`groupID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO `services` (`serviceID`, `service`, `abbreviatedService`, `groupID`) VALUES
-(14,	'Iron Sports',	'amethyst',	14),
-(15,	'Bronze Music',	'erin',	204),
-(26,	'Rubber Music',	'indigo',	204),
-(27,	'Steel Beauty',	'emerald',	204),
-(28,	'Cotton Movies & Books',	'cerulean',	28),
-(29,	'Bronze Kids',	'red',	28),
-(30,	'Wooden Beauty',	'peach',	28),
-(33,	'Marble Home',	'burgundy',	14),
-(35,	'Marble Health & Books',	'jade',	204),
-(36,	'Rubber Grocery',	'taupe',	204),
-(67,	'Wooden Clothing & Tools',	'maroon',	204),
-(68,	'Wool Games',	'fuchsia',	204),
-(74,	'Plastic Jewelry',	'grey',	74),
-(75,	'Steel Movies',	'byzantium',	74),
-(79,	'Copper Electronics & Sports',	'azure',	79),
-(80,	'Copper Music & Books',	'amethyst',	204),
-(81,	'Concrete Music',	'lime',	79),
-(82,	'Plastic Electronics',	'grey',	79),
-(86,	'Cotton Automotive',	'azure',	74),
-(90,	'Concrete Electronics',	'orange',	90),
-(91,	'Leather Grocery',	'byzantium',	28),
-(92,	'Cotton Computers',	'byzantium',	90),
-(102,	'Plastic Clothing & Toys',	'rose',	74),
-(103,	'Marble Games',	'carmine',	74),
-(200,	'AS Test Group',	'',	201),
-(201,	'AS - Service',	'',	201),
-(204,	'Office of the Director ELT',	'',	204),
-(205,	'Office of Associate Director of Patient Care Services',	'',	201);
-
 DROP TABLE IF EXISTS `service_chiefs`;
 CREATE TABLE `service_chiefs` (
-  `serviceID` smallint(5) NOT NULL,
+  `serviceID` smallint NOT NULL,
   `userID` varchar(50) NOT NULL,
   `backupID` varchar(50) NOT NULL DEFAULT '',
   `locallyManaged` tinyint(1) DEFAULT '0',
-  `active` tinyint(4) NOT NULL DEFAULT '1',
+  `active` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`userID`,`serviceID`,`backupID`),
   KEY `serviceID` (`serviceID`),
   KEY `userID` (`userID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `service_chiefs` (`serviceID`, `userID`, `backupID`, `locallyManaged`, `active`) VALUES
 (15,	'tester',	'',	0,	1),
@@ -13108,12 +13068,52 @@ INSERT INTO `service_chiefs` (`serviceID`, `userID`, `backupID`, `locallyManaged
 (102,	'VTRVXHCONCEPTION',	'',	0,	1),
 (68,	'VTRZAZSHARLENE',	'',	0,	1);
 
+DROP TABLE IF EXISTS `services`;
+CREATE TABLE `services` (
+  `serviceID` smallint NOT NULL AUTO_INCREMENT,
+  `service` varchar(100) NOT NULL,
+  `abbreviatedService` varchar(25) NOT NULL,
+  `groupID` mediumint DEFAULT NULL,
+  PRIMARY KEY (`serviceID`),
+  KEY `groupID` (`groupID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+INSERT INTO `services` (`serviceID`, `service`, `abbreviatedService`, `groupID`) VALUES
+(14,	'Iron Sports',	'amethyst',	14),
+(15,	'Bronze Music',	'erin',	204),
+(26,	'Rubber Music',	'indigo',	204),
+(27,	'Steel Beauty',	'emerald',	204),
+(28,	'Cotton Movies & Books',	'cerulean',	28),
+(29,	'Bronze Kids',	'red',	28),
+(30,	'Wooden Beauty',	'peach',	28),
+(33,	'Marble Home',	'burgundy',	14),
+(35,	'Marble Health & Books',	'jade',	204),
+(36,	'Rubber Grocery',	'taupe',	204),
+(67,	'Wooden Clothing & Tools',	'maroon',	204),
+(68,	'Wool Games',	'fuchsia',	204),
+(74,	'Plastic Jewelry',	'grey',	74),
+(75,	'Steel Movies',	'byzantium',	74),
+(79,	'Copper Electronics & Sports',	'azure',	79),
+(80,	'Copper Music & Books',	'amethyst',	204),
+(81,	'Concrete Music',	'lime',	79),
+(82,	'Plastic Electronics',	'grey',	79),
+(86,	'Cotton Automotive',	'azure',	74),
+(90,	'Concrete Electronics',	'orange',	90),
+(91,	'Leather Grocery',	'byzantium',	28),
+(92,	'Cotton Computers',	'byzantium',	90),
+(102,	'Plastic Clothing & Toys',	'rose',	74),
+(103,	'Marble Games',	'carmine',	74),
+(200,	'AS Test Group',	'',	201),
+(201,	'AS - Service',	'',	201),
+(204,	'Office of the Director ELT',	'',	204),
+(205,	'Office of Associate Director of Patient Care Services',	'',	201);
+
 DROP TABLE IF EXISTS `sessions`;
 CREATE TABLE `sessions` (
   `sessionKey` varchar(40) NOT NULL,
   `variableKey` varchar(40) NOT NULL DEFAULT '',
   `data` text NOT NULL,
-  `lastModified` int(10) unsigned NOT NULL,
+  `lastModified` int unsigned NOT NULL,
   UNIQUE KEY `sessionKey` (`sessionKey`,`variableKey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -13129,7 +13129,7 @@ CREATE TABLE `settings` (
 
 INSERT INTO `settings` (`setting`, `data`) VALUES
 ('adPath',	'{}'),
-('dbversion',	'2023100500'),
+('dbversion',	'2024022901'),
 ('emailBCC',	'{}'),
 ('emailCC',	'{}'),
 ('heading',	'New LEAF Site'),
@@ -13146,7 +13146,7 @@ INSERT INTO `settings` (`setting`, `data`) VALUES
 
 DROP TABLE IF EXISTS `short_links`;
 CREATE TABLE `short_links` (
-  `shortID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `shortID` mediumint unsigned NOT NULL AUTO_INCREMENT,
   `type` varchar(20) NOT NULL,
   `hash` varchar(64) NOT NULL,
   `data` text NOT NULL,
@@ -13161,25 +13161,45 @@ INSERT INTO `short_links` (`shortID`, `type`, `hash`, `data`) VALUES
 
 DROP TABLE IF EXISTS `signatures`;
 CREATE TABLE `signatures` (
-  `signatureID` mediumint(9) NOT NULL AUTO_INCREMENT,
+  `signatureID` mediumint NOT NULL AUTO_INCREMENT,
   `signature` text NOT NULL,
-  `recordID` mediumint(8) unsigned NOT NULL,
-  `stepID` smallint(6) NOT NULL,
-  `dependencyID` smallint(6) NOT NULL,
+  `recordID` mediumint unsigned NOT NULL,
+  `stepID` smallint NOT NULL,
+  `dependencyID` smallint NOT NULL,
   `message` longtext NOT NULL,
   `signerPublicKey` text NOT NULL,
   `userID` varchar(50) NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL,
+  `timestamp` int unsigned NOT NULL,
   PRIMARY KEY (`signatureID`),
   UNIQUE KEY `recordID_stepID_depID` (`recordID`,`stepID`,`dependencyID`),
   CONSTRAINT `fk_records_signatures_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+
+DROP TABLE IF EXISTS `sites`;
+CREATE TABLE `sites` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `launchpadID` mediumint unsigned NOT NULL,
+  `site_type` varchar(8) NOT NULL,
+  `site_path` varchar(250) NOT NULL,
+  `site_uploads` varchar(250) DEFAULT NULL,
+  `portal_database` varchar(250) DEFAULT NULL,
+  `orgchart_path` varchar(250) DEFAULT NULL,
+  `orgchart_database` varchar(250) DEFAULT NULL,
+  `decommissionTimestamp` int DEFAULT '0',
+  `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `site_path` (`site_path`),
+  KEY `site_type` (`site_type`),
+  KEY `launchpadID` (`launchpadID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `step_dependencies`;
 CREATE TABLE `step_dependencies` (
-  `stepID` smallint(6) NOT NULL,
-  `dependencyID` smallint(6) NOT NULL,
+  `stepID` smallint NOT NULL,
+  `dependencyID` smallint NOT NULL,
   UNIQUE KEY `stepID` (`stepID`,`dependencyID`),
   KEY `dependencyID` (`dependencyID`),
   CONSTRAINT `fk_step_dependencyID` FOREIGN KEY (`dependencyID`) REFERENCES `dependencies` (`dependencyID`),
@@ -13202,36 +13222,36 @@ INSERT INTO `step_dependencies` (`stepID`, `dependencyID`) VALUES
 
 DROP TABLE IF EXISTS `step_modules`;
 CREATE TABLE `step_modules` (
-  `stepID` smallint(6) NOT NULL,
+  `stepID` smallint NOT NULL,
   `moduleName` varchar(50) NOT NULL,
   `moduleConfig` text NOT NULL,
   UNIQUE KEY `stepID_moduleName` (`stepID`,`moduleName`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `tags`;
 CREATE TABLE `tags` (
-  `recordID` mediumint(8) unsigned NOT NULL,
+  `recordID` mediumint unsigned NOT NULL,
   `tag` varchar(50) NOT NULL,
-  `timestamp` int(10) unsigned NOT NULL DEFAULT '0',
+  `timestamp` int unsigned NOT NULL DEFAULT '0',
   `userID` varchar(50) NOT NULL,
   UNIQUE KEY `recordID` (`recordID`,`tag`),
   KEY `tag` (`tag`),
   CONSTRAINT `fk_records_tags_deletion` FOREIGN KEY (`recordID`) REFERENCES `records` (`recordID`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 DROP TABLE IF EXISTS `template_history_files`;
 CREATE TABLE `template_history_files` (
-  `file_id` int(11) NOT NULL AUTO_INCREMENT,
+  `file_id` int NOT NULL AUTO_INCREMENT,
   `file_parent_name` text,
   `file_name` text,
   `file_path` text,
-  `file_size` mediumint(9) DEFAULT NULL,
+  `file_size` mediumint DEFAULT NULL,
   `file_modify_by` text,
   `file_created` text,
   PRIMARY KEY (`file_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `template_history_files` (`file_id`, `file_parent_name`, `file_name`, `file_path`, `file_size`, `file_modify_by`, `file_created`) VALUES
 (1,	'Mass_data_generate',	'1694021344_Mass_data_generate.tpl',	'../templates_history/leaf_programmer/1694021344_Mass_data_generate.tpl',	1729,	'tester tester',	'2023-09-06 05:29:04'),
@@ -13249,14 +13269,14 @@ INSERT INTO `template_history_files` (`file_id`, `file_parent_name`, `file_name`
 DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
   `userID` varchar(50) NOT NULL,
-  `groupID` mediumint(9) NOT NULL,
+  `groupID` mediumint NOT NULL,
   `backupID` varchar(50) NOT NULL DEFAULT '',
   `primary_admin` tinyint(1) NOT NULL DEFAULT '0',
   `locallyManaged` tinyint(1) DEFAULT '0',
-  `active` tinyint(4) NOT NULL DEFAULT '1',
+  `active` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`userID`,`groupID`,`backupID`),
   KEY `groupID` (`groupID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `users` (`userID`, `groupID`, `backupID`, `primary_admin`, `locallyManaged`, `active`) VALUES
 ('tester',	1,	'',	0,	0,	1),
@@ -13309,27 +13329,11 @@ INSERT INTO `users` (`userID`, `groupID`, `backupID`, `primary_admin`, `locallyM
 ('VTRXSNELIZA',	203,	'',	0,	0,	1),
 ('VTRYZIORA',	107,	'',	0,	0,	1);
 
-DROP TABLE IF EXISTS `workflows`;
-CREATE TABLE `workflows` (
-  `workflowID` smallint(6) NOT NULL AUTO_INCREMENT,
-  `initialStepID` smallint(6) NOT NULL DEFAULT '0',
-  `description` varchar(64) NOT NULL,
-  PRIMARY KEY (`workflowID`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-INSERT INTO `workflows` (`workflowID`, `initialStepID`, `description`) VALUES
-(-2,	-4,	'Leaf Developer Console'),
-(-1,	-3,	'LEAF Secure Certification'),
-(1,	1,	'General Workflow'),
-(2,	5,	'Test Requestor Followup'),
-(3,	7,	'Service Chief'),
-(4,	8,	'Multiple person designated');
-
 DROP TABLE IF EXISTS `workflow_routes`;
 CREATE TABLE `workflow_routes` (
-  `workflowID` smallint(6) NOT NULL,
-  `stepID` smallint(6) NOT NULL,
-  `nextStepID` smallint(6) NOT NULL,
+  `workflowID` smallint NOT NULL,
+  `stepID` smallint NOT NULL,
+  `nextStepID` smallint NOT NULL,
   `actionType` varchar(50) NOT NULL,
   `displayConditional` text NOT NULL,
   UNIQUE KEY `workflowID` (`workflowID`,`stepID`,`actionType`),
@@ -13364,17 +13368,17 @@ INSERT INTO `workflow_routes` (`workflowID`, `stepID`, `nextStepID`, `actionType
 
 DROP TABLE IF EXISTS `workflow_steps`;
 CREATE TABLE `workflow_steps` (
-  `workflowID` smallint(6) NOT NULL,
-  `stepID` smallint(6) NOT NULL AUTO_INCREMENT,
+  `workflowID` smallint NOT NULL,
+  `stepID` smallint NOT NULL AUTO_INCREMENT,
   `stepTitle` varchar(64) NOT NULL,
   `stepBgColor` varchar(10) NOT NULL DEFAULT '#fffdcd',
   `stepFontColor` varchar(10) NOT NULL DEFAULT 'black',
   `stepBorder` varchar(20) NOT NULL DEFAULT '1px solid black',
   `jsSrc` varchar(128) NOT NULL,
-  `posX` smallint(6) DEFAULT NULL,
-  `posY` smallint(6) DEFAULT NULL,
-  `indicatorID_for_assigned_empUID` smallint(6) DEFAULT NULL,
-  `indicatorID_for_assigned_groupID` smallint(6) DEFAULT NULL,
+  `posX` smallint DEFAULT NULL,
+  `posY` smallint DEFAULT NULL,
+  `indicatorID_for_assigned_empUID` smallint DEFAULT NULL,
+  `indicatorID_for_assigned_groupID` smallint DEFAULT NULL,
   `requiresDigitalSignature` tinyint(1) DEFAULT NULL,
   `stepData` text,
   PRIMARY KEY (`stepID`),
@@ -13394,3 +13398,20 @@ INSERT INTO `workflow_steps` (`workflowID`, `stepID`, `stepTitle`, `stepBgColor`
 (3,	7,	'Service Chief',	'#fffdcd',	'black',	'1px solid black',	'',	625,	135,	NULL,	NULL,	NULL,	NULL),
 (4,	8,	'Reviewer 1',	'#fffdcd',	'black',	'1px solid black',	'',	526,	147,	14,	NULL,	NULL,	NULL),
 (4,	9,	'Reviewer 2',	'#fffdcd',	'black',	'1px solid black',	'',	530,	242,	15,	NULL,	NULL,	NULL);
+
+DROP TABLE IF EXISTS `workflows`;
+CREATE TABLE `workflows` (
+  `workflowID` smallint NOT NULL AUTO_INCREMENT,
+  `initialStepID` smallint NOT NULL DEFAULT '0',
+  `description` varchar(64) NOT NULL,
+  PRIMARY KEY (`workflowID`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+INSERT INTO `workflows` (`workflowID`, `initialStepID`, `description`) VALUES
+(-2,	-4,	'Leaf Developer Console'),
+(-1,	-3,	'LEAF Secure Certification'),
+(1,	1,	'General Workflow'),
+(2,	5,	'Test Requestor Followup'),
+(3,	7,	'Service Chief'),
+(4,	8,	'Multiple person designated');
+

--- a/x-test/API-tests/dbsetup_test.go
+++ b/x-test/API-tests/dbsetup_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log"
 	"os"
+	"strings"
 )
 
 var origPortalDbName, origNexusDbName string
@@ -80,9 +81,15 @@ func setupTestDB() {
 		testNexusDbName)
 }
 
+func updateTestDBSchema() {
+	res, _ := httpGet(RootURL + `scripts/updateDatabase.php`)
+	if strings.Contains(res, `Db Update failed`) {
+		log.Fatal(`Could not update database schema: ` + res)
+	}
+}
+
 // teardownTestDB reroutes the standard LEAF dev environment back to the original configuration
 func teardownTestDB() {
-	// Setup test database
 	db, err := sql.Open("mysql", mysqlDSN)
 	if err != nil {
 		log.Fatal("Can't connect to database: ", err.Error())

--- a/x-test/API-tests/employee_test.go
+++ b/x-test/API-tests/employee_test.go
@@ -39,7 +39,7 @@ func postEmployee(postUrl string, data Employee) (string, error) {
 	postData.Set("firstName", data.FirstName)
 	postData.Set("lastName", data.LastName)
 	postData.Set("userName", data.UserName)
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 
 	// Send POST request
 	res, err := client.PostForm(postUrl, postData)
@@ -61,7 +61,7 @@ func postEmployee(postUrl string, data Employee) (string, error) {
 func disableEmployee(postUrl string) error {
 
 	data := url.Values{}
-	data.Set("CSRFToken", csrfToken)
+	data.Set("CSRFToken", CsrfToken)
 
 	req, err := http.NewRequest("DELETE", postUrl, strings.NewReader(data.Encode()))
 
@@ -100,7 +100,7 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 		UserName:  "testuser",
 	}
 
-	employeeId, err := postEmployee(natOrgURL+`api/employee/new`, m)
+	employeeId, err := postEmployee(NationalOrgchartURL+`api/employee/new`, m)
 
 	if err != nil {
 		t.Error(err)
@@ -110,7 +110,7 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 		t.Error("no user id returned")
 	}
 
-	employeeId, err = postEmployee(orgURL+`api/employee/new`, m)
+	employeeId, err = postEmployee(RootOrgchartURL+`api/employee/new`, m)
 
 	if err != nil {
 		t.Error(err)
@@ -123,7 +123,7 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 	var localEmployeeKey string
 	var natEmployeeKey string
 
-	natEmpoyeeRes, err := getEmployee(natOrgURL + `api/employee/search?q=username:testuser`)
+	natEmpoyeeRes, err := getEmployee(NationalOrgchartURL + `api/employee/search?q=username:testuser`)
 
 	if err != nil {
 		t.Error(err)
@@ -134,7 +134,7 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 		break
 	}
 
-	localEmployeeRes, _ := getEmployee(orgURL + `api/employee/search?q=username:testuser`)
+	localEmployeeRes, _ := getEmployee(RootOrgchartURL + `api/employee/search?q=username:testuser`)
 	for key := range localEmployeeRes {
 		localEmployeeKey = key
 		break
@@ -153,13 +153,13 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 	}
 
 	// delete remote employee
-	err = disableEmployee(fmt.Sprintf("%sapi/employee/%s", natOrgURL, natEmployeeKey))
+	err = disableEmployee(fmt.Sprintf("%sapi/employee/%s", NationalOrgchartURL, natEmployeeKey))
 	if err != nil {
 		t.Error(err)
 	}
 
 	// make sure the national is disabled
-	res, _ := getEmployee(natOrgURL + `api/employee/search?q=username:testuser`)
+	res, _ := getEmployee(NationalOrgchartURL + `api/employee/search?q=username:testuser`)
 
 	gotId := fmt.Sprintf("%d", res[natEmployeeKey].EmployeeId)
 	wantId := natEmployeeKey
@@ -168,7 +168,7 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 	}
 
 	// make sure the local is not disabled
-	res, _ = getEmployee(orgURL + `api/employee/search?q=username:testuser`)
+	res, _ = getEmployee(RootOrgchartURL + `api/employee/search?q=username:testuser`)
 
 	gotId = fmt.Sprintf("%d", res[localEmployeeKey].EmployeeId)
 	wantId = localEmployeeKey
@@ -177,20 +177,20 @@ func TestEmployee_CheckNationalEmployee(t *testing.T) {
 	}
 
 	// run script again, make sure it deletes locally
-	err = updateEmployees(orgURL + `scripts/refreshOrgchartEmployees.php`)
+	err = updateEmployees(RootOrgchartURL + `scripts/refreshOrgchartEmployees.php`)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// make sure the national entry was deleted
-	res, _ = getEmployee(natOrgURL + `api/employee/search?q=username:testuser`)
+	res, _ = getEmployee(NationalOrgchartURL + `api/employee/search?q=username:testuser`)
 
 	if len(res) > 0 {
 		t.Error("User Exists on national")
 	}
 
 	// make sure the local has been deleted.
-	res, _ = getEmployee(orgURL + `api/employee/search?q=username:testuser`)
+	res, _ = getEmployee(RootOrgchartURL + `api/employee/search?q=username:testuser`)
 
 	if len(res) > 0 {
 		t.Error("User Exists on local")

--- a/x-test/API-tests/formQuery_test.go
+++ b/x-test/API-tests/formQuery_test.go
@@ -19,7 +19,7 @@ func getFormQuery(url string) (FormQueryResponse, error) {
 }
 
 func TestFormQuery_HomepageQuery(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"title","operator":"LIKE","match":"***","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"title","operator":"LIKE","match":"***","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
 
 	// get first key
 	var key int
@@ -37,7 +37,7 @@ func TestFormQuery_HomepageQuery(t *testing.T) {
 }
 
 func TestFormQuery_NonadminQuery(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"stepID","operator":"!=","match":"resolved","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service"],"sort":{},"limit":1000,"limitOffset":0}&x-filterData=recordID,title&masquerade=nonAdmin`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"stepID","operator":"!=","match":"resolved","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service"],"sort":{},"limit":1000,"limitOffset":0}&x-filterData=recordID,title&masquerade=nonAdmin`)
 
 	if _, exists := res[958]; exists {
 		t.Errorf("Record 958 should not be readable")
@@ -49,7 +49,7 @@ func TestFormQuery_NonadminQuery(t *testing.T) {
 }
 
 func TestFormQuery_NonadminQueryActionable(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"stepID","operator":"=","match":"actionable","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service"],"sort":{},"limit":1000,"limitOffset":0}&x-filterData=recordID,title&masquerade=nonAdmin`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"stepID","operator":"=","match":"actionable","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service"],"sort":{},"limit":1000,"limitOffset":0}&x-filterData=recordID,title&masquerade=nonAdmin`)
 
 	if _, exists := res[503]; !exists {
 		t.Errorf("Record 503 should be actionable because tester is backup of person designated")
@@ -77,7 +77,7 @@ func TestFormQuery_NonadminQueryActionable(t *testing.T) {
 }
 
 func TestFormQuery_FulltextSearch_ApplePearOrange(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"data","indicatorID":"3","operator":"MATCH","match":"apple pear orange","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"data","indicatorID":"3","operator":"MATCH","match":"apple pear orange","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
 
 	if _, exists := res[499]; !exists {
 		t.Errorf(`Record 499 should exist because a data field contains either apple, pear, or orange`)
@@ -89,7 +89,7 @@ func TestFormQuery_FulltextSearch_ApplePearOrange(t *testing.T) {
 }
 
 func TestFormQuery_FulltextSearch_ApplePear_RequireOrange(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"data","indicatorID":"3","operator":"MATCH","match":"apple pear %2Borange","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"data","indicatorID":"3","operator":"MATCH","match":"apple pear %2Borange","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
 
 	if _, exists := res[499]; !exists {
 		t.Errorf(`Record 499 should exist because a data field contains the word "orange"`)
@@ -101,7 +101,7 @@ func TestFormQuery_FulltextSearch_ApplePear_RequireOrange(t *testing.T) {
 }
 
 func TestFormQuery_FulltextSearch_ApplePearNoOrange(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"data","indicatorID":"3","operator":"MATCH","match":"apple pear %2Dorange","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"data","indicatorID":"3","operator":"MATCH","match":"apple pear %2Dorange","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
 
 	if _, exists := res[499]; exists {
 		t.Errorf(`Record 499 should not exist because data fields contain the word "orange". want = no orange`)
@@ -113,7 +113,7 @@ func TestFormQuery_FulltextSearch_ApplePearNoOrange(t *testing.T) {
 }
 
 func TestFormQuery_RecordIdAndFulltext(t *testing.T) {
-	res, _ := getFormQuery(rootURL + `api/form/query?q={"terms":[{"id":"recordID","operator":"=","match":"499","gate":"AND"},{"id":"data","indicatorID":"0","operator":"MATCH ALL","match":"apple","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"recordID","operator":"=","match":"499","gate":"AND"},{"id":"data","indicatorID":"0","operator":"MATCH ALL","match":"apple","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
 
 	if _, exists := res[499]; !exists {
 		t.Errorf(`Record 499 should exist because the data fields contain the word "apple". want = recordID IS 499 AND data contains apple`)

--- a/x-test/API-tests/formStack_test.go
+++ b/x-test/API-tests/formStack_test.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"encoding/json"
-	"net/url"
 	"io"
 	"log"
-	"testing"
+	"net/url"
 	"strconv"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestFormStack_Version(t *testing.T) {
-	got, _ := httpGet(rootURL + "api/formStack/version")
+	got, _ := httpGet(RootURL + "api/formStack/version")
 	want := `"1"`
 
 	if !cmp.Equal(got, want) {
@@ -22,12 +22,12 @@ func TestFormStack_Version(t *testing.T) {
 
 func postNewForm() string {
 	postData := url.Values{}
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("name", "Test New Form")
 	postData.Set("description", "Test New Form Description")
 	postData.Set("parentID", "")
 
-	res, _ := client.PostForm(rootURL+`api/formEditor/new`, postData)
+	res, _ := client.PostForm(RootURL+`api/formEditor/new`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)
 
 	var c string
@@ -51,7 +51,6 @@ func getFormStack(url string) FormStackResponse {
 	return m
 }
 
-
 func TestFormStack_NewFormProperties(t *testing.T) {
 	catID := postNewForm()
 
@@ -61,7 +60,7 @@ func TestFormStack_NewFormProperties(t *testing.T) {
 		t.Errorf("new form return value length, got = %v, want = %v", gotLen, wantLen)
 	}
 
-	res := getFormStack(rootURL + `api/formStack/categoryList/all`)
+	res := getFormStack(RootURL + `api/formStack/categoryList/all`)
 
 	categoryTable := map[string]*FormStackCategory{}
 	for _, v := range res {
@@ -70,7 +69,7 @@ func TestFormStack_NewFormProperties(t *testing.T) {
 	}
 
 	category := categoryTable[catID]
-	if(category == nil) {
+	if category == nil {
 		t.Errorf("New Form not found in table")
 		return
 	}

--- a/x-test/API-tests/form_test.go
+++ b/x-test/API-tests/form_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestForm_Version(t *testing.T) {
-	got, _ := httpGet(rootURL + "api/form/version")
+	got, _ := httpGet(RootURL + "api/form/version")
 	want := `"1"`
 
 	if !cmp.Equal(got, want) {
@@ -19,10 +19,10 @@ func TestForm_Version(t *testing.T) {
 
 func TestForm_AdminCanEditData(t *testing.T) {
 	postData := url.Values{}
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("3", "12345")
 
-	res, _ := client.PostForm(rootURL+`api/form/505`, postData)
+	res, _ := client.PostForm(RootURL+`api/form/505`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)
 	got := string(bodyBytes)
 	want := `"1"`
@@ -34,10 +34,10 @@ func TestForm_AdminCanEditData(t *testing.T) {
 
 func TestForm_NonadminCannotEditData(t *testing.T) {
 	postData := url.Values{}
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("3", "12345")
 
-	res, _ := client.PostForm(rootURL+`api/form/505?masquerade=nonAdmin`, postData)
+	res, _ := client.PostForm(RootURL+`api/form/505?masquerade=nonAdmin`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)
 	got := string(bodyBytes)
 	want := `"0"`
@@ -48,7 +48,7 @@ func TestForm_NonadminCannotEditData(t *testing.T) {
 }
 
 func TestForm_NeedToKnowDataReadAccess(t *testing.T) {
-	got, res := httpGet(rootURL + "api/form/505/data?masquerade=nonAdmin")
+	got, res := httpGet(RootURL + "api/form/505/data?masquerade=nonAdmin")
 	if !cmp.Equal(res.StatusCode, 200) {
 		t.Errorf("./api/form/505/data?masquerade=nonAdmin Status Code = %v, want = %v", res.StatusCode, 200)
 	}
@@ -60,10 +60,10 @@ func TestForm_NeedToKnowDataReadAccess(t *testing.T) {
 
 func TestForm_RequestFollowupAllowCaseInsensitiveUserID(t *testing.T) {
 	postData := url.Values{}
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("3", "12345")
 
-	res, _ := client.PostForm(rootURL+`api/form/7?masquerade=nonAdmin`, postData)
+	res, _ := client.PostForm(RootURL+`api/form/7?masquerade=nonAdmin`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)
 	got := string(bodyBytes)
 	want := `"1"`
@@ -74,7 +74,7 @@ func TestForm_RequestFollowupAllowCaseInsensitiveUserID(t *testing.T) {
 }
 
 func TestForm_WorkflowIndicatorAssigned(t *testing.T) {
-	got, res := httpGet(rootURL + "api/form/508/workflow/indicator/assigned")
+	got, res := httpGet(RootURL + "api/form/508/workflow/indicator/assigned")
 
 	if !cmp.Equal(res.StatusCode, 200) {
 		t.Errorf("./api/form/508/workflow/indicator/assigned Status Code = %v, want = %v", res.StatusCode, 200)

--- a/x-test/API-tests/hotspot_benchmarks_test.go
+++ b/x-test/API-tests/hotspot_benchmarks_test.go
@@ -6,12 +6,12 @@ import (
 
 func BenchmarkHomepage_defaultQuery(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		httpGet(rootURL + `api/form/query?q={"terms":[{"id":"title","operator":"LIKE","match":"***","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+		httpGet(RootURL + `api/form/query?q={"terms":[{"id":"title","operator":"LIKE","match":"***","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
 	}
 }
 
 func BenchmarkInbox_nonAdminActionable(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		httpGet(rootURL + `api/form/query?q={"terms":[{"id":"stepID","operator":"=","match":"actionable","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service"],"sort":{},"limit":1000,"limitOffset":0}&x-filterData=recordID,title&masquerade=nonAdmin`)
+		httpGet(RootURL + `api/form/query?q={"terms":[{"id":"stepID","operator":"=","match":"actionable","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service"],"sort":{},"limit":1000,"limitOffset":0}&x-filterData=recordID,title&masquerade=nonAdmin`)
 	}
 }

--- a/x-test/API-tests/main_test.go
+++ b/x-test/API-tests/main_test.go
@@ -14,16 +14,17 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-var rootURL = "https://host.docker.internal/LEAF_Request_Portal/"
-var natOrgURL = "https://host.docker.internal/LEAF_NationalNexus/"
-var orgURL = "https://host.docker.internal/LEAF_Nexus/"
+const RootURL = "https://host.docker.internal/LEAF_Request_Portal/"
+const NationalOrgchartURL = "https://host.docker.internal/LEAF_NationalNexus/"
+const RootOrgchartURL = "https://host.docker.internal/LEAF_Nexus/"
+
 var dbHost = "leaf-mysql"
 var dbUsername = os.Getenv("MYSQL_USER")
 var dbPassword = os.Getenv("MYSQL_PASSWORD")
 var testPortalDbName = "leaf_portal_API_testing"
 var testNexusDbName = "leaf_users_API_testing"
 
-var csrfToken string
+var CsrfToken string
 
 var tr = &http.Transport{
 	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -38,10 +39,9 @@ var client = &http.Client{
 
 // TestMain performs initial setup and logs into the dev environment.
 // In dev, the current username is set via REMOTE_USER docker environment
-// Tests must not trigger Fatal. See teardownTestDB()
 func TestMain(m *testing.M) {
 
-	req, _ := http.NewRequest("GET", rootURL, nil)
+	req, _ := http.NewRequest("GET", RootURL, nil)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36 Edg/118.0.2088.46")
 	res, err := client.Do(req)
 	if err != nil {
@@ -56,9 +56,11 @@ func TestMain(m *testing.M) {
 
 	startIdx := strings.Index(body, "var CSRFToken = '") + 17
 	endIdx := strings.Index(body[startIdx:], "';")
-	csrfToken = body[startIdx : startIdx+endIdx]
+	CsrfToken = body[startIdx : startIdx+endIdx]
 
 	setupTestDB()
+
+	updateTestDBSchema()
 
 	code := m.Run()
 

--- a/x-test/API-tests/service_test.go
+++ b/x-test/API-tests/service_test.go
@@ -38,8 +38,8 @@ func getQuad(url string) QuadResponse {
 }
 
 func TestService_getMembers(t *testing.T) {
-	quads := getQuad(rootURL + `api/service/quadrads`)
-	members := getService(rootURL + `api/service/members`)
+	quads := getQuad(RootURL + `api/service/quadrads`)
+	members := getService(RootURL + `api/service/members`)
 
 	count := len(members)
 	retrieved := 28


### PR DESCRIPTION
This modifies the response for `api/formWorkflow/[digit]/apply` by replacing the returned "status" property with HTTP status codes, which improves interoperability in custom implementations.

Also:
- Adds automated tests for common error conditions
- Updates verbiage for incomplete workflow
- Changes in API test framework:
  - Modifies the names for some global variables
  - Now automatically runs DB schema updates (updateDatabase.php)
  - Updated the base test DB with the latest schema

### Potential Impact
- This can potentially break existing custom pages that use `api/formWorkflow/[digit]/apply`. Custom code must be scanned to determine whether they use the now-removed "status" property. Note that the reference implementation within `workflow.js` did not use it.

### Testing
- [ ] Automated tests pass
- [ ] Workflow actions function normally
