### PR TITLE
LEAF 4327 fix show all fields display bug

### DIFF
--- a/LEAF_Nexus/templates/print_subindicators.tpl
+++ b/LEAF_Nexus/templates/print_subindicators.tpl
@@ -83,7 +83,7 @@
     }
     function showAllFields() {
         $('.printformblock').css('display', 'inline');
-        $('.notrequired').css('display', 'inline');
+        $('.notrequired:not(#tools button.options)').css('display', 'inline');
         $('.tempText').css('display', 'none');
     }
 </script>

--- a/LEAF_Nexus/templates/view_employee.tpl
+++ b/LEAF_Nexus/templates/view_employee.tpl
@@ -110,9 +110,9 @@ function refreshEmp(userName) {
                 dialog_ok.setSaveHandler(function() {
                     dialog_ok.clearDialog();
                     dialog_ok.hide();
-                    $("#enable_account_<!--{$empUID}-->").removeClass('notrequired');
-                    $("#disable_account_<!--{$empUID}-->").addClass('notrequired');
-                    $("#disabled_label").removeClass('notrequired');
+                    $("#enable_account_<!--{$empUID}-->").show();
+                    $("#disable_account_<!--{$empUID}-->").hide();
+                    $("#disabled_label").show();
                 });
                 dialog_ok.show();
             }
@@ -251,9 +251,9 @@ function disableAccount(backupEmpUID) {
             success: function(response) {
                 confirm_dialog.hide();
                 if(response == true) {
-                    $("#enable_account_<!--{$empUID}-->").removeClass('notrequired');
-                    $("#disable_account_<!--{$empUID}-->").addClass('notrequired');
-                    $("#disabled_label").removeClass('notrequired');
+                    $("#enable_account_<!--{$empUID}-->").show();
+                    $("#disable_account_<!--{$empUID}-->").hide();
+                    $("#disabled_label").show();
                     alert('The account has been disabled.');
 
                     //window.location.reload();
@@ -279,9 +279,9 @@ function enableAccount(backupEmpUID) {
             success: function(response) {
                 confirm_dialog.hide();
                 if(response == true) {
-                    $("#enable_account_<!--{$empUID}-->").addClass('notrequired');
-                    $("#disable_account_<!--{$empUID}-->").removeClass('notrequired');
-                    $("#disabled_label").addClass('notrequired');
+                    $("#enable_account_<!--{$empUID}-->").hide();
+                    $("#disable_account_<!--{$empUID}-->").show();
+                    $("#disabled_label").hide();
                     alert('The account has been enabled.');
                     //window.location.reload();
                 }
@@ -306,7 +306,9 @@ $(function() {
         url: "ajaxEmployee.php?a=getForm&empUID=<!--{$empUID}-->",
         success: function(response) {
             if(response != '') {
-                $('#employeeName').html('<!--{$summary.employee.firstName|escape}--> <!--{$summary.employee.lastName|escape}--> <span id="disabled_label" class="<!--{if $summary.employee.deleted == 0}-->notrequired<!--{/if}-->">(Disabled account)</span>');
+                const content = '<!--{$summary.employee.firstName|escape}--> <!--{$summary.employee.lastName|escape}-->' +
+                 ' <span id="disabled_label" <!--{if $summary.employee.deleted == 0}-->style="display: none;"<!--{/if}-->">(Disabled account)</span>';
+                $('#employeeName').html(content);
                 $('#employeeAccount').html("<!--{$summary.employee.userName}-->");
                 $('#employeeBody').html(response);
             }


### PR DESCRIPTION
Fixes a display issue in Nexus view_employee page that would cause 'disabled account' and both enable and disable menu buttons to incorrectly display when 'show all fields' was activated.

Testing / Impact
Specific to the Nexus view_employee template (employee page)

-Clicking 'Show all fields' should not cause 'disabled account' or extra buttons to show.
-Page should remain reactive/responsive to account status changes.
-Confirm that label/buttons reflect actual account status.
