### PR TITLE
LEAF 4342 fix comment note overflow

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -945,6 +945,7 @@ div[id*="xhrDialog"] {
 .comments_message {
   margin-left: 20px;
   padding-top: 4px;
+  word-break: break-word;
 }
 
 .tools {


### PR DESCRIPTION
Adds a style to prevent request notes from overflowing the note container.

Testing / Impact

Form request, side notes.  Add a note with long text (eg request URL).
Text should wrap if needed.