### PR TITLE
LEAF-4346 - formSearch.js cleanup

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -944,8 +944,8 @@ var LeafFormSearch = function (containerID) {
                 $(`#${prefixID}widgetCod_${widgetID}`).on("change", checkDateStatus);
                 url =
                     rootURL === ""
-                        ? "./api/workflow/steps"
-                        : rootURL + "api/workflow/steps";
+                        ? "./api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description"
+                        : rootURL + "api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description";
                 if(cache['api/workflow/steps'] == undefined) {
                     await $.ajax({
                         type: "GET",

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -953,6 +953,8 @@ var LeafFormSearch = function (containerID) {
                             res = res.filter(step => step.workflowID > 0);
                         }
                         return res;
+                    }).catch(error => {
+                        console.error(error);
                     });
                 }
                 let allStepsData = await cache['api/workflow/steps'];
@@ -962,7 +964,7 @@ var LeafFormSearch = function (containerID) {
                                     <option value="resolved" selected>Resolved</option>
                                     <option value="actionable">Actionable by me</option>`;
                 //categories += '<option value="destruction">Scheduled for Destruction</option>';
-                for (var i in allStepsData) {
+                for (let i in allStepsData) {
                     categories += `<option value="${allStepsData[i].stepID}">${allStepsData[i].description}: ${allStepsData[i].stepTitle}</option>`;
                 }
                 categories += "</select>";

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -946,14 +946,13 @@ var LeafFormSearch = function (containerID) {
                     cache['api/workflow/steps'] = $.ajax({
                         type: "GET",
                         url,
-                        dataType: "json",
-                        success: function (res) {
-                            // Hide standard workflows unless the GET parameter "dev" exists
-                            if(new URLSearchParams(window.location.search).get('dev') == null) {
-                                res = res.filter(step => step.workflowID > 0);
-                            }
-                            return res;
+                        dataType: "json"
+                    }).then(res => {
+                        // Hide standard workflows unless the GET parameter "dev" exists
+                        if(new URLSearchParams(window.location.search).get('dev') == null) {
+                            res = res.filter(step => step.workflowID > 0);
                         }
+                        return res;
                     });
                 }
                 let allStepsData = await cache['api/workflow/steps'];

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -199,11 +199,6 @@ var LeafFormSearch = function (containerID) {
      * prevQuery - optional JSON object
      */
     function renderPreviousAdvancedSearch(prevQuery) {
-        if(!openedAdvancedSearch) {
-            openedAdvancedSearch = true;
-            newSearchWidget();
-        }
-
         var isJSON = true;
         var advSearch = {};
         try {

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -279,6 +279,7 @@ var LeafFormSearch = function (containerID) {
                     renderWidget(i);
                 }
                 $("#" + prefixID + "widgetCod_" + i).val(advSearch[i].operator);
+                $("#" + prefixID + "widgetCod_" + i).trigger("chosen:updated");
                 if (typeof advSearch[i].match == "string" && advSearch[i].operator.indexOf('MATCH') == -1) {
                     $("#" + prefixID + "widgetMat_" + i).val(
                         advSearch[i].match.replace(/\*/g, "")
@@ -942,7 +943,7 @@ var LeafFormSearch = function (containerID) {
                         ? "./api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description"
                         : rootURL + "api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description";
                 if(cache['api/workflow/steps'] == undefined) {
-                    await $.ajax({
+                    cache['api/workflow/steps'] = $.ajax({
                         type: "GET",
                         url,
                         dataType: "json",
@@ -951,11 +952,11 @@ var LeafFormSearch = function (containerID) {
                             if(new URLSearchParams(window.location.search).get('dev') == null) {
                                 res = res.filter(step => step.workflowID > 0);
                             }
-                            cache['api/workflow/steps'] = res;
+                            return res;
                         }
                     });
                 }
-                let allStepsData = cache['api/workflow/steps'];
+                let allStepsData = await cache['api/workflow/steps'];
                 let categories = `<select id="${prefixID}widgetMat_${widgetID}" class="chosen" aria-label="stepID" style="width: 250px">
                                     <option value="submitted">Submitted</option>
                                     <option value="deleted">Cancelled</option>
@@ -975,7 +976,6 @@ var LeafFormSearch = function (containerID) {
                     );
                 }
 
-                chosenOptions();
                 if (callback != undefined) {
                     callback();
                 }

--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
@@ -748,6 +748,7 @@ async function main() {
     });
     leafSearch.search('');
     leafSearch.init();
+    document.querySelector('#' + leafSearch.getPrefixID() + 'advancedSearchButton').click();
 
     if(userQuery.terms == undefined) {
         getDataBuildCharts(categoryID);
@@ -768,10 +769,9 @@ async function main() {
         }
         leafSearch.renderPreviousAdvancedSearch(userQuery.terms);
     }
-    
+
     document.querySelector('#btn_addFilter').addEventListener('click', function() {
     	dialog_message.show();
-        document.querySelector('#' + leafSearch.getPrefixID() + 'advancedSearchButton').click();
     });
     
 }

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -566,7 +566,7 @@ function loadSearchPrereqs() {
 
             $.ajax({
                 type: 'GET',
-                url: './api/workflow/steps',
+                url: './api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description',
                 dataType: 'json',
                 success: function(res) {
                     let allStepsData = res;


### PR DESCRIPTION
This resolves a few edge-cases related to the formSearch widget.

Additionally, this hides references to built-in forms behind the "dev" GET parameter to reduce clutter.

Steps to reproduce Issue 1:
1. Open the Data Visualizer
2. Select a form
3. Click on `Edit Filter`
4. Add a filter for `Date Submitted...` (can be anything)
5. Click on `Apply Filters`
6. Click on `Edit Filter` 
7. Note that excess search options are incorrectly included

Steps to reproduce Issue 2:
1. On the homepage in the search area, click on `Advanced Options`
2. Change the search term to `Record ID`
3. Change the search term back to `Current Status`
4. Note that the dropdown of status options is missing

Steps to reproduce Issue 3:
1. Open the Report Builder
2. Note that every time you click on `And...`, a network transaction is incorrectly made

Steps to reproduce Issue 4:
1. Open the Homepage (with a cleared search bar)
2. Note that there is an unnecessary network request to `api/workflow/steps`

### Potential Impact
- Everywhere formSearch.js is used, such as the Homepage and Report Builder Step 1

### Testing
- [ ] The issues outlined above cannot be reproduced
- [ ] Homepage search options are recalled correctly through page refreshes
- [ ] Report Builder -> Modify Search -> Search options are recalled correctly
- [ ] On the Homepage search when "Current Status" is selected, there is no reference to "Leaf Developer Console".