### PR TITLE
LEAF-4345 - Update rules for cancelling requests

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -220,15 +220,6 @@ switch ($action) {
         }
 
         break;
-    case 'cancel':
-        /* This endpoint has been deprecated as of 8/31/2023 */
-        if (is_numeric($_POST['cancel']))
-        {
-            $form = new Portal\Form($db, $login);
-            echo $form->deleteRecord((int)$_POST['cancel']);
-        }
-
-        break;
     case 'restore':
         if (is_numeric($_POST['restore']))
         {

--- a/LEAF_Request_Portal/api/controllers/FormController.php
+++ b/LEAF_Request_Portal/api/controllers/FormController.php
@@ -258,10 +258,6 @@ class FormController extends RESTfulResponse
             return $form->cancelRecord((int)$args[0], $_POST['comment']);
         });
 
-        $this->index['POST']->register('form/[digit]/delete', function ($args) use ($form) {
-            return $form->permanentlyDeleteRecord((int)$args[0]);
-        });
-
         $this->index['POST']->register('form/[digit]/reminder/[digit]', function ($args) use ($form) {
             return $form->sendReminderEmail((int)$args[0], (int)$args[1]);
         });

--- a/LEAF_Request_Portal/api/controllers/FormController.php
+++ b/LEAF_Request_Portal/api/controllers/FormController.php
@@ -255,7 +255,7 @@ class FormController extends RESTfulResponse
         });
 
         $this->index['POST']->register('form/[digit]/cancel', function ($args) use ($form) {
-            return $form->deleteRecord((int)$args[0], $_POST['comment']);
+            return $form->cancelRecord((int)$args[0], $_POST['comment']);
         });
 
         $this->index['POST']->register('form/[digit]/delete', function ($args) use ($form) {

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -4384,6 +4384,9 @@ class Form
     }
 
     public function permanentlyDeleteRecord($recordID) {
+        if(!$this->login->checkGroup(1)) {
+            return 0;
+        }
         /*if ($_POST['CSRFToken'] != $_SESSION['CSRFToken']) {
             return 0;
         }*/

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -769,76 +769,66 @@ class Form
     }
 
     /**
+     * cancelRecord marks a record as cancelled.
+     * 
+     * Only admins should be able to cancel submitted records.
+     * 
      * @param int $recordID
      * @param string $comment
      *
-     * @return int|string
-     *
-     * Created at: 8/24/2023, 2:15:39 PM (America/New_York)
+     * @return int|string Return 1 on success, error string on failure
      */
-    public function deleteRecord(int $recordID, ?string $comment = ''): int|string
+    public function cancelRecord(int $recordID, ?string $comment = ''): int|string
     {
-        if ($_POST['CSRFToken'] != $_SESSION['CSRFToken']) {
-            $return_value = 0;
-        } elseif (!$this->hasWriteAccess($recordID)) {
-            $return_value = 'Please contact your administrator to cancel this request to help avoid confusion in the process.';
-        } else {
-            // only allow admins to delete resolved requests
-            $vars = array(':recordID' => $recordID);
-            $sql = 'SELECT `recordID`, `submitted`, `stepID`
+        $return_value = 'Please contact your administrator';
+
+        $vars = array(':recordID' => $recordID);
+        $sql = 'SELECT `submitted`
                     FROM `records`
-                    LEFT JOIN `records_workflow_state` USING (`recordID`)
-                    WHERE `recordID` = :recordID
-                    AND `submitted` > 0';
+                    WHERE `recordID` = :recordID';
+        $resIsSubmitted = $this->db->prepared_query($sql, $vars);
+
+        if ($resIsSubmitted[0]['submitted'] != 0 && !$this->login->checkGroup(1)) {
+            $return_value = 'To help avoid confusion in the process, Please contact your administrator to cancel this request.';
+        } else if ($this->hasWriteAccess($recordID)) {
+            $vars = array(':recordID' => $recordID,
+                        ':time' => time());
+            $sql = 'UPDATE `records`
+                    SET `deleted` = :time
+                    WHERE `recordID` = :recordID';
 
             $res = $this->db->prepared_query($sql, $vars);
 
-            if (
-                isset($res[0])
-                && $res[0]['stepID'] == null
-                && !$this->login->checkGroup(1)
-            ) {
-                $return_value = 'Cannot cancel resolved request.';
-            } else {
-                $vars = array(':recordID' => $recordID,
-                            ':time' => time());
-                $sql = 'UPDATE `records`
-                        SET `deleted` = :time
-                        WHERE `recordID` = :recordID';
+            // actionID 4 = delete
+            $vars = array(':recordID' => $recordID,
+                        ':userID' => $this->login->getUserID(),
+                        ':dependencyID' => 0,
+                        ':actionType' => 'deleted',
+                        ':actionTypeID' => 4,
+                        ':time' => time(),
+                        ':comment' => XSSHelpers::xscrub($comment));
+            $sql = 'INSERT INTO `action_history`
+                        (`recordID`, `userID`, `dependencyID`, `actionType`, `actionTypeID`, `time`, `comment`)
+                    VALUES
+                        (:recordID, :userID, :dependencyID, :actionType, :actionTypeID, :time, :comment)';
 
-                $res = $this->db->prepared_query($sql, $vars);
+            $res = $this->db->prepared_query($sql, $vars);
 
-                // actionID 4 = delete
-                $vars = array(':recordID' => $recordID,
-                            ':userID' => $this->login->getUserID(),
-                            ':dependencyID' => 0,
-                            ':actionType' => 'deleted',
-                            ':actionTypeID' => 4,
-                            ':time' => time(),
-                            ':comment' => XSSHelpers::xscrub($comment));
-                $sql = 'INSERT INTO `action_history`
-                            (`recordID`, `userID`, `dependencyID`, `actionType`, `actionTypeID`, `time`, `comment`)
-                        VALUES
-                            (:recordID, :userID, :dependencyID, :actionType, :actionTypeID, :time, :comment)';
+            // delete state
+            $vars = array(':recordID' => $recordID);
+            $sql = 'DELETE
+                    FROM `records_workflow_state`
+                    WHERE `recordID` = :recordID';
 
-                $res = $this->db->prepared_query($sql, $vars);
+            $this->db->prepared_query($sql, $vars);
 
-                // delete state
-                $vars = array(':recordID' => $recordID);
-                $sql = 'DELETE
-                        FROM `records_workflow_state`
-                        WHERE `recordID` = :recordID';
+            // delete tags
+            $vars = array(':recordID' => $recordID);
+            $sql = 'DELETE
+                    FROM `tags`
+                    WHERE `recordID` = :recordID';
 
-                $this->db->prepared_query($sql, $vars);
-
-                // delete tags
-                $vars = array(':recordID' => $recordID);
-                $sql = 'DELETE
-                        FROM `tags`
-                        WHERE `recordID` = :recordID';
-
-                $res = $this->db->prepared_query($sql, $vars);
-            }
+            $res = $this->db->prepared_query($sql, $vars);
 
             $return_value = 1;
         }


### PR DESCRIPTION
The only situations when a record can be cancelled:
- If you are the author of the record and it has not been submitted
- If you are an admin

Added automated tests.

### Potential Impact
- This changes previous rules about who can cancel records. The community should be notified about this change.

### Testing
- [ ] Automated tests pass
