### PR TITLE
LEAF-4349 - Query step actions

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -709,10 +709,10 @@ var LeafFormSearch = function (containerID) {
 
     // getWorkflowStepActions retrieves data to support stepAction queries
     async function getWorkflowStepActions(workflowID) {
-        url =
-        rootURL === ""
-            ? `./api/workflow/${workflowID}/route?x-filterData=workflowID,stepID,actionType,actionTextPasttense`
-            : rootURL + `api/workflow/${workflowID}/route?x-filterData=workflowID,stepID,actionType,actionTextPasttense`;
+        let url = `./api/workflow/${workflowID}/route?x-filterData=workflowID,stepID,actionType,actionTextPasttense`;
+        if(rootURL != '') {
+            url = rootURL + `api/workflow/${workflowID}/route?x-filterData=workflowID,stepID,actionType,actionTextPasttense`;
+        }
         if(cache[`api/workflow/${workflowID}/route`] == undefined) {
             cache[`api/workflow/${workflowID}/route`] = $.ajax({
                 type: "GET",
@@ -1517,7 +1517,7 @@ var LeafFormSearch = function (containerID) {
                                 res = res.filter(step => step.workflowID > 0);
                             }
                             return res;
-                        });
+                        }).catch(err => console.error(err));
                     }
 
                     let workflowStepsData = await cache['api/workflow/steps'];

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -222,7 +222,8 @@ var LeafFormSearch = function (containerID) {
                     advSearch[i].indicatorID != undefined ||
                     advSearch[i].id == "serviceID" ||
                     advSearch[i].id == "categoryID" ||
-                    advSearch[i].id == "stepID"
+                    advSearch[i].id == "stepID" ||
+                    advSearch[i].id == "stepAction"
                 ) {
                     renderWidget(
                         i,
@@ -690,6 +691,50 @@ var LeafFormSearch = function (containerID) {
         }
     }
 
+    // getStepActionOptions retrieves data to support stepAction queries
+    async function getStepActionOptions(stepWorkflowIdx, widgetID) {
+        let stepID = $("#" + prefixID + "widgetIndicator_" + widgetID).val();
+        let options = '';
+        if(stepID != '') {
+            let actions = (await getWorkflowStepActions(stepWorkflowIdx[stepID]))[stepID];
+            options = `<select id="${prefixID}widgetMat_${widgetID}" class="chosen" aria-label="options" style="width: 250px">`;
+            for(let i in actions) {
+                options += `<option value="${actions[i].actionType}">${actions[i].actionTextPasttense}</option>`;
+            }
+            options += '</select>';
+        }
+
+        return options;
+    }
+
+    // getWorkflowStepActions retrieves data to support stepAction queries
+    async function getWorkflowStepActions(workflowID) {
+        url =
+        rootURL === ""
+            ? `./api/workflow/${workflowID}/route?x-filterData=workflowID,stepID,actionType,actionTextPasttense`
+            : rootURL + `api/workflow/${workflowID}/route?x-filterData=workflowID,stepID,actionType,actionTextPasttense`;
+        if(cache[`api/workflow/${workflowID}/route`] == undefined) {
+            cache[`api/workflow/${workflowID}/route`] = $.ajax({
+                type: "GET",
+                url
+            }).then(res => {
+                let workflowStepActions = {};
+                for(let i in res) {
+                    workflowStepActions[res[i].stepID] = workflowStepActions[res[i].stepID] || [];
+                    workflowStepActions[res[i].stepID].push({
+                        actionType: res[i].actionType,
+                        actionTextPasttense: res[i].actionTextPasttense
+                    });
+                }
+                return workflowStepActions;
+            }).catch(err => {
+                console.error(err);
+            });
+        }
+
+        return cache[`api/workflow/${workflowID}/route`];
+    }
+
     /**
      * @memberOf LeafFormSearch
      */
@@ -922,8 +967,7 @@ var LeafFormSearch = function (containerID) {
                         if (callback != undefined) {
                             callback();
                         }
-                    },
-                    cache: false,
+                    }
                 });
                 break;
             case "stepID":
@@ -1450,6 +1494,76 @@ var LeafFormSearch = function (containerID) {
                         '" style="width: 200px" />'
                 );
                 break;
+            case "stepAction":
+                    $("#" + prefixID + "widgetCondition_" + widgetID).html(`<select id="${prefixID}widgetCod_${widgetID}" style="width: 140px" class="chosen" aria-label="categoryID">
+                            <option value="=">IS</option>
+                            <option value="!=">IS NOT</option>
+                        </select>`);
+                    $("#" + prefixID + "widgetMatch_" + widgetID).html('');
+                    if(rootURL == "") {
+                        url = "./api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description";
+                    } else {
+                        url = rootURL + "api/workflow/steps?x-filterData=workflowID,stepID,stepTitle,description";
+                    }
+
+                    if(cache['api/workflow/steps'] == undefined) {
+                        cache['api/workflow/steps'] = $.ajax({
+                            type: "GET",
+                            url,
+                            dataType: "json"
+                        }).then(res => {
+                            // Hide standard workflows unless the GET parameter "dev" exists
+                            if(new URLSearchParams(window.location.search).get('dev') == null) {
+                                res = res.filter(step => step.workflowID > 0);
+                            }
+                            return res;
+                        });
+                    }
+
+                    let workflowStepsData = await cache['api/workflow/steps'];
+
+                    let groupedStepData = {};
+                    for(let i in workflowStepsData) {
+                        groupedStepData[workflowStepsData[i].workflowID] = groupedStepData[workflowStepsData[i].workflowID] || {};
+                        groupedStepData[workflowStepsData[i].workflowID].description = workflowStepsData[i].description;
+                        groupedStepData[workflowStepsData[i].workflowID].steps = groupedStepData[workflowStepsData[i].workflowID].steps || {};
+                        groupedStepData[workflowStepsData[i].workflowID].steps[workflowStepsData[i].stepID] = workflowStepsData[i].stepTitle;
+                    }
+
+                    let workflowSteps = `<select id="${prefixID}widgetIndicator_${widgetID}" class="chosen" aria-label="workflow steps" style="width: 250px">`;
+                    let stepWorkflowIdx = {};
+                    workflowSteps += `<option value="">Select a workflow step...</option>`;
+                    for(let i in groupedStepData) {
+                        workflowSteps += `<optgroup label="${groupedStepData[i].description}">`;
+                        for(let j in groupedStepData[i].steps) {
+                            workflowSteps += `<option value="${j}">${groupedStepData[i].steps[j]}</option>`;
+                            stepWorkflowIdx[j] = i;
+                        }
+                        workflowSteps += `</optgroup>`;
+                    }
+                    workflowSteps += "</select>";
+                    $("#" + prefixID + "widgetTerm_" + widgetID).after(
+                        workflowSteps
+                    );
+
+                    if (callback != undefined) {
+                        callback();
+                    }
+
+                    let options = await getStepActionOptions(stepWorkflowIdx, widgetID);
+                    renderSingleSelectInputType(widgetID, options);
+
+                    $("#" + prefixID + "widgetIndicator_" + widgetID).on("change", async () => {
+                        options = await getStepActionOptions(stepWorkflowIdx, widgetID);
+                        renderSingleSelectInputType(widgetID, options);
+                    });
+
+                    $(`#${prefixID}widgetTerm_${widgetID}_chosen`).css("display", "none");
+
+                    if (callback != undefined) {
+                        callback();
+                    }
+                break;
             default:
                 $("#" + prefixID + "widgetCondition_" + widgetID).html(
                     '<select id="' +
@@ -1501,14 +1615,15 @@ var LeafFormSearch = function (containerID) {
             widgetCounter +
             '" style="width: 150px" class="chosen" aria-label="condition">\
                             <option value="stepID">Current Status</option>\
-            				<option value="data">Data Field</option>\
+            				<option value="data">Data Field ...</option>\
             				<option value="dateSubmitted">Date Submitted</option>\
                             <option value="userID">Initiator</option>\
             				<option value="serviceID">Service</option>\
             				<option value="title">Title</option>\
             				<option value="categoryID">Type</option>\
                             <option value="recordID">Record ID</option>\
-            				<option value="dependencyID">Requirement</option>\
+                            <option value="stepAction">Record Actions ...</option>\
+            				<option value="dependencyID">Requirement ...</option>\
             				</select></td>\
 			            <td id="' +
             prefixID +
@@ -1559,7 +1674,7 @@ var LeafFormSearch = function (containerID) {
         for (var i = 0; i < widgetCounter; i++) {
             if ($("#" + prefixID + "widgetTerm_" + i).val() != undefined) {
                 term = $("#" + prefixID + "widgetTerm_" + i).val();
-                if (term != "data" && term != "dependencyID") {
+                if (term != "data" && term != "dependencyID" && term != "stepAction") {
                     id = $("#" + prefixID + "widgetTerm_" + i).val();
                     cod = $("#" + prefixID + "widgetCod_" + i).val();
                     match = $("#" + prefixID + "widgetMat_" + i).val();

--- a/LEAF_Request_Portal/templates/view_search.tpl
+++ b/LEAF_Request_Portal/templates/view_search.tpl
@@ -222,7 +222,8 @@ function main() {
         else if(isJSON) {
             for(let i in advSearch) {
                 if(advSearch[i].id != 'data'
-                    && advSearch[i].id != 'dependencyID') {
+                    && advSearch[i].id != 'dependencyID'
+                    && advSearch[i].id != 'stepAction') {
                     query.addTerm(advSearch[i].id, advSearch[i].operator, advSearch[i].match, advSearch[i].gate);
                 }
                 else {

--- a/x-test/API-tests/database/portal_test_db.sql
+++ b/x-test/API-tests/database/portal_test_db.sql
@@ -29,7 +29,11 @@ INSERT INTO `action_history` (`actionID`, `recordID`, `userID`, `stepID`, `depen
 (2,	530,	'tester',	0,	0,	'changeInitiator',	8,	1699056198,	'Initiator changed to Alysa Dare'),
 (3,	530,	'tester',	0,	0,	'move',	8,	1699056206,	'Moved to Requestor Followup step'),
 (4,	7,	'tester',	0,	0,	'move',	8,	1700253479,	'Moved to Requestor Followup step'),
-(5,	7,	'tester',	3,	-2,	'sendback',	8,	1700253822,	'');
+(5,	7,	'tester',	3,	-2,	'sendback',	8,	1700253822,	''),
+(6,	9,	'tester',	1,	9,	'approve',	8,	1716939853,	''),
+(7,	9,	'tester',	2,	9,	'approve',	8,	1716939855,	''),
+(8,	9,	'tester',	3,	-2,	'approve',	8,	1716939857,	''),
+(9,	9,	'tester',	4,	-3,	'approve',	8,	1716939859,	'');
 
 DROP TABLE IF EXISTS `action_types`;
 CREATE TABLE `action_types` (
@@ -6271,8 +6275,8 @@ INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `prio
 (5,	1692288069,	0,	'tester',	'LEAF Secure Certification',	0,	'Submitted',	1692288081,	0,	0,	1),
 (6,	1693258385,	0,	'tester',	'untitled',	0,	NULL,	0,	0,	1,	1),
 (7,	1694021464,	0,	'tESTER',	'Requestor followup - Different Username case sensitivity',	0,	'Re-opened for editing',	0,	0,	1,	1),
-(8,	1694021464,	0,	'tester',	'Available for test case',	0,	'Approved',	1694021485,	0,	0,	1),
-(9,	1694021464,	0,	'tester',	'Available for test case',	0,	'Approved',	1694021485,	0,	0,	1),
+(8,	1694021464,	0,	'tester',	'TestFormWorkflow_ApplyAction',	0,	'Approved',	1694021485,	0,	0,	1),
+(9,	1694021464,	0,	'tester',	'TestFormQuery_GroupClickedApprove',	0,	'Approved',	1694021485,	0,	0,	1),
 (10,	1694021465,	0,	'tester',	'TestFormWorkflow_ApplyAction',	0,	'Submitted',	1694021485,	0,	0,	1),
 (11,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1),
 (12,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1),
@@ -7250,11 +7254,11 @@ INSERT INTO `records_dependencies` (`recordID`, `dependencyID`, `filled`, `time`
 (8,	-1,	1,	1694126647),
 (8,	5,	1,	1694021485),
 (8,	9,	1,	1694126651),
-(9,	-3,	0,	NULL),
-(9,	-2,	0,	1694021485),
+(9,	-3,	1,	1716939859),
+(9,	-2,	1,	1716939857),
 (9,	-1,	1,	1694130219),
 (9,	5,	1,	1694021485),
-(9,	9,	0,	NULL),
+(9,	9,	1,	1716939855),
 (10,	-3,	0,	NULL),
 (10,	-2,	0,	1694021485),
 (10,	-1,	0,	NULL),
@@ -12017,6 +12021,10 @@ INSERT INTO `records_step_fulfillment` (`recordID`, `stepID`, `fulfillmentTime`)
 (8,	1,	1694126647),
 (8,	2,	1694126651),
 (8,	3,	1694126654),
+(9,	1,	1716939853),
+(9,	2,	1716939855),
+(9,	3,	1716939857),
+(9,	4,	1716939859),
 (500,	8,	1698275281),
 (501,	8,	1698275239),
 (502,	7,	1697554890),
@@ -12039,7 +12047,6 @@ CREATE TABLE `records_workflow_state` (
 INSERT INTO `records_workflow_state` (`recordID`, `stepID`, `blockingStepID`, `lastNotified`, `initialNotificationSent`) VALUES
 (5,	-3,	0,	'2023-08-17 16:01:21',	0),
 (8,	4,	0,	'2023-09-07 22:45:09',	0),
-(9,	1,	0,	'2023-09-06 17:31:25',	0),
 (10,	1,	0,	'2023-09-06 17:31:25',	0),
 (11,	1,	0,	'2023-09-06 17:31:25',	0),
 (12,	1,	0,	'2023-09-06 17:31:25',	0),

--- a/x-test/API-tests/formQuery_test.go
+++ b/x-test/API-tests/formQuery_test.go
@@ -119,3 +119,11 @@ func TestFormQuery_RecordIdAndFulltext(t *testing.T) {
 		t.Errorf(`Record 499 should exist because the data fields contain the word "apple". want = recordID IS 499 AND data contains apple`)
 	}
 }
+
+func TestFormQuery_GroupClickedApprove(t *testing.T) {
+	res, _ := getFormQuery(RootURL + `api/form/query?q={"terms":[{"id":"stepAction","indicatorID":"4","operator":"=","match":"approve","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"date","direction":"DESC"},"limit":50}`)
+
+	if _, exists := res[9]; !exists {
+		t.Errorf(`Record 9 should exist because the "Group designated step" clicked "Approve". want = recordID 9 exists in the result set`)
+	}
+}

--- a/x-test/API-tests/form_test.go
+++ b/x-test/API-tests/form_test.go
@@ -89,7 +89,7 @@ func TestForm_WorkflowIndicatorAssigned(t *testing.T) {
 }
 
 func TestForm_IsMaskable(t *testing.T) {
-	res, _ := httpGet(rootURL + "api/form/_form_ce46b")
+	res, _ := httpGet(RootURL + "api/form/_form_ce46b")
 
 	var m FormCategoryResponse
 	err := json.Unmarshal([]byte(res), &m)
@@ -101,7 +101,7 @@ func TestForm_IsMaskable(t *testing.T) {
 		t.Errorf("./api/form/_form_ce46b isMaskable = %v, want = %v", m[0].IsMaskable, nil)
 	}
 
-	res, _ = httpGet(rootURL + "api/form/_form_ce46b?context=formEditor")
+	res, _ = httpGet(RootURL + "api/form/_form_ce46b?context=formEditor")
 
 	err = json.Unmarshal([]byte(res), &m)
 	if err != nil {
@@ -116,14 +116,14 @@ func TestForm_IsMaskable(t *testing.T) {
 func TestForm_NonadminCannotCancelOwnSubmittedRecord(t *testing.T) {
 	// Setup conditions
 	postData := url.Values{}
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("numform_5ea07", "1")
 	postData.Set("title", "TestForm_NonadminCannotCancelOwnSubmittedRecord")
 	postData.Set("8", "1")
 	postData.Set("9", "112")
 
 	// TODO: streamline this
-	res, _ := client.PostForm(rootURL+`api/form/new`, postData)
+	res, _ := client.PostForm(RootURL+`api/form/new`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)
 	var response string
 	json.Unmarshal(bodyBytes, &response)
@@ -134,14 +134,14 @@ func TestForm_NonadminCannotCancelOwnSubmittedRecord(t *testing.T) {
 	}
 
 	postData = url.Values{}
-	postData.Set("CSRFToken", csrfToken)
-	client.PostForm(rootURL+`api/form/`+strconv.Itoa(recordID)+`/submit`, postData)
+	postData.Set("CSRFToken", CsrfToken)
+	client.PostForm(RootURL+`api/form/`+strconv.Itoa(recordID)+`/submit`, postData)
 
 	// Non-admin shouldn't be able to cancel a submitted record
 	postData = url.Values{}
-	postData.Set("CSRFToken", csrfToken)
+	postData.Set("CSRFToken", CsrfToken)
 
-	res, _ = client.PostForm(rootURL+`api/form/`+strconv.Itoa(recordID)+`/cancel?masquerade=nonAdmin`, postData)
+	res, _ = client.PostForm(RootURL+`api/form/`+strconv.Itoa(recordID)+`/cancel?masquerade=nonAdmin`, postData)
 	bodyBytes, _ = io.ReadAll(res.Body)
 	json.Unmarshal(bodyBytes, &response)
 	got := response


### PR DESCRIPTION
This expands `api/form/query`: Find all records if a specific action was taken for a given step.

No additional DB indexes seem to make a meaningful difference in query performance. Observed up to 0.14s query time on a site containing 2M actions.

Automated tests pending merge of PR#2390

### This PR is dependent on:
- https://github.com/department-of-veterans-affairs/LEAF/pull/2395
- https://github.com/department-of-veterans-affairs/LEAF/pull/2390

### Potential Impact
Minimal because this adds new functionality without touching existing core logic.

### Testing
- [ ] Passes automated tests
- [ ] Create a record and apply actions to it. Using the Homepage Advanced Search or Report Builder, use the new `Record Actions ...` term to find the record by using matching Step and Actions.