### PR TITLE
LEAF 4238 update print to PDF homeurl

### DIFF
--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -17,7 +17,7 @@ var printer = function () {
     var requestInfo = new Object();
     var internalInfo = new Array();
     var homeQR = document.createElement("img");
-    var homeURL = encodeURIComponent($('a[href="./"]')[0].href);
+    const homeURL = encodeURIComponent(portal_path + '/');
     //get QR code of record
     homeQR.setAttribute("class", "print nodisplay");
     homeQR.setAttribute("style", "width: 72px");
@@ -186,7 +186,6 @@ var printer = function () {
         var splitTitle = [];
         var splitOption = [];
         var format = indicator.format;
-        console.log(indicator.format);
         if (
           format === "text" &&
           ((indicator.value && indicator.value.length > 30) ||


### PR DESCRIPTION
Updates the way print to PDF sets up the URL so that it is not reliant on content in customizable templates.

Testing / Impact

Print to PDF button.
Changing the home link  href value in Template Editor menu.tpl should no longer cause an error when PDF button is clicked.
QRCode on forms exported with Print to PDF button should continue to refer to the request URL.