### PR TITLE
LEAF 4344 - add metadata column to portal data, data_history

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1130,7 +1130,7 @@ class Form
             $this->db->prepared_query('INSERT INTO data_history (recordID, indicatorID, series, data, metadata, timestamp, userID)
                                                    VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID)', $vars);
         }
-
+        /*  signatures (not yet implemented)
         $vars = array(':recordID' => $recordID,
                       ':indicatorID' => $key,
                       ':series' => $series, );
@@ -1141,7 +1141,7 @@ class Form
 
         if (strpos($res[0]['format'], 'signature') == 0) {
             // $this->writeSignature($recordID);
-        }
+        }*/
         return 1;
     }
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1118,17 +1118,16 @@ class Form
                       ':indicatorID' => $key,
                       ':series' => $series,
                       ':data' => trim($_POST[$key]),
-                      ':metadata' => null,
                       ':timestamp' => time(),
                       ':userID' => $this->login->getUserID(), );
 
-        $this->db->prepared_query('INSERT INTO data (recordID, indicatorID, series, data, metadata, timestamp, userID)
-                                            VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID)
-                                            ON DUPLICATE KEY UPDATE data=:data, metadata=:metadata, timestamp=:timestamp, userID=:userID', $vars);
+        $this->db->prepared_query('INSERT INTO data (recordID, indicatorID, series, data, timestamp, userID)
+                                            VALUES (:recordID, :indicatorID, :series, :data, :timestamp, :userID)
+                                            ON DUPLICATE KEY UPDATE data=:data, timestamp=:timestamp, userID=:userID', $vars);
 
         if (!$duplicate) {
-            $this->db->prepared_query('INSERT INTO data_history (recordID, indicatorID, series, data, metadata, timestamp, userID)
-                                                   VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID)', $vars);
+            $this->db->prepared_query('INSERT INTO data_history (recordID, indicatorID, series, data, timestamp, userID)
+                                                   VALUES (:recordID, :indicatorID, :series, :data, :timestamp, :userID)', $vars);
         }
         /*  signatures (not yet implemented)
         $vars = array(':recordID' => $recordID,

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1118,16 +1118,17 @@ class Form
                       ':indicatorID' => $key,
                       ':series' => $series,
                       ':data' => trim($_POST[$key]),
+                      ':metadata' => null,
                       ':timestamp' => time(),
                       ':userID' => $this->login->getUserID(), );
 
-        $this->db->prepared_query('INSERT INTO data (recordID, indicatorID, series, data, timestamp, userID)
-                                            VALUES (:recordID, :indicatorID, :series, :data, :timestamp, :userID)
-                                            ON DUPLICATE KEY UPDATE data=:data, timestamp=:timestamp, userID=:userID', $vars);
+        $this->db->prepared_query('INSERT INTO data (recordID, indicatorID, series, data, metadata, timestamp, userID)
+                                            VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID)
+                                            ON DUPLICATE KEY UPDATE data=:data, metadata=:metadata, timestamp=:timestamp, userID=:userID', $vars);
 
         if (!$duplicate) {
-            $this->db->prepared_query('INSERT INTO data_history (recordID, indicatorID, series, data, timestamp, userID)
-                                                   VALUES (:recordID, :indicatorID, :series, :data, :timestamp, :userID)', $vars);
+            $this->db->prepared_query('INSERT INTO data_history (recordID, indicatorID, series, data, metadata, timestamp, userID)
+                                                   VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID)', $vars);
         }
 
         $vars = array(':recordID' => $recordID,

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024022901-2024052000.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024022901-2024052000.sql
@@ -1,0 +1,18 @@
+START TRANSACTION;
+
+ALTER TABLE `data` ADD COLUMN `metadata` json DEFAULT NULL AFTER `data`;
+ALTER TABLE `data_history` ADD COLUMN `metadata` json DEFAULT NULL AFTER `data`;
+
+UPDATE `settings` SET `data` = '2024052000' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+ALTER TABLE `data` DROP COLUMN `metadata`;
+ALTER TABLE `data_history` DROP COLUMN `metadata`;
+
+UPDATE `settings` SET `data` = '2024022901' WHERE `settings`.`setting` = 'dbversion';
+COMMIT;
+*/


### PR DESCRIPTION
Adds a metadata column to portal data and portal data_history tables.
Also comments out a currently unused query.

Testing / Impact

Portal Database update for table associated with request data entry and editing.

Confirm database update and revert work as expected.
The added column is not currently used and has a null default value.  Confirm no changes in behavior.