### PR TITLE
LEAF-4350 - Report Builder: Only join service when requested

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -80,6 +80,7 @@ function addHeader(column) {
             break;
         case 'service':
             filterData['service'] = 1;
+            leafSearch.getLeafFormQuery().join('service');
             headers.push({
                 name: 'Service',
                 indicatorID: 'service',
@@ -1177,7 +1178,6 @@ $(function() {
             if(!isSearchingDeleted(leafSearch)) {
                 leafSearch.getLeafFormQuery().addTerm('deleted', '=', 0);
             }
-            leafSearch.getLeafFormQuery().join('service');
             headers = [];
         }
         else if(!isSearchingDeleted(leafSearch)) {


### PR DESCRIPTION
Minor fix to avoid a database join when it's not requested

Steps to reproduce issue:
1. Report Builder -> Do not select "Service" in step 2 -> Generate report
2. Click JSON
3. Note that the URL incorrectly includes "service" in the "joins" section

### Potential Impact
No dependencies

### Testing
- [ ] Cannot reproduce the issue
- [ ] When selecting "Service" in step 2, the generated report includes the expected column for Service
