### PR TITLE
LEAF-4351 - Form Editor: Fix access indicator

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -508,7 +508,9 @@ class Form
             }
             else {
                 $vars = array(':indicatorID' => $indicatorID);
-                $data = $this->db->prepared_query('SELECT * FROM indicators WHERE indicatorID=:indicatorID AND disabled = 0', $vars);
+                $data = $this->db->prepared_query('SELECT * FROM indicators
+                                                    LEFT JOIN indicator_mask USING (indicatorID)
+                                                    WHERE indicatorID=:indicatorID AND disabled = 0', $vars);
                 $this->cache['getIndicator_'.$indicatorID] = $data;
             }
         }


### PR DESCRIPTION
Resolves an issue where the Special Access Restriction indicator doesn't show up correctly for fields where its `parentID == 0`

Steps to reproduce issue in the Form Editor:
1. Open a form and edit a section heading
2. Click "Show Advanced Attributes" and add a group
3. Note that the icon in the form overview is missing

### Potential Impact
Minimal. This adds a missing join and the same join is used for fields where `parentID > 0`

### Testing
- [ ] Cannot reproduce issue