### PR TITLE
Leaf 4221 - automate step change reminder

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -640,7 +640,7 @@
             async: false
         }).done(function(res) {
             groupList = res;
-        }).error(function(error) {
+        }).fail(function(error) {
             alert(error);
         });
         $.ajax({

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -58,6 +58,7 @@ class Email
     const NOTIFY_COMPLETE = -3;
     const EMAIL_REMINDER = -4;
     const AUTOMATED_EMAIL_REMINDER = -5;
+    const AUTOMATED_STEP_CHANGE_REMINDER = -6;
 
     public function __construct()
     {
@@ -676,7 +677,7 @@ class Email
 
                         $resEmpUID = $form->getIndicator($resStep[0]['indicatorID_for_assigned_empUID'], 1, $recordID);
 
-                        // empuid is required to move forward, make sure this exists before continuing. 
+                        // empuid is required to move forward, make sure this exists before continuing.
                         // This can be a result of user not setting a user in form field
                         if(is_array($resEmpUID) && !empty($resEmpUID[$resStep[0]['indicatorID_for_assigned_empUID']])){
 
@@ -728,8 +729,8 @@ class Email
                         $resStep = $this->portal_db->prepared_query($strSQL, $varsStep);
 
                         $resGroupID = $form->getIndicator($resStep[0]['indicatorID_for_assigned_groupID'], 1, $recordID);
-                        
-                        // groupid is required to move forward, make sure this exists before continuing. 
+
+                        // groupid is required to move forward, make sure this exists before continuing.
                         // This can be a result of user not setting a group in form field
                         if(is_array($resGroupID) && !empty($resGroupID[$resStep[0]['indicatorID_for_assigned_groupID']])){
                             $groupID = $resGroupID[$resStep[0]['indicatorID_for_assigned_groupID']]['value'];

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -692,7 +692,8 @@ class Workflow
                         'AutomateEmailGroup' => $data['AutomatedEmailReminders']['Automate Email Group'],
                         'DaysSelected' => $data['AutomatedEmailReminders']['Days Selected'],
                         'DateSelected' => $data['AutomatedEmailReminders']['Date Selected'],
-                        'AdditionalDaysSelected' => $data['AutomatedEmailReminders']['Additional Days Selected']
+                        'AdditionalDaysSelected' => $data['AutomatedEmailReminders']['Additional Days Selected'],
+                        'MoveStepTo' => $data['AutomatedEmailReminders']['Move Step to'],
                     ]
                 ])
             ];

--- a/LEAF_Request_Portal/templates/email/LEAF_automated_step_change_reminder_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_automated_step_change_reminder_body.tpl
@@ -1,0 +1,9 @@
+This reminder is to let you know that a change step has occurred and that action is needed once again.<br /><br />
+
+Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
+    {{$fullTitle}}</a><br />
+Request status: {{$lastStatus}}<br /><br />
+Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
+    {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
+    {{$reminderBodyText}}
+<br />

--- a/LEAF_Request_Portal/templates/email/LEAF_automated_step_change_reminder_subject.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_automated_step_change_reminder_subject.tpl
@@ -1,0 +1,1 @@
+Change Step Reminder: {{$truncatedTitle}} (#{{$recordID}})

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024022901-2024052400.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024022901-2024052400.sql
@@ -1,0 +1,17 @@
+START TRANSACTION;
+
+INSERT INTO `email_templates` (`emailTemplateID`, `label`, `emailTo`, `emailCc`, `subject`, `body`)
+VALUES ('-6', 'Automated Step Change Reminder', 'LEAF_automated_step_change_reminder_emailTo.tpl', 'LEAF_automated_step_change_reminder_emailCc.tpl', 'LEAF_automated_step_change_reminder_subject.tpl', 'LEAF_automated_step_change_reminder_body.tpl');
+
+UPDATE `settings` SET `data` = '2024051700' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+ /**** Revert DB *****
+ START TRANSACTION;
+ DELETE FROM `email_templates` WHERE `emailTemplateID` = -6;
+
+ UPDATE `settings` SET `data` = '2024022901' WHERE `settings`.`setting` = 'dbversion';
+ COMMIT;
+ */


### PR DESCRIPTION
Summary:
This branch adds the ability to add a step change reminder to a workflow step. This will send an email reminder and change the step in the same automated step. The email will basically let the recipients know that the step change occurred and that they must take action again on a request.

Potential Impact:
This adds functionality and doesn't really affect anything else. It does add code to the automatedEmailReminder so if something goes wrong it would probably be here.

Testing:
Create a Workflow
In one step add an email reminder
    in the reminder setup select Step Change Reminder
    enter the number of days this needs to go out in
    enter the number of additional days
    select the step to go back to
Attach this workflow to a form
create a request based on this workflow
get the request to the step that will do a step change
wait the number of days that you setup in the workflow and observe that the step change actually worked.