### PR TITLE
Cache timestamp for last action

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1022,8 +1022,9 @@ class FormWorkflow
                 $vars2 = array(
                     ':recordID' => $this->recordID,
                     ':lastStatus' => $resActionData[0]['actionTextPasttense'],
+                    ':lastActionTime' => $time
                 );
-                $strSQL2 = 'UPDATE records SET lastStatus=:lastStatus
+                $strSQL2 = 'UPDATE records SET lastStatus=:lastStatus, lastActionTime=:lastActionTime
                     WHERE recordID = :recordID';
                 $this->db->prepared_query($strSQL2, $vars2);
 

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -256,6 +256,26 @@ function addHeader(column) {
                  }});
             break;
         case 'days_since_last_action':
+            filterData['lastActionTime'] = 1;
+            headers.push({
+                name: 'Days Since Last Action',
+                indicatorID: 'daysSinceLastAction',
+                editable: false,
+                callback: function(data, blob) {
+                    let daysSinceAction;
+                    let recordBlob = blob[data.recordID];
+                    if(blob[data.recordID].lastActionTime != null) {
+                        let date = new Date(blob[data.recordID].lastActionTime * 1000);
+
+                        daysSinceAction = Math.round((today.getTime() - date.getTime()) / 86400000);
+                    }
+                    else {
+                        daysSinceAction = "Not Submitted";
+                    }
+                    $('#'+data.cellContainerID).html(daysSinceAction);
+                }
+            });
+            break;
         case 'days_since_last_step_movement':
             filterData['action_history.time'] = 1;
             filterData['action_history.stepID'] = 1;

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024022901-2024050900.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024022901-2024050900.sql
@@ -1,0 +1,17 @@
+START TRANSACTION;
+
+ALTER TABLE `records` ADD `lastActionTime` int unsigned NULL AFTER `lastStatus`;
+
+UPDATE `settings` SET `data` = '2024022901' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `records` DROP `lastActionTime`;
+
+UPDATE `settings` SET `data` = '2024022901' WHERE `settings`.`setting` = 'dbversion';
+COMMIT;
+*/


### PR DESCRIPTION
This stores the timestamp for a record's last action in the main records table in order to enable more efficient queries.

The Report Builder has been updated to use the new database column.

### Prerequisite
LEAF-4348 needs to be completed and coordinated with this PR.

### Potential Impact
- This changes how the "Days since last action" is retrieved in the report builder.
- Database schema change

### Testing
- [ ] Reports for "Days since last action" are identical to before this change