### PR TITLE
LEAF-4359 - Avoid duplicate message in formGrid

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -590,7 +590,7 @@ var LeafFormGrid = function (containerID, options) {
 
     var colspan = showIndex ? headers.length + 1 : headers.length;
     if (currentData.length == 0) {
-      $("#" + prefixID + "tbody").append(
+      $("#" + prefixID + "tbody").html(
         '<tr><td colspan="' +
           colspan +
           '" style="text-align: center">No Results</td></tr>'


### PR DESCRIPTION
This avoids a duplicate "No results" message in certain customizations.

### Potential Impact
Minimal since we're asserting that the grid should only ever show "no results" when there's no data to display.

### Testing
- [ ] Results and the lack of results on the homepage show up normally
