### PR TITLE
LEAF-4360 - Revert inbox role organization

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -299,7 +299,7 @@
             // index by roles
             for(let depID in dataInboxes[sites[i].url][j].unfilledDependencyData) {
                 let uDD = dataInboxes[sites[i].url][j].unfilledDependencyData[depID];
-                let roleID = String(depID) + dataInboxes[sites[i].url][j].stepID;
+                let roleID = Number(depID);
                 let description = uDD.description;
                 if(roleID < 0 && uDD.approverUID != undefined) { // handle "smart requirements"
                     roleID = Sha1.hash(uDD.approverUID);
@@ -562,7 +562,6 @@
             <button type="button" id="depLabel${hash}_${stepID}" class="depInbox" style="background-color: ${site.backgroundColor}">
                 <div>
                     <span style="font-size: 130%; font-weight: bold; color: ${site.fontColor}">${stepName}</span><br />
-                    <span style="color: ${site.fontColor}">${categoryName}</span>
                 </div>
                 <span style="text-align:end;text-decoration: underline; font-weight: bold; color: ${site.fontColor}">View ${recordIDs.length} requests</span>
             </button>


### PR DESCRIPTION
This partially reverts 36b3bdb000aab8e54c04c680ab1c86c20f0ab561 where Inbox Role organization was "improved" to subdivide roles by the forms in which they appear.

The view when organizing by roles has also been updated to remove the form label and step, which aligns more strictly with the original intent of "Organize by Roles".

### Potential Impact
This can cause confusion if roles are shared between multiple forms. In those cases, people should be directed to use the "Organize by Forms" option. It may be necessary to explain that people will only see records when they personally have a pending action, unless they're an admin.

### Testing
- [ ] "Organize by Roles" in the LEAF Inbox only shows unique Workflow Requirements
