### PR TITLE
LEAF 4362 Add word breaks for form comments and content

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -569,6 +569,7 @@ span.printResponse {
   letter-spacing: 0.01rem;
   line-height: 150%;
   color: rgba(0, 0, 0, 0.8);
+  word-break: break-word;
 }
 
 div.printResponse::-webkit-scrollbar {

--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -727,7 +727,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                             response.comment != null
                         ) {
                             text +=
-                                '<div style="padding: 4px 16px"><fieldset style="border: 1px solid black"><legend class="noprint">Comment</legend><span style="font-size: 80%; font-weight: normal">' +
+                                '<div style="padding: 4px 16px"><fieldset style="border: 1px solid black;word-break:break-word;"><legend class="noprint">Comment</legend><span style="font-size: 80%; font-weight: normal">' +
                                 response.comment +
                                 "</span></fieldset></div>";
                         }

--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -669,7 +669,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                             response.comment != null
                         ) {
                             text +=
-                                '<div style="font-size: 80%; padding: 4px 8px 4px 8px">Comment:<br /><div style="font-weight: normal; padding-left: 16px; font-size: 12px">' +
+                                '<div style="font-size: 80%; padding: 4px 8px 4px 8px">Comment:<br /><div style="font-weight: normal; padding-left: 16px; font-size: 12px; word-break:break-word;">' +
                                 response.comment +
                                 "</div></div>";
                         }


### PR DESCRIPTION
Adds a word-break style for form -Comment- area and printResponse spans to prevent text overflow.

**Testing / Impact**
Style change should be specific to Comment and form data areas and only be noticeable for long strings without spaces.

Long comments (eg Report Builder URL) should wrap rather than overflow the comment or form areas.
Check for unexpected display changes.