### PR TITLE
LEAF-4364 - INC33016631 Data export date not detected as date

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -944,11 +944,7 @@ var LeafFormGrid = function (containerID, options) {
 
     $("#" + prefixID + "getExcel").on("click", async function () {
       // get indicator formats in case they need special handling (e.g. dates)
-      let iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format").then(res => res.json());
-      let indicatorFormats = {};
-      iFormatData.forEach(i => {
-        indicatorFormats[i.indicatorID] = i.format;
-      });
+      
 
       if (currentRenderIndex != currentData.length) {
         renderBody(0, Infinity);
@@ -979,7 +975,7 @@ var LeafFormGrid = function (containerID, options) {
           let trimmedText = val.innerText.trim();
           line[i] = trimmedText;
           //prevent some values from being interpreted as dates by excel
-          const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
+          const dataFormat = val.getAttribute("data-format");
           const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
           const isNumber = /^\d+$/;
 


### PR DESCRIPTION
When exporting there was logic added to prevent normal numbers being seen as dates, now legitimate dates are tied up in this logic. 4325 and [LEAF-4267](https://jira.devops.va.gov/browse/LEAF-4267) Remove seldom used response property - VA DTE Jira may have been where this issue has come in.

Date Initiated is the example column that is not triggered as a date

Testing:

regression, test if dates are exported as they are, numbers that could be dates are exported with the special format still.