### PR TITLE
LEAF-4364 - INC33016631 Data export date not detected as date

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -980,17 +980,16 @@ var LeafFormGrid = function (containerID, options) {
           line[i] = trimmedText;
           //prevent some values from being interpreted as dates by excel
           const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
-          const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
+          const testExcelDateFormat = /^\d{1,2}[\/-]\d{1,2}([\/-]\d{2,4})?$/; // Excel thinks these are dates
           const isNumber = /^\d+$/;
 
-          line[i] =
-            (dataFormat !== null &&
-              dataFormat !== 'date' &&
-              testDateFormat.test(line[i])) ||
-            (isNumber.test(line[i]) &&
-              dataFormat === 'text')
-              ? `="${line[i]}"`
-              : line[i];
+          if(dataFormat == 'text') {
+              if(isNumber.test(line[i]) // workaround for excel's handling of very large numbers (e.g. serial number)
+                 || testExcelDateFormat.test(line[i])) {
+                  line[i] = `="${line[i]}"`;
+              }
+          }
+
           if (i == 0 && headers[i] == "UID") {
             line[i] =
               '=HYPERLINK("' +

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -980,17 +980,16 @@ var LeafFormGrid = function (containerID, options) {
           line[i] = trimmedText;
           //prevent some values from being interpreted as dates by excel
           const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
-          const testDateFormat = /^\d+[\/-]\d+([\/-]\d+)?$/;
+          const testExcelDateFormat = /^\d{1,2}[\/-]\d{1,2}([\/-]\d{2,4})?$/; // Excel thinks these are dates
           const isNumber = /^\d+$/;
 
-          line[i] =
-            (dataFormat !== null &&
-              dataFormat !== 'date' &&
-              testDateFormat.test(line[i])) ||
-            (isNumber.test(line[i]) &&
-              dataFormat === 'text')
-              ? `="${line[i]}"`
-              : line[i];
+          if(dataFormat == 'text') {
+              if(isNumber.test(line[i]) // workaround for excel's handling of very large numbers (e.g. serial number)
+                 || testExcelDateFormat.test(line[i])) {
+                  line[i] = `="${line[i]}"`;
+              }
+          }
+
           if (i == 0 && headers[i] == "UID") {
             line[i] =
               '=HYPERLINK("' +


### PR DESCRIPTION
In essence: Dates should be dates. Text that look like it could be a date should be treated as plain text.

### Testing
If the user enters in a text field:
- 2/2
- 2-2
- 1/2/34
- 123456789000000000000000

Excel should NOT show:
- 2-Feb
- 2-Feb
- 1/2/1934
- 1.23457E+23

