### PR TITLE
Leaf 4378 - Change wording

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3852,7 +3852,8 @@ class Form
             $temp['format'] = $item['format'];
             $temp['description'] = $item['description'];
             $temp['categoryName'] = $item['categoryName'];
-            $temp['disabled'] = ($item['disabled'] == 1) ? 'Archived' : 'Deletion Date: '. $delDateFormat;
+            // TODO: change the below name. New output should use new property names instead of recycling existing ones.
+            $temp['disabled'] = ($item['disabled'] == 1) ? 'Archived' : 'Scheduled Deletion Date: '. $delDateFormat;
             $disabledIndicatorList[] = $temp;
         }
 


### PR DESCRIPTION
This is a quick fix to change the wording in the Status column of the "Restore Fields" page `?a=form_vue#/restore`.

Given the context of the page, "Deletion Date" implies it's a date when the user deleted the item. However the meaning is actually "Scheduled Deletion Date".

Also added a TODO item, since more consideration is needed when introducing structural changes to API responses.

### Potential Impact
Should be minimal since it's a verbiage change

### Testing
- [ ] "Restore Fields" page works normally.