### PR TITLE
Leaf 3135 - email priors on cancel

### DIFF
--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -776,7 +776,7 @@ class Email
             $comments = $this->getDeletedComments($recordID);
 
             $comment = $comments[0]['comment'] === '' ? '' : 'Reason for cancelling: ' . $comments[0]['comment'] . '<br /><br />';
-            error_log(print_r($comments, true));
+
             $title = strlen($recordInfo[0]['title']) > 45 ? substr($recordInfo[0]['title'], 0, 42) . '...' : $recordInfo[0]['title'];
 
             $this->addSmartyVariables(array(

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -58,6 +58,7 @@ class Email
     const NOTIFY_COMPLETE = -3;
     const EMAIL_REMINDER = -4;
     const AUTOMATED_EMAIL_REMINDER = -5;
+    const CANCEL_REQUEST = -7;
 
     public function __construct()
     {
@@ -676,7 +677,7 @@ class Email
 
                         $resEmpUID = $form->getIndicator($resStep[0]['indicatorID_for_assigned_empUID'], 1, $recordID);
 
-                        // empuid is required to move forward, make sure this exists before continuing. 
+                        // empuid is required to move forward, make sure this exists before continuing.
                         // This can be a result of user not setting a user in form field
                         if(is_array($resEmpUID) && !empty($resEmpUID[$resStep[0]['indicatorID_for_assigned_empUID']])){
 
@@ -728,8 +729,8 @@ class Email
                         $resStep = $this->portal_db->prepared_query($strSQL, $varsStep);
 
                         $resGroupID = $form->getIndicator($resStep[0]['indicatorID_for_assigned_groupID'], 1, $recordID);
-                        
-                        // groupid is required to move forward, make sure this exists before continuing. 
+
+                        // groupid is required to move forward, make sure this exists before continuing.
                         // This can be a result of user not setting a group in form field
                         if(is_array($resGroupID) && !empty($resGroupID[$resStep[0]['indicatorID_for_assigned_groupID']])){
                             $groupID = $resGroupID[$resStep[0]['indicatorID_for_assigned_groupID']]['value'];
@@ -746,14 +747,7 @@ class Email
             $return_value = $this->sendMail($recordID);
         } elseif ($emailTemplateID === -4) {
             // Record has no approver so if it is sent from Mass Action Email Reminder, notify user
-            $vars = array(':recordID' => $recordID);
-            $strSQL =  "SELECT rec.userID, rec.serviceID, ser.service, rec.title,
-                            rec.lastStatus
-                        FROM records AS rec
-                        LEFT JOIN services AS ser USING (serviceID)
-                        WHERE recordID=:recordID";
-
-            $recordInfo = $this->portal_db->prepared_query($strSQL, $vars);
+            $recordInfo = $this->getRecord($recordID);
 
             $title = strlen($recordInfo[0]['title']) > 45 ? substr($recordInfo[0]['title'], 0, 42) . '...' : $recordInfo[0]['title'];
 
@@ -777,10 +771,91 @@ class Email
                 $this->addRecipient($tmp[0]['Email']);
             }
             $return_value = $this->sendMail($recordID);
+        } elseif ($emailTemplateID === -7) {
+            $recordInfo = $this->getRecord($recordID);
+            $comments = $this->getDeletedComments($recordID);
+
+            $comment = $comments[0]['comment'] === '' ? '' : 'Reason for cancelling: ' . $comments[0]['comment'] . '<br /><br />';
+            error_log(print_r($comments, true));
+            $title = strlen($recordInfo[0]['title']) > 45 ? substr($recordInfo[0]['title'], 0, 42) . '...' : $recordInfo[0]['title'];
+
+            $this->addSmartyVariables(array(
+                "truncatedTitle" => $title,
+                "fullTitle" => $recordInfo[0]['title'],
+                "recordID" => $recordID,
+                "service" => $recordInfo[0]['service'],
+                "lastStatus" => $comments[0]['actionType'],
+                "siteRoot" => $this->siteRoot,
+                "field" => null,
+                "comment" => $comment
+            ));
+
+            $this->processPriorStepsEmailed($this->getPriorStepsEmailed($recordID));
+            $this->setTemplateByID($emailTemplateID);
+            $this->sendMail($recordID);
         } elseif ($emailTemplateID > 1) {
             $return_value = $this->sendMail($recordID); // Check for custom event to finalize email on Notify Next
         }
 
         return $return_value;
+    }
+
+    private function getRecord(int $recordID): array
+    {
+        $vars = array(':recordID' => $recordID);
+        $strSQL =  "SELECT `rec`.`userID`, `rec`.`serviceID`, `ser`.`service`, `rec`.`title`,
+                        `rec`.`lastStatus`
+                    FROM `records` AS `rec`
+                    LEFT JOIN `services` AS `ser` USING (`serviceID`)
+                    WHERE `recordID` = :recordID";
+
+        $recordInfo = $this->portal_db->prepared_query($strSQL, $vars);
+
+        return $recordInfo;
+    }
+
+    private function getDeletedComments(int $recordID): array
+    {
+        $vars = array(':recordID' => $recordID);
+        $strSQL =  "SELECT `comment`, `actionType`
+                    FROM `action_history`
+                    WHERE `recordID` = :recordID
+                    AND `actionType` = 'deleted'
+                    ORDER BY `actionID` DESC";
+
+        $recordInfo = $this->portal_db->prepared_query($strSQL, $vars);
+
+        return $recordInfo;
+    }
+
+    private function getPriorStepsEmailed(int $recordID): array
+    {
+        // get the email_tracker data for this record
+        $vars = array(':recordID' => $recordID);
+        $sql = 'SELECT `recipients`
+                FROM `email_tracker`
+                WHERE `recordID` = :recordID';
+
+        $return_result = $this->portal_db->prepared_query($sql, $vars);
+
+        return $return_result;
+    }
+
+    private function processPriorStepsEmailed(array $email_recipients): void
+    {
+        $recipient_list = array();
+
+        foreach ($email_recipients as $recipient) {
+            $clean_list = str_replace('Recipient(s): ', '', $recipient['recipients']);
+
+            $list = explode(',', $clean_list);
+
+            foreach ($list as $email) {
+                if (!in_array(trim($email), $recipient_list)) {
+                    array_push($recipient_list, trim($email));
+                    $this->addRecipient(trim($email));
+                }
+            }
+        }
     }
 }

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -366,6 +366,9 @@ class Email
             $recipients.=", ".$cc;
         };
         $email_tracker = new EmailTracker($this->portal_db);
+
+        // the second argument in this method is a list of recipients. The format needs to be "Recipient(s): <email@address.com>[, <email@address.com>]"
+        // this list of recipients is used in the processPriorStepsEmailed method below and expects this format.
         $email_tracker->postEmailTracker($recordID, 'Recipient(s): ' . $recipients, 'Subject: ' . $this->emailSubject);
     }
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -834,8 +834,6 @@ class Form
 
             // need to send emails to everyone upstream from the currect step.
             $this->notifyPriorSteps($recordID);
-            /* $status = $this->getDependencyStatus($recordID);
-            error_log(print_r($status, true)); */
 
             $return_value = 1;
         }

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -461,12 +461,12 @@ class Form
 
     /**
      * Get a form's indicator and all children, including data if available
-     * 
+     *
      * Flags:
      *  $_GET['context'] If the context is set to "formEditor", an additional "isMaskable" property indicates
      *                   whether the field has Special Access Restrictions assigned. Used in the Form Editor
      *                   to provide a visual indicator.
-     * 
+     *
      * @param int $indicatorID
      * @param int $series
      * @param int $recordID
@@ -772,9 +772,9 @@ class Form
 
     /**
      * cancelRecord marks a record as cancelled.
-     * 
+     *
      * Only admins should be able to cancel submitted records.
-     * 
+     *
      * @param int $recordID
      * @param string $comment
      *
@@ -832,10 +832,23 @@ class Form
 
             $res = $this->db->prepared_query($sql, $vars);
 
+            // need to send emails to everyone upstream from the currect step.
+            $this->notifyPriorSteps($recordID);
+            /* $status = $this->getDependencyStatus($recordID);
+            error_log(print_r($status, true)); */
+
             $return_value = 1;
         }
 
         return $return_value;
+    }
+
+    private function notifyPriorSteps(int $recordID): void
+    {
+        $email = new Email();
+        $email->setSender('leaf.noreply@va.gov');
+
+        $email->attachApproversAndEmail($recordID, Email::CANCEL_REQUEST, $this->login);
     }
 
     public function restoreRecord($recordID)
@@ -2422,7 +2435,7 @@ class Form
 
     /* getCustomData iterates through an array of $recordID_list and incorporates any associated data
      * specified by $indicatorID_list (string of ID#'s delimited by ',')
-     * 
+     *
      * WARNING: $alreadyCheckedReadAccess can only be set to true if $recordID_list has been
      *          processed by checkReadAccess().
      *
@@ -2919,7 +2932,7 @@ class Form
     /**
      * parseBooleanQuery transforms a user's query to add implied "+" prefixes when
      * a "MATCH ALL" condition is selected.
-     * 
+     *
      * @param $query
      * @return string Transformed query
      */
@@ -2938,9 +2951,9 @@ class Form
 
     /**
      * query parses a JSON formatted user query defined in formQuery.js.
-     * 
+     *
      * Returns an array on success, and string/int for malformed queries
-     * 
+     *
      * @param string JSON formatted string of the query
      * @return mixed
      */
@@ -3523,7 +3536,7 @@ class Form
                     break;
             }
         }
-        
+
         // avoid extra sort when using fulltext index
         if($usingFulltextIndex) {
             $sort = '';

--- a/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
@@ -1,0 +1,12 @@
+A request that you were a part of has been cancelled.<br />
+Request #{{$recordID}} - {{$fullTitle}}.<br /><br />
+This is a notification only and no action is required on your part.<br /><br />
+
+{{$comment}}
+
+Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
+    {{$fullTitle}}</a><br />
+Request status: {{$lastStatus}}<br /><br />
+Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
+    {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
+<br />

--- a/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_subject.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_subject.tpl
@@ -1,0 +1,1 @@
+The request for {{$truncatedTitle}} (#{{$recordID}}) has been canceled.

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024052000-2024060700.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024052000-2024060700.sql
@@ -1,0 +1,17 @@
+START TRANSACTION;
+
+INSERT INTO `email_templates` (`emailTemplateID`, `label`, `emailTo`, `emailCc`, `subject`, `body`)
+VALUES ('-7', 'Cancel Notification', 'LEAF_cancel_notification_emailTo.tpl', 'LEAF_cancel_notification_emailCc.tpl', 'LEAF_cancel_notification_subject.tpl', 'LEAF_cancel_notification_body.tpl');
+
+UPDATE `settings` SET `data` = '2024060700' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+ /**** Revert DB *****
+ START TRANSACTION;
+ DELETE FROM `email_templates` WHERE `emailTemplateID` = -7;
+
+ UPDATE `settings` SET `data` = '2024052000' WHERE `settings`.`setting` = 'dbversion';
+ COMMIT;
+ */

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024060200-2024060600.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024060200-2024060600.sql
@@ -3,7 +3,7 @@ START TRANSACTION;
 INSERT INTO `email_templates` (`emailTemplateID`, `label`, `emailTo`, `emailCc`, `subject`, `body`)
 VALUES ('-7', 'Cancel Notification', 'LEAF_cancel_notification_emailTo.tpl', 'LEAF_cancel_notification_emailCc.tpl', 'LEAF_cancel_notification_subject.tpl', 'LEAF_cancel_notification_body.tpl');
 
-UPDATE `settings` SET `data` = '2024060700' WHERE `settings`.`setting` = 'dbversion';
+UPDATE `settings` SET `data` = '2024060600' WHERE `settings`.`setting` = 'dbversion';
 
 COMMIT;
 
@@ -12,6 +12,6 @@ COMMIT;
  START TRANSACTION;
  DELETE FROM `email_templates` WHERE `emailTemplateID` = -7;
 
- UPDATE `settings` SET `data` = '2024052000' WHERE `settings`.`setting` = 'dbversion';
+ UPDATE `settings` SET `data` = '2024060200' WHERE `settings`.`setting` = 'dbversion';
  COMMIT;
  */


### PR DESCRIPTION
Summary:
An email should be sent to notify people associated with prior steps

- The email should state the request has been cancelled, the reason for cancellation (if any), and a link to the request
- If a request has not been submitted, the email is not necessary

Potential Impact:
This should only affect cancelled requests.

Testing:
Setup a request that can be cancelled.
Cancel the request, (entering a comment as well as not entering a comment)
Observe that an email went to the previous recipients of emails from this request (check the view history to find a list of those previously email)
The email should have the comment if one was supplied.