### PR TITLE
Leaf 4382 - Switch to descending record index

### DIFF
--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024052000-2024060200.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024052000-2024060200.sql
@@ -1,0 +1,17 @@
+START TRANSACTION;
+
+ALTER TABLE `records` ADD PRIMARY KEY `PRIMARY` (`recordID` DESC), DROP INDEX `PRIMARY`;
+
+UPDATE `settings` SET `data` = '2024060200' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `records` ADD PRIMARY KEY `PRIMARY` (`recordID`), DROP INDEX `PRIMARY`;
+
+UPDATE `settings` SET `data` = '2024052000' WHERE `settings`.`setting` = 'dbversion';
+COMMIT;
+*/


### PR DESCRIPTION
The main advantage of using a descending index here is that most views typically show the newest records on top. This provides a much better user experience, especially in the Report Builder, since we can quickly render the first set of records while the rest load in the background.

How does this impact performance elsewhere?


### Potential impact
This might impact performance.

### Testing
- [ ] No impact to response time