### PR TITLE
Leaf 4386 - Report Builder: Add example in the JSON dialog

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -896,9 +896,6 @@ function showJSONendpoint() {
         selection.addRange(range);
         return selection;
     }
-    document.querySelector('#exportPathContainer').addEventListener('click', (e) => {
-        selectExample();
-    });
 
     document.querySelector('#copy').addEventListener('click', () => {
         navigator.clipboard.writeText(selectExample().focusNode.innerText);

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -827,6 +827,7 @@ function showJSONendpoint() {
     dialog_message.setContent('<p>This provides a live data source for custom dashboards or automated programs.</p><br />'
                            + '<button id="shortenLink" class="buttonNorm" style="float: right">Shorten Link</button>'
                            + '<button id="expandLink" class="buttonNorm" style="float: right; display: none">Expand Link</button>'
+                           + '<button id="copy" class="buttonNorm" style="float: right">Copy to Clipboard</button>'
                            + '<select id="format">'
                            + '<option value="json">JSON</option>'
                            + '<option value="htmltable">HTML Table</option>'
@@ -886,6 +887,24 @@ function showJSONendpoint() {
                 break;
         }
     }
+
+    function selectExample() {
+        let selection = window.getSelection();
+        let range = document.createRange();
+        range.selectNodeContents(document.querySelector('#exportPathContainer'));
+        selection.removeAllRanges();
+        selection.addRange(range);
+        return selection;
+    }
+    document.querySelector('#exportPathContainer').addEventListener('click', (e) => {
+        selectExample();
+    });
+
+    document.querySelector('#copy').addEventListener('click', () => {
+        navigator.clipboard.writeText(selectExample().focusNode.innerText);
+        $("#formatStatus").show().text("Copied!");
+        $("#formatStatus").fadeOut(3000);
+    });
 
     $('#format').on('change', function() {
         setExportFormat();

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -816,13 +816,15 @@ function openShareDialog() {
 
 function showJSONendpoint() {
     let pwd = document.URL.substr(0,document.URL.lastIndexOf('?'));
-    leafSearch.getLeafFormQuery().setLimit(0, 10000);
-    let queryString = JSON.stringify(leafSearch.getLeafFormQuery().getQuery());
+    let query = leafSearch.getLeafFormQuery().getQuery();
+    delete query.limit;
+    delete query.limitOffset;
+    let queryString = JSON.stringify(query);
     let jsonPath = pwd + leafSearch.getLeafFormQuery().getRootURL() + 'api/form/query/?q=' + queryString + '&x-filterData=recordID,'+ Object.keys(filterData).join(',');
     let powerQueryURL = '<!--{$powerQueryURL}-->' + window.location.pathname;
 
     dialog_message.setTitle('Data Endpoints');
-    dialog_message.setContent('<p>This provides a live data source for custom dashboards or automated programs.</p><p><b>A configurable limit of 10,000 records has been preset</b>.</p><br />'
+    dialog_message.setContent('<p>This provides a live data source for custom dashboards or automated programs.</p><br />'
                            + '<button id="shortenLink" class="buttonNorm" style="float: right">Shorten Link</button>'
                            + '<button id="expandLink" class="buttonNorm" style="float: right; display: none">Expand Link</button>'
                            + '<select id="format">'
@@ -832,10 +834,11 @@ function showJSONendpoint() {
                            + '<option value="csv">CSV</option>'
                            + '<option value="xml">XML</option>'
                            + '<option value="debug">Plaintext</option>'
+                           + '<option value="leafFormQuery">JavaScript Template</option>'
                            + '<option value="x-visualstudio">Visual Studio (testing)</option>'
                            + '</select>'
                            + '<span id="formatStatus" style="background-color:green; padding:5px 5px; color:white; display:none;"></span>'
-                           + '<br /><div id="exportPathContainer" contenteditable="true" style="border: 1px solid gray; padding: 4px; margin-top: 4px; width: 95%; height: 100px; word-break: break-all;"><span id="exportPath">'+ jsonPath +'</span><span id="exportFormat"></span></div>'
+                           + '<br /><div id="exportPathContainer" contenteditable="true" spellcheck="false" style="border: 1px solid gray; padding: 4px; margin-top: 4px; width: 95%; min-height: 100px; word-break: break-all;"><span id="exportPath">'+ jsonPath +'</span><span id="exportFormat"></span></div>'
                            + '<a href="report.php?a=LEAF_Data_Dictionary" target="_blank">Data Dictionary Reference</a>'
                            + '<br /><br />'
                            + '<fieldset>'
@@ -860,8 +863,23 @@ function showJSONendpoint() {
         switch($('#format').val()) {
             case 'json':
                 $('#exportFormat').html('');
+                document.querySelector('#exportPath').style.display = 'inline';
+                break;
+            case 'leafFormQuery':
+                let buffer = "&lt;script&gt;<br />";
+                buffer += `async function main() {<br />
+                    &nbsp;&nbsp;&nbsp;&nbsp;let query = new LeafFormQuery();<br />
+                    &nbsp;&nbsp;&nbsp;&nbsp;query.importQuery(${queryString});<br />
+                    &nbsp;&nbsp;&nbsp;&nbsp;let results = await query.execute();<br />
+                    &nbsp;&nbsp;&nbsp;&nbsp;// Do something with the results<br />
+                    }<br /><br />
+                    document.addEventListener('DOMContentLoaded', main);`;
+                buffer += "<br />&lt;/script&gt;";
+                document.querySelector('#exportFormat').innerHTML = buffer;
+                document.querySelector('#exportPath').style.display = 'none';
                 break;
             default:
+                document.querySelector('#exportPath').style.display = 'inline';
                 $('#exportFormat').append('format=' + $('#format').val());
                 $("#formatStatus").show().text("Format changed to " + $('#format').val());
                 $("#formatStatus").fadeOut(3000);

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -867,16 +867,16 @@ function showJSONendpoint() {
                 document.querySelector('#exportPath').style.display = 'inline';
                 break;
             case 'leafFormQuery':
-                let buffer = "&lt;script&gt;<br />";
-                buffer += `async function main() {<br />
-                    &nbsp;&nbsp;&nbsp;&nbsp;let query = new LeafFormQuery();<br />
-                    &nbsp;&nbsp;&nbsp;&nbsp;query.importQuery(${queryString});<br />
-                    &nbsp;&nbsp;&nbsp;&nbsp;let results = await query.execute();<br />
-                    &nbsp;&nbsp;&nbsp;&nbsp;// Do something with the results<br />
-                    }<br /><br />
-                    document.addEventListener('DOMContentLoaded', main);`;
-                buffer += "<br />&lt;/script&gt;";
-                document.querySelector('#exportFormat').innerHTML = buffer;
+                let buffer = "<scr"+"ipt>\n";
+                buffer += `async function main() {
+                    \u00A0\u00A0\u00A0\u00A0let query = new LeafFormQuery();
+                    \u00A0\u00A0\u00A0\u00A0query.importQuery(${queryString});
+                    \u00A0\u00A0\u00A0\u00A0let results = await query.execute();
+                    \u00A0\u00A0\u00A0\u00A0// Do something with the results
+                    }
+                    document.addEventListener('DOMContentLoaded', main);\n`;
+                buffer += "</scr"+"ipt>";
+                document.querySelector('#exportFormat').innerText = buffer;
                 document.querySelector('#exportPath').style.display = 'none';
                 break;
             default:


### PR DESCRIPTION
This updates the JSON dialog in the Report Builder:
- Remove 10,000 record limit
- Added "JavaScript Template" example
- "Copy to clipboard" button

### Potential Impact
Minimal because the changes are limited to the JSON dialog area.

### Testing
- [ ] Report builder functions normally
- [ ] "JavaScript Template" shows up correctly
- [ ] The "Copy to clipboard" button works