### PR TITLE
Leaf 4391 - formGrid.js UX - Part 2: Virtual scrollbar

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -707,7 +707,8 @@ table.leaf_grid td:first-child {
 }
 
 table.leaf_grid thead tr th,
-table.leaf_grid tbody tr td {
+table.leaf_grid tbody tr td,
+table.leaf_grid tfoot tr td {
   border-bottom: 1px solid black;
   border-right: 1px solid black;
   transition: filter 0.25s;
@@ -715,6 +716,20 @@ table.leaf_grid tbody tr td {
 
 table.leaf_grid>tbody>tr>td {
   padding: 8px;
+}
+
+.leaf_grid-loading tr td {
+  background: linear-gradient(90deg, #ffffff, #dbdbdb, #ffffff);
+  animation: leaf_grid-loading 30s linear infinite;
+}
+
+@keyframes leaf_grid-loading {
+  0% {
+      background-position: 0 0;
+  }
+  100% {
+      background-position: 1200px 0;
+  }
 }
 
 .agenda th {

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -324,7 +324,7 @@ var LeafFormGrid = function (containerID, options) {
     // sticky header UX
     const domHeader = document.querySelector(`#${prefixID}thead`);
     const observer = new IntersectionObserver((evt) => {
-      if(evt[0].intersectionRatio < 1) {
+      if(evt[0].boundingClientRect.y != evt[0].intersectionRect.y) {
         $("#" + prefixID + "table thead tr th").css({
           "filter": "invert(1) grayscale(1)",
           height: "1.3rem",

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -1061,6 +1061,13 @@ var LeafFormGrid = function (containerID, options) {
     },
     hideIndex: hideIndex,
     setHeaders: setHeaders,
+    getNumHeaders: () => {
+      if(showIndex) {
+        return headers.length + 1;
+      } else {
+        return headers.length;
+      }
+    },
     sort: sort,
     renderVirtualHeader: renderVirtualHeader,
     renderBody: renderBody,

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -707,7 +707,7 @@ var LeafFormGrid = function (containerID, options) {
     } else {
       let tfootBuf = `<tr style="height: ${fillerHeight}px">`;
       document.querySelectorAll(`#${prefixID}thead_tr th`).forEach(el => {
-        tfootBuf += `<td style="width: ${el.offsetWidth}px"></td>`
+        tfootBuf += `<td></td>`;
       });
       tfootBuf += `</tr>`;
       document.querySelector(`#${prefixID}tfoot`).innerHTML = tfootBuf;

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3557,6 +3557,10 @@ class Form
                     $sort = 'ORDER BY date ';
 
                     break;
+                case 'recordID':
+                    $sort = 'ORDER BY recordID ';
+
+                    break;
                 case 'title':
                     $sort = 'ORDER BY title ';
 

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1162,7 +1162,7 @@ $(function() {
     });
     var extendedToolbar = false;
     $('#generateReport').off();
-    $('#generateReport').on('click', function() {
+    $('#generateReport').on('click', async function() {
         $('#results').fadeIn(700);
         $('#saveLinkContainer').fadeIn(700);
         $('#step_2').slideUp(700);
@@ -1311,17 +1311,21 @@ $(function() {
             abortController.abort();
             abortLoad = true;
         });
-        let firstBatchLoaded = false;
+
+        // show top results asap
+        let queryFirstBatch = leafSearch.getLeafFormQuery();
+        queryFirstBatch.sort('recordID', 'DESC');
+        queryFirstBatch.setLimit(50);
+        queryFirstBatch.setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
+        let firstBatch = await queryFirstBatch.execute();
+        renderGrid(firstBatch);
+
         leafSearch.getLeafFormQuery().setBatchSize(1000);
         leafSearch.getLeafFormQuery().setLimit(Infinity); // Backward compat: limit shouldn't exist
         leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
         leafSearch.getLeafFormQuery().setAbortSignal(abortController.signal);
         leafSearch.getLeafFormQuery().onProgress(progress => {
             $('#reportStats').html(`Loading ${progress}+ records`);
-            if(!firstBatchLoaded) {
-                renderGrid(leafSearch.getLeafFormQuery().getResults());
-                firstBatchLoaded = true;
-            }
         });
 
         // get data

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1313,7 +1313,8 @@ $(function() {
         });
 
         // show top results asap
-        let queryFirstBatch = leafSearch.getLeafFormQuery();
+        let queryFirstBatch = new LeafFormQuery();
+        queryFirstBatch.setQuery(structuredClone(leafSearch.getLeafFormQuery().getQuery()));
         queryFirstBatch.sort('recordID', 'DESC');
         queryFirstBatch.setLimit(50);
         queryFirstBatch.setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
@@ -1325,7 +1326,12 @@ $(function() {
         leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
         leafSearch.getLeafFormQuery().setAbortSignal(abortController.signal);
         leafSearch.getLeafFormQuery().onProgress(progress => {
-            $('#reportStats').html(`Loading ${progress}+ records`);
+            document.querySelector('#reportStats').innerText = `Loading ${progress}+ records`;
+            document.querySelector(`#${grid.getPrefixID()}tfoot`).innerHTML = `<tr>
+                <td colspan="${grid.getNumHeaders()}" style="padding: 8px; font-size: 120%; font-weight: bold">
+                <img src="./images/indicator.gif" style="vertical-align: middle" alt="" /> Loading ${progress}+ records
+                </td>
+            </tr>`;
         });
 
         // get data


### PR DESCRIPTION
This is a follow-up to https://github.com/department-of-veterans-affairs/LEAF/pull/2424.

This also enables support for `ORDER BY recordID` within `api/form/query` without changing the DB schema. This is used in the Report Builder to quickly show the most recent 50 records that fit the user's query.

Improvements:
- Implements a virtual scrollbar, enabling quick seeking
- Replaces on `onscroll` with `onscrollend`, and includes a compatible solution for Safari
- Uses `IntersectionObserver` to manage the sticky header UX
- Adds `aria-rowcount` for screen readers
- Updates UX for rows that are still loading (shows up as a blank column with subtle animation)

### Potential Impact
Same as https://github.com/department-of-veterans-affairs/LEAF/pull/2424

### Testing
- [ ] The following works as expected:
  1. Load the test page from https://github.com/department-of-veterans-affairs/LEAF/pull/2424
  2. Scroll to the middle of the document
  3. Click any Col# header to sort
  4. You should expect to see numbers in the ~50,000 range, and the column is sorted
- [ ] Report Builder works as expected