### PR TITLE
Leaf 4392 - Add Test: Descending indexes apparently break things

### DIFF
--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -707,7 +707,8 @@ table.leaf_grid td:first-child {
 }
 
 table.leaf_grid thead tr th,
-table.leaf_grid tbody tr td {
+table.leaf_grid tbody tr td,
+table.leaf_grid tfoot tr td {
   border-bottom: 1px solid black;
   border-right: 1px solid black;
   transition: filter 0.25s;
@@ -715,6 +716,20 @@ table.leaf_grid tbody tr td {
 
 table.leaf_grid>tbody>tr>td {
   padding: 8px;
+}
+
+.leaf_grid-loading tr td {
+  background: linear-gradient(90deg, #ffffff, #dbdbdb, #ffffff);
+  animation: leaf_grid-loading 30s linear infinite;
+}
+
+@keyframes leaf_grid-loading {
+  0% {
+      background-position: 0 0;
+  }
+  100% {
+      background-position: 1200px 0;
+  }
 }
 
 .agenda th {

--- a/LEAF_Request_Portal/css/style.css
+++ b/LEAF_Request_Portal/css/style.css
@@ -713,6 +713,10 @@ table.leaf_grid tbody tr td {
   transition: filter 0.25s;
 }
 
+table.leaf_grid>tbody>tr>td {
+  padding: 8px;
+}
+
 .agenda th {
   padding: 8px 4px 8px 4px;
   border: 1px solid black;

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -602,47 +602,18 @@ var LeafFormGrid = function (containerID, options) {
             if (currentData[i].s1 == undefined) {
               currentData[i].s1 = {};
             }
-            data.data =
-              currentData[i].s1["id" + headers[j].indicatorID] != undefined
-                ? currentData[i].s1["id" + headers[j].indicatorID]
-                : "";
+            data.data = '';
+            if(currentData[i].s1["id" + headers[j].indicatorID] != undefined) {
+              data.data = currentData[i].s1["id" + headers[j].indicatorID];
+            }
             validateHtml.innerHTML = data.data;
             data.data = validateHtml.innerHTML;
-            if (
-              currentData[i].s1["id" + headers[j].indicatorID + "_htmlPrint"] !=
-              undefined
-            ) {
-              var htmlPrint =
-                '<textarea id="data_' +
-                currentData[i].recordID +
-                "_" +
-                headers[j].indicatorID +
-                '_1" style="display: none">' +
-                data.data +
-                "</textarea>";
-              htmlPrint += currentData[i].s1[
-                "id" + headers[j].indicatorID + "_htmlPrint"
-              ]
-                .replace(
-                  /{{ iID }}/g,
-                  currentData[i].recordID + "_" + headers[j].indicatorID
-                )
+            if (currentData[i].s1[`id${headers[j].indicatorID}_htmlPrint`] != undefined) {
+              let htmlPrint = `<textarea id="data_${currentData[i].recordID}_${headers[j].indicatorID}_1" style="display: none">${data.data}</textarea>`;
+              htmlPrint += currentData[i].s1[`id${headers[j].indicatorID}_htmlPrint`]
+                .replace(/{{ iID }}/g, currentData[i].recordID + "_" + headers[j].indicatorID)
                 .replace(/{{ recordID }}/g, currentData[i].recordID);
-              buffer +=
-                '<td id="' +
-                prefixID +
-                currentData[i].recordID +
-                "_" +
-                headers[j].indicatorID +
-                '" data-editable="' +
-                editable +
-                '" data-record-id="' +
-                currentData[i].recordID +
-                '" data-indicator-id="' +
-                headers[j].indicatorID +
-                '">' +
-                htmlPrint +
-                "</td>";
+              buffer += `<td id="${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}" data-editable="${editable}" data-record-id="${currentData[i].recordID}" data-indicator-id="${headers[j].indicatorID}">${htmlPrint}</td>`;
             } else {
               if (headers[j].cols !== undefined) {
                 if (

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -236,7 +236,8 @@ var LeafFormGrid = function (containerID, options) {
           } else {
             sort("recordID", "desc", postSortRequestFunc);
           }
-          renderBody(0, Infinity);
+          let currPosition = renderRequest.length; // retain scroll position
+          renderBody(0, currPosition);
         }
       });
     }

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -324,7 +324,7 @@ var LeafFormGrid = function (containerID, options) {
     // sticky header UX
     const domHeader = document.querySelector(`#${prefixID}thead`);
     const observer = new IntersectionObserver((evt) => {
-      if(evt[0].intersectionRatio < 1) {
+      if(evt[0].boundingClientRect.y != evt[0].intersectionRect.y) {
         $("#" + prefixID + "table thead tr th").css({
           "filter": "invert(1) grayscale(1)",
           height: "1.3rem",

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -637,17 +637,7 @@ var LeafFormGrid = function (containerID, options) {
                   );
                 }
               }
-              buffer += `<td id="${prefixID + currentData[i].recordID}_${
-                headers[j].indicatorID
-              }"
-                                           data-editable="${editable}"
-                                           data-record-id="${
-                                             currentData[i].recordID
-                                           }"
-                                           data-indicator-id="${
-                                             headers[j].indicatorID
-                                           }">
-                                            ${data.data}</td>`;
+              buffer += `<td id="${prefixID + currentData[i].recordID}_${headers[j].indicatorID}" data-editable="${editable}" data-record-id="${currentData[i].recordID}" data-indicator-id="${headers[j].indicatorID}">${data.data}</td>`;
             }
           } else if (headers[j].callback != undefined) {
             buffer +=

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -220,10 +220,10 @@ var LeafFormGrid = function (containerID, options) {
     headers = headersIn;
     let temp = `<tr id="${prefixID}thead_tr">`;
     if (showIndex) {
-      temp +=
-        '<th scope="col" tabindex="0" id="' +
-        prefixID +
-        'header_UID" style="text-align: center">UID<span id="' + prefixID + 'header_UID_sort" class="' + prefixID + 'sort"></span></th>';
+      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" role="button">
+        UID
+        <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
+      </th>`;
     }
     $("#" + prefixID + "thead").html(temp);
 
@@ -242,28 +242,15 @@ var LeafFormGrid = function (containerID, options) {
       });
     }
 
+    let domThead = document.querySelector(`#${prefixID}thead_tr`);
     for (let i in headers) {
       if (headers[i].visible == false) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      $("#" + prefixID + "thead_tr").append(
-        '<th scope="col" id="' +
-          prefixID +
-          "header_" +
-          headers[i].indicatorID +
-          '" tabindex="0"  style="text-align:' +
-          align +
-          '">' +
-          headers[i].name +
-          '<span id="' +
-          prefixID +
-          "header_" +
-          headers[i].indicatorID +
-          '_sort" class="' +
-          prefixID +
-          'sort"></span></th>'
-      );
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" role="button">
+        ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
+        </th>`);
 
       if (headers[i].sortable == undefined || headers[i].sortable == true) {
         $("#" + prefixID + "header_" + headers[i].indicatorID).css(

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -552,7 +552,7 @@ var LeafFormGrid = function (containerID, options) {
 
     var buffer = "";
     var callbackBuffer = [];
-    let callbackCacheBuffer = [];
+    let outputBuffer = []; // buffer of pre-rendered rows
 
     var colspan = showIndex ? headers.length + 1 : headers.length;
     if (currentData.length == 0) {
@@ -574,7 +574,7 @@ var LeafFormGrid = function (containerID, options) {
       renderHistory[currentData[i].recordID] = 1;
 
       if(renderCache[currentData[i].recordID] != undefined) {
-        callbackCacheBuffer.push(renderCache[currentData[i].recordID]);
+        outputBuffer.push(renderCache[currentData[i].recordID]);
         counter++;
 
         if (fullRender) {
@@ -732,8 +732,8 @@ var LeafFormGrid = function (containerID, options) {
     for (let i in callbackBuffer) {
       callbackBuffer[i]();
     }
-    for (let i in callbackCacheBuffer) {
-      domTableBody.appendChild(callbackCacheBuffer[i]);
+    for (let i in outputBuffer) {
+      domTableBody.appendChild(outputBuffer[i]);
     }
 
     if (postRenderFunc != null) {

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -1061,6 +1061,13 @@ var LeafFormGrid = function (containerID, options) {
     },
     hideIndex: hideIndex,
     setHeaders: setHeaders,
+    getNumHeaders: () => {
+      if(showIndex) {
+        return headers.length + 1;
+      } else {
+        return headers.length;
+      }
+    },
     sort: sort,
     renderVirtualHeader: renderVirtualHeader,
     renderBody: renderBody,

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -364,13 +364,13 @@ var LeafFormGrid = function (containerID, options) {
    * @memberOf LeafFormGrid
    */
   function sort(key, order, callback) {
+    const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
+    const headerText = document.querySelector(headerSelector)?.innerText || "";
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
 
     $("." + prefixID + "sort").css("display", "none");
-    const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
-    const headerText = document.querySelector(headerSelector)?.innerText || "";
     $(`th[id*="${prefixID}header_"]`).removeAttr('aria-sort');
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", ascending.");

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -707,7 +707,7 @@ var LeafFormGrid = function (containerID, options) {
     } else {
       let tfootBuf = `<tr style="height: ${fillerHeight}px">`;
       document.querySelectorAll(`#${prefixID}thead_tr th`).forEach(el => {
-        tfootBuf += `<td style="width: ${el.offsetWidth}px"></td>`
+        tfootBuf += `<td></td>`;
       });
       tfootBuf += `</tr>`;
       document.querySelector(`#${prefixID}tfoot`).innerHTML = tfootBuf;

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -390,9 +390,7 @@ var LeafFormGrid = function (containerID, options) {
     var tDate;
     for (let i in currentData) {
       if (currentData[i][key] == undefined) {
-        currentData[i][key] = $(
-          "#" + prefixID + currentData[i].recordID + "_" + key
-        ).html();
+        currentData[i][key] = document.querySelector(`#${prefixID}${currentData[i].recordID}_${key}`).innerHTML;
         currentData[i][key] =
           currentData[i][key] == undefined ? "" : currentData[i][key];
       }
@@ -543,7 +541,7 @@ var LeafFormGrid = function (containerID, options) {
     var fullRender = false;
     if (startIdx == undefined || startIdx == 0) {
       startIdx = 0;
-      $("#" + prefixID + "tbody").empty();
+      document.querySelector(`#${prefixID}tbody`).innerHTML = '';
       renderHistory = {};
       fullRender = true;
     }
@@ -553,11 +551,7 @@ var LeafFormGrid = function (containerID, options) {
 
     var colspan = showIndex ? headers.length + 1 : headers.length;
     if (currentData.length == 0) {
-      $("#" + prefixID + "tbody").html(
-        '<tr><td colspan="' +
-          colspan +
-          '" style="text-align: center">No Results</td></tr>'
-      );
+      document.querySelector(`#${prefixID}tbody`).innerHTML = `<tr><td colspan="${colspan}" style="text-align: center">No Results</td></tr>`;
     }
     var counter = 0;
     var validateHtml = document.createElement("div");
@@ -735,24 +729,22 @@ var LeafFormGrid = function (containerID, options) {
       currentRenderIndex + limit >= currentData.length ||
       limit == undefined
     ) {
-      $("#" + prefixID + "tfoot").html("");
+      document.querySelector(`#${prefixID}tfoot`).innerHTML = '';
     } else {
-      $("#" + prefixID + "tfoot").html(
-        "<tr><td colspan=" +
-          colspan +
-          ' style="padding: 8px; background-color: #feffd1; font-size: 120%; font-weight: bold"><img src="' +
-          rootURL +
-          'images/indicator.gif" style="vertical-align: middle" alt="" /> Loading more results...</td></tr>'
-      );
+      document.querySelector(`#${prefixID}tfoot`).innerHTML = `<tr>
+          <td colspan="${colspan}" style="padding: 8px; background-color: #feffd1; font-size: 120%; font-weight: bold">
+            <img src="${rootURL}images/indicator.gif" style="vertical-align: middle" alt="" /> Loading more results...
+          </td>
+        </tr>`;
     }
 
-    $("#" + prefixID + "tbody").append(buffer);
-    $("#" + prefixID + "tbody td[data-editable=true]").addClass(
-      "table_editable"
-    );
-    $("#" + prefixID + "tbody td[data-clickable=true]").addClass(
-      "table_editable"
-    );
+    document.querySelector(`#${prefixID}tbody`).insertAdjacentHTML('beforeend', buffer);
+    document.querySelectorAll(`#${prefixID}tbody td[data-editable=true]`).forEach(el => {
+      el.classList.add('table_editable');
+    });
+    document.querySelectorAll(`#${prefixID}tbody td[data-clickable=true]`).forEach(el => {
+      el.classList.add('table_editable');
+    });
     $("#" + prefixID + "tbody").unbind("click"); //prevents multiple firing on same report builder element, which causes subsequent problems with icheck
     $("#" + prefixID + "tbody").on(
       "click",
@@ -772,13 +764,9 @@ var LeafFormGrid = function (containerID, options) {
       callbackBuffer[i]();
     }
 
-    $("#" + prefixID + "table>tbody>tr>td").css({
-      padding: "8px",
-    });
     if (postRenderFunc != null) {
       postRenderFunc();
     }
-    renderVirtualHeader();
   }
 
   /**

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -646,7 +646,7 @@ var LeafFormGrid = function (containerID, options) {
             if(callbackCache[currentData[i].recordID] == undefined || callbackCache[currentData[i].recordID][data.indicatorID] == undefined) {
               buffer += `<td id="${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}" data-clickable="${editable}"></td>`;
             } else {
-              buffer += `<td id="${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}" data-clickable="${editable}">${callbackCache[currentData[i].recordID][data.indicatorID]}</td>`;
+              buffer += `<td id="${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}" data-clickable="${editable}" style="${callbackCache[currentData[i].recordID][data.indicatorID].style}">${callbackCache[currentData[i].recordID][data.indicatorID].content}</td>`;
             }
           } else {
             buffer +=
@@ -736,9 +736,14 @@ var LeafFormGrid = function (containerID, options) {
           let id = currentData[i].recordID;
           callbackCache[id] = callbackCache[id] || {};
           if (callbackCache[id][headers[j].indicatorID] == undefined) {
-            callbackCache[id][headers[j].indicatorID] = document.querySelector(`#${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}`)?.innerHTML;
-            if(callbackCache[id][headers[j].indicatorID] == undefined) {
-              callbackCache[id][headers[j].indicatorID] = "";
+            callbackCache[id][headers[j].indicatorID] = {};
+            let el = document.querySelector(`#${prefixID}${currentData[i].recordID}_${headers[j].indicatorID}`);
+            if(el != undefined) {
+              callbackCache[id][headers[j].indicatorID].content = el.innerHTML;
+              callbackCache[id][headers[j].indicatorID].style = el.style.cssText;
+            } else {
+              callbackCache[id][headers[j].indicatorID].content = '';
+              callbackCache[id][headers[j].indicatorID].style = '';
             }
           }
         }

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -331,6 +331,7 @@ var LeafFormQuery = function () {
     updateTerm,
     updateDataTerm,
     setQuery: (inc) => query = inc,
+    setBatchSize: (size) => batchSize = size,
     setLimit,
     setLimitOffset,
     setRootURL: (url) => rootURL = url,

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -302,7 +302,7 @@ var LeafFormQuery = function () {
     if (query.getData != undefined && query.getData.length == 0) {
       delete query.getData;
     }
-    if (query.limit == undefined || isNaN(query.limit) || parseInt(query.limit) > 1000) {
+    if (query.limit == undefined || isNaN(query.limit) || parseInt(query.limit) > 1000 || !isFinite(query.limit)) {
       return getBulkData();
     }
 

--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -343,6 +343,7 @@ var LeafFormQuery = function () {
     onSuccess,
     onProgress,
     setAbortSignal,
+    getResults: () => results,
     execute
   };
 };

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3557,6 +3557,10 @@ class Form
                     $sort = 'ORDER BY date ';
 
                     break;
+                case 'recordID':
+                    $sort = 'ORDER BY recordID ';
+
+                    break;
                 case 'title':
                     $sort = 'ORDER BY title ';
 

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1162,7 +1162,7 @@ $(function() {
     });
     var extendedToolbar = false;
     $('#generateReport').off();
-    $('#generateReport').on('click', function() {
+    $('#generateReport').on('click', async function() {
         $('#results').fadeIn(700);
         $('#saveLinkContainer').fadeIn(700);
         $('#step_2').slideUp(700);
@@ -1311,17 +1311,21 @@ $(function() {
             abortController.abort();
             abortLoad = true;
         });
-        let firstBatchLoaded = false;
+
+        // show top results asap
+        let queryFirstBatch = leafSearch.getLeafFormQuery();
+        queryFirstBatch.sort('recordID', 'DESC');
+        queryFirstBatch.setLimit(50);
+        queryFirstBatch.setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
+        let firstBatch = await queryFirstBatch.execute();
+        renderGrid(firstBatch);
+
         leafSearch.getLeafFormQuery().setBatchSize(1000);
         leafSearch.getLeafFormQuery().setLimit(Infinity); // Backward compat: limit shouldn't exist
         leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
         leafSearch.getLeafFormQuery().setAbortSignal(abortController.signal);
         leafSearch.getLeafFormQuery().onProgress(progress => {
             $('#reportStats').html(`Loading ${progress}+ records`);
-            if(!firstBatchLoaded) {
-                renderGrid(leafSearch.getLeafFormQuery().getResults());
-                firstBatchLoaded = true;
-            }
         });
 
         // get data

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -21,7 +21,7 @@
 <div id="saveLinkContainer" style="display: none">
     <div id="reportTitleDisplay" style="font-size: 200%; padding-left: 8px;"></div>
     <input id="reportTitle" type="text" aria-label="Text" style="font-size: 200%; width: 50%" placeholder="Untitled Report" />
-    <br /><span id="reportStats" style="padding-left: 8px; z-index: 1"></span><button id="btn_abort" class="buttonNorm" style="display: none">Stop</button>
+    <br /><span id="reportStats" style="padding-left: 8px; z-index: 1"></span><button id="btn_abort" class="buttonNorm" style="display: none">Stop and show results</button>
 </div>
 
 <div id="results" style="display: none">Loading...</div>
@@ -1311,12 +1311,17 @@ $(function() {
             abortController.abort();
             abortLoad = true;
         });
+        let firstBatchLoaded = false;
         leafSearch.getLeafFormQuery().setBatchSize(1000);
         leafSearch.getLeafFormQuery().setLimit(Infinity); // Backward compat: limit shouldn't exist
         leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
         leafSearch.getLeafFormQuery().setAbortSignal(abortController.signal);
         leafSearch.getLeafFormQuery().onProgress(progress => {
             $('#reportStats').html(`Loading ${progress}+ records`);
+            if(!firstBatchLoaded) {
+                renderGrid(leafSearch.getLeafFormQuery().getResults());
+                firstBatchLoaded = true;
+            }
         });
 
         // get data

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1313,7 +1313,8 @@ $(function() {
         });
 
         // show top results asap
-        let queryFirstBatch = leafSearch.getLeafFormQuery();
+        let queryFirstBatch = new LeafFormQuery();
+        queryFirstBatch.setQuery(structuredClone(leafSearch.getLeafFormQuery().getQuery()));
         queryFirstBatch.sort('recordID', 'DESC');
         queryFirstBatch.setLimit(50);
         queryFirstBatch.setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
@@ -1325,7 +1326,12 @@ $(function() {
         leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
         leafSearch.getLeafFormQuery().setAbortSignal(abortController.signal);
         leafSearch.getLeafFormQuery().onProgress(progress => {
-            $('#reportStats').html(`Loading ${progress}+ records`);
+            document.querySelector('#reportStats').innerText = `Loading ${progress}+ records`;
+            document.querySelector(`#${grid.getPrefixID()}tfoot`).innerHTML = `<tr>
+                <td colspan="${grid.getNumHeaders()}" style="padding: 8px; font-size: 120%; font-weight: bold">
+                <img src="./images/indicator.gif" style="vertical-align: middle" alt="" /> Loading ${progress}+ records
+                </td>
+            </tr>`;
         });
 
         // get data

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1311,6 +1311,7 @@ $(function() {
             abortController.abort();
             abortLoad = true;
         });
+        leafSearch.getLeafFormQuery().setBatchSize(1000);
         leafSearch.getLeafFormQuery().setLimit(Infinity); // Backward compat: limit shouldn't exist
         leafSearch.getLeafFormQuery().setExtraParams('&x-filterData=recordID,'+ Object.keys(filterData).join(',') + addMasqueradeParam);
         leafSearch.getLeafFormQuery().setAbortSignal(abortController.signal);

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -72,10 +72,10 @@ function addHeader(column) {
                 name: 'Title',
                 indicatorID: 'title',
                 callback: function(data, blob) {
-                    $('#'+data.cellContainerID).html(blob[data.recordID].title);
-                    $('#'+data.cellContainerID).on('click', function(){
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].title;
+                    document.querySelector(`#${data.cellContainerID}`).addEventListener('click', () => {
                         changeTitle(data, $('#'+data.cellContainerID).html());
-                });
+                    });
             }});
             break;
         case 'service':
@@ -86,7 +86,7 @@ function addHeader(column) {
                 indicatorID: 'service',
                 editable: false,
                 callback: function(data, blob) {
-                $('#'+data.cellContainerID).html(blob[data.recordID].service);
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].service;
             }});
             break;
         case 'type':
@@ -102,7 +102,7 @@ function addHeader(column) {
                          types += blob[data.recordID].categoryNames[i] + ' | ';
                      }
                      types = types.substr(0, types.length - 3);
-                     $('#'+data.cellContainerID).html(types);
+                     document.querySelector(`#${data.cellContainerID}`).innerHTML = types;
             }});
             break;
         case 'status':
@@ -119,7 +119,7 @@ function addHeader(column) {
                      if(blob[data.recordID].deleted > 0) {
                          status += ', Cancelled';
                      }
-                     $('#'+data.cellContainerID).html(status);
+                     document.querySelector(`#${data.cellContainerID}`).innerHTML = status;
             }});
             break;
         case 'initiator':
@@ -128,7 +128,7 @@ function addHeader(column) {
             leafSearch.getLeafFormQuery().join('initiatorName');
             headers.push({
                 name: 'Initiator', indicatorID: 'initiator', editable: false, callback: function(data, blob) {
-                $('#'+data.cellContainerID).html(blob[data.recordID].lastName + ', ' + blob[data.recordID].firstName);
+                document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].lastName + ', ' + blob[data.recordID].firstName;
             }});
             break;
         case 'dateCancelled':
@@ -139,7 +139,7 @@ function addHeader(column) {
                 name: 'Date Cancelled', indicatorID: 'dateCancelled', editable: false, callback: function(data, blob) {
                 if(blob[data.recordID].deleted > 0) {
                     var date = new Date(blob[data.recordID].deleted * 1000);
-                    $('#'+data.cellContainerID).html(date.toLocaleDateString().replace(/[^ -~]/g,'')); // IE11 encoding workaround: need regex replacement
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = date.toLocaleDateString();
                 }
             }});
             headers.push({
@@ -147,7 +147,7 @@ function addHeader(column) {
                 if(blob[data.recordID].action_history != undefined) {
                     var cancelData = blob[data.recordID].action_history.pop();
                     if(cancelData != undefined && cancelData.actionType === 'deleted') {
-                        $('#'+data.cellContainerID).html(cancelData.approverName);
+                        document.querySelector(`#${data.cellContainerID}`).innerHTML = cancelData.approverName;
                     }
                 }
             }});
@@ -157,7 +157,7 @@ function addHeader(column) {
             headers.push({
                 name: 'Date Initiated', indicatorID: 'dateInitiated', editable: false, callback: function(data, blob) {
                 var date = new Date(blob[data.recordID].date * 1000);
-                $('#'+data.cellContainerID).html(date.toLocaleDateString().replace(/[^ -~]/g,'')); // IE11 encoding workaround: need regex replacement
+                document.querySelector(`#${data.cellContainerID}`).innerHTML = date.toLocaleDateString();
             }});
             break;
         case 'dateResolved':
@@ -167,13 +167,13 @@ function addHeader(column) {
                 name: 'Date Resolved', indicatorID: 'dateResolved', editable: false, callback: function(data, blob) {
                 if(blob[data.recordID].recordResolutionData != undefined) {
                     var date = new Date(blob[data.recordID].recordResolutionData.fulfillmentTime * 1000);
-                    $('#'+data.cellContainerID).html(date.toLocaleDateString().replace(/[^ -~]/g,'')); // IE11 encoding workaround: need regex replacement
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = date.toLocaleDateString();
                 }
             }});
             headers.push({
                 name: 'Action Taken', indicatorID: 'typeResolved', editable: false, callback: function(data, blob) {
                 if(blob[data.recordID].recordResolutionData != undefined) {
-                    $('#'+data.cellContainerID).html(blob[data.recordID].recordResolutionData.lastStatus);
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].recordResolutionData.lastStatus;
                 }
             }});
             break;
@@ -183,21 +183,21 @@ function addHeader(column) {
             headers.push({
                 name: 'Resolved By', indicatorID: 'resolvedBy', editable: false, callback: function(data, blob) {
                 if(blob[data.recordID].recordResolutionBy != undefined) {
-                    $('#'+data.cellContainerID).html(blob[data.recordID].recordResolutionBy.resolvedBy);
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].recordResolutionBy.resolvedBy;
                 }
             }});
             break;
         case 'actionButton':
             headers.unshift({
                 name: 'Action', indicatorID: 'actionButton', editable: false, callback: function(data, blob) {
-                $('#'+data.cellContainerID).html('<div tabindex="0" class="buttonNorm">Take Action</div>');
-                $('#'+data.cellContainerID).on('keydown', function(e) {
+                document.querySelector(`#${data.cellContainerID}`).innerHTML = '<div tabindex="0" class="buttonNorm">Take Action</div>';
+                document.querySelector(`#${data.cellContainerID}`).addEventListener('keydown', function(e) {
                     if (e.which === 13) {
                         e.preventDefault();
                         loadWorkflow(data.recordID, grid.getPrefixID());
                     }
                 });
-                $('#'+data.cellContainerID).on('click', function() {
+                document.querySelector(`#${data.cellContainerID}`).addEventListener('click', function() {
                     loadWorkflow(data.recordID, grid.getPrefixID());
                 });
             }});
@@ -224,7 +224,7 @@ function addHeader(column) {
                          }
                      }
                      buffer += '</table>';
-                     $('#'+data.cellContainerID).html(buffer);
+                     document.querySelector(`#${data.cellContainerID}`).innerHTML = buffer;
             }});
             break;
         case 'approval_history':
@@ -253,7 +253,7 @@ function addHeader(column) {
                                + delimLF + '</tr>';
                      }
                      buffer += '</table>';
-                     $('#'+data.cellContainerID).html(buffer);
+                     document.querySelector(`#${data.cellContainerID}`).innerHTML = buffer;
                  }});
             break;
         case 'days_since_last_action':
@@ -305,7 +305,7 @@ function addHeader(column) {
                     else {
                         daysSinceAction = "Not Submitted";
                     }
-                    $('#'+data.cellContainerID).html(daysSinceAction);
+                    document.querySelector(`#${data.cellContainerID}`).innerHTML = daysSinceAction;
                 }
             });
             break;
@@ -339,7 +339,7 @@ function addHeader(column) {
                         content = new Date(fulfillmentTime + destMilliseconds).toLocaleDateString();
                     }
                 }
-                $('#'+data.cellContainerID).html(content);
+                document.querySelector(`#${data.cellContainerID}`).innerHTML = content;
             }});
             break;
         default:
@@ -357,10 +357,10 @@ function addHeader(column) {
                         if(blob[data.recordID].recordsDependencies != undefined
                             && blob[data.recordID].recordsDependencies[depID] != undefined) {
                             var date = new Date(blob[data.recordID].recordsDependencies[depID].time * 1000);
-                            $('#'+data.cellContainerID).html(date.toLocaleDateString().replace(/[^ -~]/g,'')); // IE11 encoding workaround: need regex replacement
+                            document.querySelector(`#${data.cellContainerID}`).innerHTML = date.toLocaleDateString();
                             if(tDepHeader[depID] == 0) {
                                 headerID = data.cellContainerID.substr(0, data.cellContainerID.indexOf('_') + 1) + 'header_' + column;
-                                $('#' + headerID).html(blob[data.recordID].recordsDependencies[depID].description);
+                                document.querySelector(`#${headerID}`).innerHTML = blob[data.recordID].recordsDependencies[depID].description;
                                 tDepHeader[depID] = 1;
                             }
                         }
@@ -381,11 +381,11 @@ function addHeader(column) {
                         if(blob[data.recordID].stepFulfillment != undefined
                             && blob[data.recordID].stepFulfillment[stepID] != undefined) {
                             var date = new Date(blob[data.recordID].stepFulfillment[stepID].time * 1000);
-                            $('#'+data.cellContainerID).html(date.toLocaleDateString().replace(/[^ -~]/g,'')); // IE11 encoding workaround: need regex replacement
+                            document.querySelector(`#${data.cellContainerID}`).innerHTML = date.toLocaleDateString();
 
                             if(tStepHeader[stepID] == 0) {
                                 headerID = data.cellContainerID.substr(0, data.cellContainerID.indexOf('_') + 1) + 'header_' + column;
-                                $('#' + headerID).html(blob[data.recordID].stepFulfillment[stepID].step);
+                                document.querySelector(`#${headerID}`).innerHTML = blob[data.recordID].stepFulfillment[stepID].step;
                                 tStepHeader[stepID] = 1;
                             }
                         }

--- a/x-test/API-tests/database/portal_test_db.sql
+++ b/x-test/API-tests/database/portal_test_db.sql
@@ -6273,7 +6273,7 @@ INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `prio
 (3,	1692287472,	0,	'tester',	'LEAF Secure Certification',	0,	'Approved',	1692287490,	1692287512,	0,	1),
 (4,	1692287968,	0,	'tester',	'LEAF Secure Certification',	0,	NULL,	0,	1692287993,	1,	1),
 (5,	1692288069,	0,	'tester',	'LEAF Secure Certification',	0,	'Submitted',	1692288081,	0,	0,	1),
-(6,	1693258385,	0,	'tester',	'untitled',	0,	NULL,	0,	0,	1,	1),
+(6,	1693258385,	0,	'VTRSHHZOFIA',	'TestFormQuery_DescendingIndex',	0,	NULL,	0,	0,	1,	1),
 (7,	1694021464,	0,	'tESTER',	'Requestor followup - Different Username case sensitivity',	0,	'Re-opened for editing',	0,	0,	1,	1),
 (8,	1694021464,	0,	'tester',	'TestFormWorkflow_ApplyAction',	0,	'Approved',	1694021485,	0,	0,	1),
 (9,	1694021464,	0,	'tester',	'TestFormQuery_GroupClickedApprove',	0,	'Approved',	1694021485,	0,	0,	1),

--- a/x-test/API-tests/formQuery_test.go
+++ b/x-test/API-tests/formQuery_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -125,5 +126,21 @@ func TestFormQuery_GroupClickedApprove(t *testing.T) {
 
 	if _, exists := res[9]; !exists {
 		t.Errorf(`Record 9 should exist because the "Group designated step" clicked "Approve". want = recordID 9 exists in the result set`)
+	}
+}
+
+func TestFormQuery_DescendingIndex(t *testing.T) {
+	// This test reproduces an issue where a descending recordID index in MySQL <= 8.4 results in unexpected query results
+	// when 2 or more potential indexes can be used. Reliably reproducing this issue also requires a new record to be created.
+	postData := url.Values{}
+	postData.Set("CSRFToken", CsrfToken)
+	postData.Set("numform_5ea07", "1")
+	postData.Set("title", "TestFormQuery_DescendingIndex")
+	client.PostForm(RootURL+`api/form/new`, postData)
+
+	res, _ := getFormQuery(RootURL + `api/form/query/?q={"terms":[{"id":"userID","operator":"=","match":"VTRSHHZOFIA","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["service","status","categoryName"],"sort":{"column":"recordID","direction":"DESC"},"limit":50}`)
+
+	if _, exists := res[6]; !exists {
+		t.Errorf(`Record ID should exist because VTRSHHZOFIA is the initiator. want = recordID is not null`)
 	}
 }


### PR DESCRIPTION
This will help us avoid potential issues in the future.

Originally when exploring this, it was thought that only MySQL <= 8.0.32 had issues with a descending records.recordID index. In the process of creating an automated test, it was apparent that no current version of MySQL supports this.


### Potential Impact
No dependencies.

### Testing
- [ ] Automated tests pass