### PR TITLE
Leaf 4397 - formGrid.js Accessibility improvements

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -222,7 +222,7 @@ var LeafFormGrid = function (containerID, options) {
     headers = headersIn;
     let temp = `<tr id="${prefixID}thead_tr">`;
     if (showIndex) {
-      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" role="button">
+      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" role="button" aria-label="Sort by unique ID">
         UID
         <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
       </th>`;
@@ -251,7 +251,7 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" role="button">
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" role="button" aria-label="Sort by ${headers[i].name}">
         ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
         </th>`);
 
@@ -367,21 +367,24 @@ var LeafFormGrid = function (containerID, options) {
   function sort(key, order, callback) {
     sortDirection[key] = order;
     const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
-    const headerText = document.querySelector(headerSelector)?.innerText || "";
+    let headerText = '';
+    for(let i in headers) {
+      if(headers[i].name == key) {
+        headerText = headers[i].name;
+        break;
+      }
+    }
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
 
     $("." + prefixID + "sort").css("display", "none");
-    $(`th[id*="${prefixID}header_"]`).removeAttr('aria-sort');
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", ascending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
-      $(headerSelector).attr('aria-sort', 'ascending');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", descending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>');
-      $(headerSelector).attr('aria-sort', 'descending');
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];

--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -369,7 +369,7 @@ var LeafFormGrid = function (containerID, options) {
     const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
     let headerText = '';
     for(let i in headers) {
-      if(headers[i].name == key) {
+      if(headers[i].indicatorID == key) {
         headerText = headers[i].name;
         break;
       }


### PR DESCRIPTION
- When navigating through column headers, screen readers will say "Sort by column [name of column]"
- Resolves aria-attribute mismatch @aerinkayne 

## Potential Impact
Specifically table headers on the Homepage and Report Builder

## Testing
- [ ] Headers on the Homepage and Report Builder work normally