### PR TITLE
Leaf 4401 - File manager: last modified date

### DIFF
--- a/LEAF_Request_Portal/admin/css/style.css
+++ b/LEAF_Request_Portal/admin/css/style.css
@@ -227,17 +227,56 @@ table.agenda {
 }
 
 table.leaf_grid {
-  border: 1px solid black;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 2px;
-  width: 95%;
-  table-layout: fixed;
 }
-table.leaf_grid td {
-  vertical-align: top;
-  word-break: break-word;
-  white-space: pre-wrap;
-  width: 20%;
+
+table.leaf_grid th {
+  font-weight: normal;
+  padding: 4px 2px 4px 2px;
+  font-size: 12px;
+  background-color: rgb(209, 223, 255);
+  border-top: 1px solid black;
+}
+table.leaf_grid th:hover,
+table.leaf_grid th:focus {
+  background-color: #79a2ff;
+}
+
+table.leaf_grid > tbody {
+  background-color: white;
+}
+
+table.leaf_grid th:first-child,
+table.leaf_grid td:first-child {
+  border-left: 1px solid black;
+}
+
+table.leaf_grid thead tr th,
+table.leaf_grid tbody tr td,
+table.leaf_grid tfoot tr td {
+  border-bottom: 1px solid black;
+  border-right: 1px solid black;
+  transition: filter 0.25s;
+}
+
+table.leaf_grid>tbody>tr>td {
+  padding: 8px;
+}
+
+.leaf_grid-loading tr td {
+  background: linear-gradient(90deg, #ffffff, #dbdbdb, #ffffff);
+  animation: leaf_grid-loading 30s linear infinite;
+}
+
+@keyframes leaf_grid-loading {
+  0% {
+      background-position: 0 0;
+  }
+  100% {
+      background-position: 1200px 0;
+  }
 }
 
 .agenda td {

--- a/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
@@ -60,7 +60,8 @@ function showFiles() {
             
             grid.setHeaders([
                 {name: 'Filename', indicatorID: 'file', editable: false, callback: function(data, blob) {
-                    $('#'+data.cellContainerID).html(`../files/${blob[data.recordID].file}`);
+                    let filePath = `../files/${blob[data.recordID].file}`;
+                    $('#'+data.cellContainerID).html(`<a href="${filePath}">${filePath}</a>`);
                 }},
                 {name: 'Last Modified', indicatorID: 'lastModified', editable: false, callback: function(data, blob) {
                     let modTime = new Date(blob[data.recordID].modifiedTime * 1000);

--- a/LEAF_Request_Portal/api/controllers/SystemController.php
+++ b/LEAF_Request_Portal/api/controllers/SystemController.php
@@ -71,7 +71,7 @@ class SystemController extends RESTfulResponse
         });
 
         $this->index['GET']->register('system/files', function ($args) use ($system) {
-            return $system->getFileList();
+            return $system->getFileList($_GET['getLastModified']);
         });
 
         $this->index['GET']->register('system/settings', function ($args) use ($system) {

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -589,8 +589,14 @@ class System
         return 1;
     }
 
-
-    public function getFileList($getLastModified = false)
+    /**
+     * getFileList retrieves filenames uploaded via Admin Panel -> File Manager
+     *
+     * @param bool getLastModified If set to true, the returned elements within the array include [file, modifiedTime]
+     * 
+     * @return array
+     */
+    public function getFileList(bool $getLastModified = false): array
     {
         if (!$this->login->checkGroup(1))
         {

--- a/LEAF_Request_Portal/sources/System.php
+++ b/LEAF_Request_Portal/sources/System.php
@@ -590,7 +590,7 @@ class System
     }
 
 
-    public function getFileList()
+    public function getFileList($getLastModified = false)
     {
         if (!$this->login->checkGroup(1))
         {
@@ -605,7 +605,12 @@ class System
             if (in_array(strtolower($ext), $this->fileExtensionWhitelist)
                 && $item != 'index.html')
             {
-                $out[] = $item;
+                if($getLastModified == false) {
+                    $out[] = $item;
+                }
+                else {
+                    $out[] = ['file' => $item, 'modifiedTime' => filemtime('../files/' . $item)];
+                }
             }
         }
 


### PR DESCRIPTION
This adds a "Last Modified" column to the File Manager.

API Change:
- `./api/system/files` now accepts the optional GET parameter `getLastModified`. When set, it includes the last modified time for each file.


## Potential Impact
- Impact due to API change mitigated via use of backward compatible $_GET flag
- CSS style for leaf_grid was updated in the admin area. This might actually indirectly fix styling for the LEAF Library, which can only be checked in pre-prod.

## Testing
- [ ] Files and their last modified dates show up correctly in the File Manager