### PR TITLE
Leaf 4403 - Loading UX

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -324,7 +324,7 @@ var LeafFormGrid = function (containerID, options) {
     // sticky header UX
     const domHeader = document.querySelector(`#${prefixID}thead`);
     const observer = new IntersectionObserver((evt) => {
-      if(evt[0].boundingClientRect.y != evt[0].intersectionRect.y) {
+      if(evt[0].boundingClientRect.y == evt[0].intersectionRect.y) {
         $("#" + prefixID + "table thead tr th").css({
           "filter": "invert(1) grayscale(1)",
           height: "1.3rem",
@@ -350,8 +350,9 @@ var LeafFormGrid = function (containerID, options) {
         });
       }
     }, {
+      root: document.querySelector(`#${prefixID}table`),
       rootMargin: -stickyHeaderOffset - 1 + 'px 0px 0px 0px',
-      threshold: [1],
+      threshold: 1,
     });
     
     observer.observe(domHeader);

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1347,6 +1347,7 @@ $(function() {
         });
 
         // show top results asap
+        document.querySelector('#reportStats').innerText = `Loading...`;
         let queryFirstBatch = new LeafFormQuery();
         queryFirstBatch.setQuery(structuredClone(leafSearch.getLeafFormQuery().getQuery()));
         queryFirstBatch.sort('recordID', 'DESC');


### PR DESCRIPTION
This shows the "loading" text a little earlier, and resolves a styling issue.

Steps to reproduce issue:
1. Navigate to the report builder
2. In Step 2, select as many columns as needed to overflow the horizontal scroll in the generated report
3. When the horizontal scroll overflows, scrolling down is supposed to invert the header's color

## Potential Impact
Minimal because this only presets the status text.

## Testing
- [ ] Report Builder loads correctly
- [ ] The issue cannot be reproduced