### PR TITLE
LEAF 4404 action_history userMetadata portal db upgrade file

### DIFF
--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024060700-2024062000.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024060700-2024062000.sql
@@ -1,0 +1,16 @@
+START TRANSACTION;
+
+ALTER TABLE `action_history` ADD COLUMN `userMetadata` json DEFAULT NULL;
+
+UPDATE `settings` SET `data` = '2024062000' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+ALTER TABLE `action_history` DROP COLUMN `userMetadata`;
+
+UPDATE `settings` SET `data` = '2024060700' WHERE `settings`.`setting` = 'dbversion';
+COMMIT;
+*/


### PR DESCRIPTION
This is associated with the overall story for 4373.  Separated out for easier tracking and deployment

DB upgrade file to add a userMetadata column to the portal action_history table.
