### PR TITLE
Leaf 4406 - Custom Email Recipient List

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -240,6 +240,17 @@
     const allowedToCcFormats = {
         "orgchart_employee": 1,
     }
+
+    $(function(){
+        $('#emailToCode').on("keyup", function(e) {
+            this.value = this.value.replace(/[;:\s]/, ',');
+        });
+
+        $('#emailCcCode').on("keyup", function(e) {
+            this.value = this.value.replace(/[;:\s]/, ',');
+        });
+    });
+
     /**
     * Force show or hide the right nav despite screen width
     * @param {bool} showNav
@@ -275,7 +286,7 @@
         return data;
     }
 
-    /** 
+    /**
     * used on load and as a listener on email To CC fields
     * displays a message if non-orgchart employee format indicators are referenced in these areas
     */
@@ -1182,7 +1193,7 @@
     }
     //loads components when the document loads
     $(document).ready(function() {
-        getIndicators(); //get indicators to make format table 
+        getIndicators(); //get indicators to make format table
         getForms(); //get forms for quick search and indicator format info
 
         dialog = new dialogController(


### PR DESCRIPTION
Summary:
A portal had entered recipients into a custom email template and separated them with a ;. This caused the email to not get sent. This fix prevents ; : and space.

Potential Impact:
Emails will go out when expected and won't get hung up on an improperly formatted recipient list

Testing:
Navigate to the email template
select a template and enter recipients in the To and CC fields, try entering any of the characters above, they will be changed to commas.