### PR TITLE
LEAF 4402 update gridsplitter to use formQuery

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_table_input_report.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_table_input_report.tpl
@@ -1,64 +1,61 @@
 <style type="text/css">
-    div#dataFieldContainer, div#progress, button#download {
+    #bodyarea {
+        padding: 1rem;
+        min-height: 100vh;
+        font-size:14px;
+    }
+    #tableInputExport {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+    div#dataFieldContainer, button#download {
         display:none;
+    }
+    label {
+        display: block;
+        margin-bottom:2px;
+        font-weight: bolder;
+    }
+    select {
+        font: inherit;
     }
 </style>
 
 <script>
+const msgStart = "Use the dropdowns to select a question";
 let headerArray = [];
 let bodyObj = {};
 let indicatorFormats = [];
 let processedRecords = 0;
-
-//populate dropdown for forms
-$.ajax({
-    type: 'GET',
-    url: './api/form/categories'
-}).done(function(data) {
-    for(let i = 0; i < data.length; i++)
-    {
-        $('select#forms').append($("<option />").val(data[i].categoryID).text(data[i].categoryName));
-    }
-}).fail(function (jqXHR, error, errorThrown) {
-    console.log(jqXHR);
-    console.log(error);
-    console.log(errorThrown);
-});
-
-//when a form is selected, populate the indicator select
-$(document).on('change', 'select#forms', function() {
-    $('button#download').hide();
-    populateIndicators(this.value);
-});
+let totalResults = null;
 
 //when an indicator is selected, show download button
-$(document).on('change', 'select#dataField', function() {
-    if(this.value !== '')
-    {
+function selectDataField(indicatorID = "") {
+    $('#progress').text(msgStart);
+    if(this.value !== '') {
         $('button#download').show();
-        $('div#progress').hide();
-    }
-    else
-    {
+    } else {
         $('button#download').hide();
-        $('div#progress').hide();
     }
-});
+}
 
 //when button is clicked, start the export process
 $(document).on('click', 'button#download', function() {
-    if($('select#dataField').val() !== '')
-    {
+    if($('select#dataField').val() !== '') {
+        $('#progress').text('Processing ...');
+        processedRecords = 0;
+        totalResults = 0;
         buildHeaderArray(indicatorFormats[$('select#dataField').val()]);
-        getDataForExport($('select#forms').val(), $('select#dataField').val());
+        queryIndicator($('select#forms').val(), $('select#dataField').val());
     }
 });
 
 //populate dropdown of table input indicators
-function populateIndicators(categoryID)
-{
-    if(categoryID != '')
-    {
+function populateIndicators(categoryID) {
+    $('#progress').text(msgStart);
+    if(categoryID != '') {
         $.ajax({
             type: 'GET',
             url: './api/form/indicator/list',
@@ -70,21 +67,20 @@ function populateIndicators(categoryID)
             $('select#dataField').empty();
             $('select#dataField').append($('<option />').val('').text('-Select Data Field-'));
             let anyTables = false;
-            for(let i = 0; i < data.length; i++)
-            {
+            for(let i = 0; i < data.length; i++) {
                 const format = data[i].format;
                 if (format.match(/^grid/) && data[i].isDisabled === 0) {
                     anyTables = true;
-                    $('select#dataField').append($('<option />').val(data[i].indicatorID).text(data[i].name.replace( /(<([^>]+)>)/ig, '').replace('&nbsp;', ' ')));
+                    let text = data[i].name.replace( /(<([^>]+)>)/ig, '').replace('&nbsp;', ' ');
+                    text = text.length <= 55 ? text : text.slice(0, 55) + '...';
+                    $('select#dataField').append($('<option />').val(data[i].indicatorID).text(text));
                     indicatorFormats[data[i].indicatorID] = JSON.parse(format.substring(5));
                 }
             }
-            if(!anyTables)
-            {
+            if(!anyTables) {
                 $('div#dataFieldContainer').hide();
                 alert('No grid input found in this form.');
-            }
-            else{
+            } else{
                 $('div#dataFieldContainer').show();
             }
         }).fail(function (jqXHR, error, errorThrown) {
@@ -92,104 +88,53 @@ function populateIndicators(categoryID)
             console.log(error);
             console.log(errorThrown);
         });
-    }
-    else
-    {
+
+    } else {
         $('div#dataFieldContainer').hide();
     }
 }
 
 //build the header array
 //these will be the headers for the current version of the grid
-function buildHeaderArray(columnNames)
-{
+function buildHeaderArray(columnNames) {
     headerArray = [];
-    if(typeof columnNames !== 'undefined')
-    {
-        for(let i = 0; i < columnNames.length; i++)
-        {
+    if(typeof columnNames !== 'undefined') {
+        for(let i = 0; i < columnNames.length; i++) {
             headerArray.push(columnNames[i].name);
         }
     }
 }
 
-//get all submitted records using this form
-function getDataForExport(categoryID, indicatorID)
-{
-    processedRecords = 0;
-    $.ajax({
-        type: 'GET',
-        url: './api/form/_'+categoryID+'/records'
-    }).done(function(data) {
-        bodyObj = {};
-        for(let i = 0; i < data.length; i++)
-        {
-            if(data[i].submitted != 0)
-            {
-                bodyObj[data[i].recordID] = [];
-            }
-        }
-        recordIDs = Object.keys(bodyObj);
-        for(let i = 0; i < recordIDs.length; i++)
-        {
-            addRecordData(recordIDs[i], indicatorID)
-        }
-    }).fail(function (jqXHR, error, errorThrown) {
-        console.log(jqXHR);
-        console.log(error);
-        console.log(errorThrown);
-    });
-}
-
 //get data for the selected indicator associated with the given recordID
-function addRecordData(recordID, indicatorID)
-{
-    $.ajax({
-        type: 'GET',
-        url: './api/formEditor/indicator/'+indicatorID,
-        data: {
-            recordID: recordID
+function addRecordData(recordID, indicatorID, gridInput = {}) {
+    let dataRows = gridInput?.cells;
+    bodyObj[recordID] = [];
+    if (dataRows !== null && dataRows !== undefined) {
+        for (let i = 0; i < dataRows.length; i++) {
+            bodyObj[recordID].push(dataRows[i]);
         }
-    }).done(function(data) {
-        let dataRows = data[indicatorID]['value']['cells'];
-        if (dataRows !== null && dataRows !== undefined) {
-            for (let i = 0; i < dataRows.length; i++) {
-                bodyObj[recordID].push(dataRows[i]);
-            }
-            updateProgress();
-        } else {
-            //if the data for this request isn't in table format, just mark as processed
-            updateProgress();
-        }
-    }).fail(function (jqXHR, error, errorThrown) {
-        console.log(jqXHR);
-        console.log(error);
-        console.log(errorThrown);
-    });
+        updateProgress();
+    } else {
+        //if the data for this request isn't in table format, just mark as processed
+        updateProgress();
+    }
 }
 
 //update the progress dialog
-function updateProgress()
-{
-    let numberOfRecords = Object.keys(bodyObj).length;
+function updateProgress() {
     processedRecords++;
-    $('div#progress span').html(processedRecords + "/" + numberOfRecords);
-
-    if(processedRecords === numberOfRecords)
-    {
+    if(totalResults && processedRecords === totalResults) {
+        $('#progress').text('Complete.  Total Results: ' + totalResults);
         exportCSV();
     }
 }
 
 //build and deliver the CSV
-function exportCSV()
-{
+function exportCSV() {
     let output = [];
     let rows = '';
-
     let extraHeaderColumns = ['RecordID', 'tableRow'];
     output.push(extraHeaderColumns.concat(headerArray));
-
     let currentRow = 1;
     $.each( bodyObj, function( recordID, dataRowArray ) {
         $.each( dataRowArray, function( key, dataRow ) {
@@ -199,14 +144,10 @@ function exportCSV()
         });
     });
 
-    //unhide progress bar
-    $('div#progress').show();
-    $(output).each(function(idx, thisRow)
-    {
+    $(output).each(function(idx, thisRow) {
         //escape double quotes
         $(thisRow).each(function(idx, col) {
-            if(typeof col === 'string')
-            {
+            if(typeof col === 'string') {
                 thisRow[idx] = col.replace(/\"/g, "\"\"");
             }
         });
@@ -227,25 +168,65 @@ function exportCSV()
         download.click();
     }
     document.body.removeChild(download);
-
 }
+
+async function queryIndicator(catID='', indicatorID=0) {
+    let query = new LeafFormQuery();
+    query.getData(indicatorID);
+    query.addTerm('deleted', '=', 0);
+    query.addTerm('submitted', '>', 0);
+    query.addTerm('categoryID', '=', catID);
+
+    let resultSet = {};
+    query.onSuccess(function(res, resStatus, resJqXHR) {
+        resultSet = Object.assign(resultSet, res);
+        totalResults = Object.keys(resultSet)?.length || 0;
+        if(totalResults === 0) {
+            $('#progress').text("No requests for selection");
+        } else {
+            bodyObj = {};
+            for(let recordID in resultSet) {
+                addRecordData(recordID, indicatorID, resultSet[recordID]?.s1?.["id" + indicatorID + "_gridInput"]);
+            }
+        }
+    });
+    await query.execute();
+}
+
+function main() {
+    //populate dropdown for forms
+    $.ajax({
+        type: 'GET',
+        url: './api/form/categories'
+    }).done(function(data) {
+        for(let i = 0; i < data.length; i++) {
+            $('select#forms').append($("<option />").val(data[i].categoryID).text(data[i].categoryName));
+        }
+        $('#progress').text(msgStart);
+    }).fail(function (jqXHR, error, errorThrown) {
+        console.log(jqXHR);
+        console.log(error);
+        console.log(errorThrown);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', main);
 </script>
 
 <div id="tableInputExport">
-    <label for="forms">Select a form: </label>
-    <select name="forms" id="forms">
-        <option value="">-Select Form-</option>
-    </select>
-    <br/><br/>
-    <div id="dataFieldContainer">
-        <label for="dataField">Select a data field: </label>
-        <select name="dataField" id="dataField">
+    <div id='progress'>Loading...</div>
+    <div id="formsContainer">
+        <label for="forms">Select a form: </label>
+        <select name="forms" id="forms" onchange="populateIndicators(this.value)">
+            <option value="">-Select Form-</option>
         </select>
     </div>
-    <br/>
+    <div id="dataFieldContainer">
+        <label for="dataField">Select a data field:</label>
+        <select name="dataField" id="dataField" onchange="selectDataField(this.value)"></select>
+    </div>
     <button class="buttonNorm" type="button" style="font-weight: bold; font-size: 120%" name="download" id="download">
         <img src="dynicons/?img=go-next.svg&amp;w=32" alt="">
-        Download&nbsp;
+        Download
     </button>
-    <div id='progress'>Progress: <span></span></div>
 </div>

--- a/LEAF_Request_Portal/templates/reports/LEAF_table_input_report.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_table_input_report.tpl
@@ -106,7 +106,7 @@ function buildHeaderArray(columnNames) {
 }
 
 //get data for the selected indicator associated with the given recordID
-function addRecordData(recordID, indicatorID, gridInput = {}) {
+function addRecordData(recordID, gridInput = {}) {
     let dataRows = gridInput?.cells;
     bodyObj[recordID] = [];
     if (dataRows !== null && dataRows !== undefined) {
@@ -186,7 +186,7 @@ async function queryIndicator(catID='', indicatorID=0) {
         } else {
             bodyObj = {};
             for(let recordID in resultSet) {
-                addRecordData(recordID, indicatorID, resultSet[recordID]?.s1?.["id" + indicatorID + "_gridInput"]);
+                addRecordData(recordID, resultSet[recordID]?.s1?.["id" + indicatorID + "_gridInput"]);
             }
         }
     });


### PR DESCRIPTION
Updates the grid-splitter report to use formQuery methods to query the selection rather than getting data for each record.
Minor style updates.

**Testing / Impact**

LEAF Programmer built-in report: LEAF_table_input_report

Confirm that grid format question entries for submitted requests can be split into columns and downloaded