### PR TITLE
LEAF 4357 avoid multiple joins (INC33064668 report not loading)

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -881,7 +881,6 @@ var LeafFormSearch = function (containerID) {
                             callback();
                         }
                     },
-                    cache: false,
                 });
                 break;
             case "userID":

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3702,9 +3702,9 @@ class Form
         foreach ($res as $item)
         {
             if(!isset($data[$item['recordID']])) {
-                $data[$item['recordID']] = $item;
                 $recordIDs .= $item['recordID'] . ',';
             }
+            $data[$item['recordID']] = $item;
         }
         $recordIDs = trim($recordIDs, ',');
         $recordIDs = $recordIDs ?: 0;

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3180,7 +3180,7 @@ class Form
 
                     break;
                 case 'categoryID':
-                    if (!strpos($joins,'category_count')) {
+                    if (!str_contains($joins,'lj_category_count')) {
                         $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_category_count USING (recordID) ";
                     }
                     if ($q['operator'] != '!=')
@@ -3234,7 +3234,7 @@ class Form
                             /*case 'destruction':
                                 $conditions .= "{$gate}(categories.destructionAge IS NOT NULL AND ".
                                     "records_workflow_state.stepID IS NULL AND submitted != 0)";
-                                if (!strpos($joins,'category_count')) {
+                                if (!str_contains($joins,'lj_category_count')) {
                                     $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_category_count USING (recordID) ";
                                 }
                                 $joins .= "LEFT JOIN categories USING (categoryID) ";
@@ -3297,7 +3297,7 @@ class Form
                                 $conditions .= "{$gate}(categories.destructionAge IS NULL OR ".
                                     "(records_workflow_state.stepID IS NOT NULL OR submitted = 0)".
                                 ")";
-                                if (!strpos($joins,'category_count')) {
+                                if (!str_contains($joins,'lj_category_count')) {
                                     $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_category_count USING (recordID) ";
                                 }
                                 $joins .= "LEFT JOIN categories USING (categoryID) ";

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3180,17 +3180,18 @@ class Form
 
                     break;
                 case 'categoryID':
+                    if (!strpos($joins,'category_count')) {
+                        $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_category_count USING (recordID) ";
+                    }
                     if ($q['operator'] != '!=')
                     {
                         // Backwards Compatibility
-                        $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_categoryID{$count} USING (recordID) ";
-                        $conditions .= "{$gate}lj_categoryID{$count}.categoryID = :categoryID{$count}";
+                        $conditions .= "{$gate}lj_category_count.categoryID = :categoryID{$count}";
                     }
                     else
                     {
                         // Backwards Compatibility
-                        $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_categoryID{$count} USING (recordID) ";
-                        $conditions .= "{$gate}lj_categoryID{$count}.categoryID != :categoryID{$count}";
+                        $conditions .= "{$gate}lj_category_count.categoryID != :categoryID{$count}";
                     }
 
                     break;
@@ -3234,7 +3235,7 @@ class Form
                                 $conditions .= "{$gate}(categories.destructionAge IS NOT NULL AND ".
                                     "records_workflow_state.stepID IS NULL AND submitted != 0)";
                                 if (!strpos($joins,'category_count')) {
-                                    $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_categoryID{$count} USING (recordID) ";
+                                    $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_category_count USING (recordID) ";
                                 }
                                 $joins .= "LEFT JOIN categories USING (categoryID) ";
                                 $joins .= "LEFT JOIN records_workflow_state USING (recordID) ";
@@ -3297,7 +3298,7 @@ class Form
                                     "(records_workflow_state.stepID IS NOT NULL OR submitted = 0)".
                                 ")";
                                 if (!strpos($joins,'category_count')) {
-                                    $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_categoryID{$count} USING (recordID) ";
+                                    $joins .= "LEFT JOIN (SELECT * FROM category_count WHERE count > 0) lj_category_count USING (recordID) ";
                                 }
                                 $joins .= "LEFT JOIN categories USING (categoryID) ";
                                 $joins .= "LEFT JOIN records_workflow_state USING (recordID) ";
@@ -3700,8 +3701,10 @@ class Form
         $recordIDs = '';
         foreach ($res as $item)
         {
-            $data[$item['recordID']] = $item;
-            $recordIDs .= $item['recordID'] . ',';
+            if(!isset($data[$item['recordID']])) {
+                $data[$item['recordID']] = $item;
+                $recordIDs .= $item['recordID'] . ',';
+            }
         }
         $recordIDs = trim($recordIDs, ',');
         $recordIDs = $recordIDs ?: 0;


### PR DESCRIPTION
Adds a check for an existing join to category_count when searching for multiple form types in the report builder before adding to the joins clause.  Updates reference names where needed.

**Testing / Impact**

Issue can be reproduced on API Testing DB (or regular local if you have 8+ form types).

-Use the Report Builder to search for numerous (8+) form types (type is form 1 OR type is form 2 etc).

-From the resulting report, open one of the requests in another tab.

-Use the admin tools 'change form'.  Add multiple forms (4+) from the checkbox selection.

-Reload the Report Builder report.

The request with multiple forms associated with it will have a large number of duplicates DB side.  The front end will repeatedly query for more results and process thousands+ before the report finally finishes loading.

Effect is exponential with form types searched and the number of forms associated with the record.
It becomes quite significant after 8-9 form types and 4 record forms (~180k duplicates).

For master branch, the front end will process through thousands of requests before loading the report.
Updated branch should load the report without this extra request count
