### PR TITLE
LEAF-4428 Dev UX

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,32 +87,13 @@ services:
             - leaf
 
     leaf-smtp:
-        #   image: kurzdigital/fake-smtp # https://hub.docker.com/r/kurzdigital/fake-smtp/
-        #   expose:
-        #     - '2525'
-        #   ports:
-        #     - "2525:25" # smtp port
-        #     - "5080:5080" # web ui port
-        #   restart: 'always'
-        #   networks:
-        #     code-network:
-        #       aliases:
-        #         - smtp
-
-        #   environment:
-        #     - "SMTP_PORT=${SMTP_PORT}"
-        #     - "APP_USER=${APP_USER}" # ui login -- defaults to tester
-        #     - "APP_PASSWORD=${APP_PASSWORD}"
-        #     - "MYSQL_USER=${MYSQL_USER}"
-        #     - "MYSQL_PASSWORD=${MYSQL_PASSWORD}"
-        image: pelentan/fake-smtp:1.0
+        image: rnwood/smtp4dev
         container_name: leaf-smtp
         env_file:
             - ./env_files/globals_local.env
             - ./env_files/secrets.env
         ports:
-            - "2525:25"
-            - "5080:5080"
+            - "5080:80"
         networks:
             - leaf
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -113,7 +113,6 @@ services:
         ports:
             - "2525:25"
             - "5080:5080"
-        restart: "always"
         networks:
             - leaf
 
@@ -136,7 +135,6 @@ services:
             - ./env_files/mysql_local.env
             - ./env_files/secrets.env
         command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION" # set same mode as prod
-        restart: "always"
         #healthcheck:
         #  test: "mysqladmin ping -h localhost -u $${MYSQL_USER} -p$${MYSQL_PASSWORD}"
         #  start_interval: 1s

--- a/docker/nginx/src/index.html
+++ b/docker/nginx/src/index.html
@@ -8,15 +8,21 @@
 <h1>LEAF Development Environment</h1>
 <h2>LEAF Sites</h2>
 <ul>
-    <li><a href="./LEAF_Request_Portal">Request Portal</a></li>
-    <li><a href="./LEAF_Nexus">Nexus</a></li>
+    <li><a href="./LEAF_Request_Portal" target="_blank">Request Portal</a></li>
+    <li><a href="./LEAF_Nexus" target="_blank">Nexus</a></li>
 </ul>
 
 <h2>Testing Helpers</h2>
 <ul>
-    <li><a href="http://localhost:8000/api/v1/test" target="_blank">API tester</a></li>
-    <li><a href="http://localhost/selenium-tests">Selenium tests</a></li>
-    <li><a href="dev/phpinfo.php">phpinfo()</a></li>
+    <li>Automated Tests
+        <ul>
+            <li><a href="http://localhost:8000/api/v1/test" target="_blank">API tester</a></li>
+            <li><a href="http://localhost/selenium-tests" target="_blank">Selenium tests</a> <b>TODO:</b> Fix this</li>
+        </ul>
+    </li>
+
+    <li><a href="http://localhost:5080/" target="_blank">SMTP Server</a></li>
+    <li><a href="dev/phpinfo.php" target="_blank">phpinfo()</a></li>
 </ul>
 
 </body>

--- a/docker/php/ssmtp/ssmtp.conf
+++ b/docker/php/ssmtp/ssmtp.conf
@@ -1,3 +1,3 @@
 hostname=fake-email.com
-mailhub=leaf-smtp
+mailhub=leaf-smtp:25
 FromLineOverride=YES

--- a/docs/InstallationConfiguration.md
+++ b/docs/InstallationConfiguration.md
@@ -38,10 +38,7 @@ docker network create leaf-sql
 
 ### Checking Email
 
-Fake SMTP server is installed as part of the Docker stack to receive email locally from the system. Navigate to https://localhost:5080/email to view emails sent from the system.
-
-- Username: tester
-- Password: tester
+smtp4dev is installed as part of the Docker stack to receive email locally from the system. Navigate to http://localhost:5080/ to view emails sent from the system.
 
 ### Vue Development
 


### PR DESCRIPTION
- Prevents mysql/smtp from auto starting
- Replaces Fake SMTP Server with smtp4dev

## Potential Impact
Only changes the dev environment

## Testing
- [ ] Emails are visible in smtp4dev without any additional configuration