### PR TITLE
LEAF-4427 Update rules for cancelling requests

### DIFF
--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -73,14 +73,18 @@ dialogController.prototype.hide = function() {
 };
 
 dialogController.prototype.show = function() {
-    //Stack clear for some events.  This helps ensure modal content is mounted before trying to set styles.
-    setTimeout(() => {
-        if($('#' + this.contentID).html() == '') {
-            $('#' + this.loadIndicatorID).css('visibility', 'visible');
-        }
-        $('#' + this.containerID).dialog('open');
-        $('#' + this.containerID).css('visibility', 'visible');
-    });
+	let promise = new Promise((resolve, reject) => {
+		//Stack clear for some events.  This helps ensure modal content is mounted before trying to set styles.
+		setTimeout(() => {
+			if($('#' + this.contentID).html() == '') {
+				$('#' + this.loadIndicatorID).css('visibility', 'visible');
+			}
+			$('#' + this.containerID).dialog('open');
+			$('#' + this.containerID).css('visibility', 'visible');
+			resolve();
+		});
+	});
+	return promise;
 };
 
 dialogController.prototype.setContent = function(content) {

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -778,7 +778,7 @@ class Email
             $recordInfo = $this->getRecord($recordID);
             $comments = $this->getDeletedComments($recordID);
 
-            $comment = $comments[0]['comment'] === '' ? '' : 'Reason for cancelling: ' . $comments[0]['comment'] . '<br /><br />';
+            $comment = $comments[0]['comment'] === '' ? '' : $comments[0]['comment'];
 
             $title = strlen($recordInfo[0]['title']) > 45 ? substr($recordInfo[0]['title'], 0, 42) . '...' : $recordInfo[0]['title'];
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -775,6 +775,8 @@ class Form
      * Only admins should be able to cancel resolved records.
      * Requestors can cancel at any time.
      * People with access to the current step can cancel.
+     * 
+     * A comment must be provided for cancellation unless it's an unsubmitted request.
      *
      * @param int $recordID
      * @param string $comment
@@ -796,6 +798,11 @@ class Form
             $return_value = 'An administrator is required to cancel a resolved request';
         }
         else if ($this->hasWriteAccess($recordID) || strtolower($res[0]['userID']) == strtolower($this->login->getUserID())) {
+            if($res[0]['submitted'] > 0 &&
+                ($comment == null || trim($comment) == '')) {
+                return 'Please explain the reason for cancellation';
+            }
+
             $vars = array(':recordID' => $recordID,
                         ':time' => time());
             $sql = 'UPDATE `records`

--- a/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
@@ -1,12 +1,11 @@
-A request that you were a part of has been cancelled.<br />
-Request #{{$recordID}} - {{$fullTitle}}.<br /><br />
-This is a notification only and no action is required on your part.<br /><br />
+For your awareness, the following request has been cancelled:<br /><br />
+<b>Request #{{$recordID}} - {{$fullTitle}}</b><br /><br />
 
-{{$comment}}
+Reason: {{$comment}}
 
-Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$fullTitle}}</a><br />
-Request status: {{$lastStatus}}<br /><br />
+<br /><br /><br />
+You are receiving this email because you have participated in this record's process in the past.<br /><br />
+
 Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
     {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
 <br />

--- a/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
@@ -4,7 +4,7 @@ For your awareness, the following request has been cancelled:<br /><br />
 Reason: {{$comment}}
 
 <br /><br /><br />
-You are receiving this email because you have participated in this record's process in the past.<br /><br />
+Note: You are receiving this email because you are associated with this record's process.<br /><br />
 
 Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
     {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -687,8 +687,15 @@ function doSubmit(recordID) {
 
     function cancelRequest() {
         dialog_confirm.setContent(
-            '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to cancel this request?<br /><textarea id="cancel_comment" cols=30 rows=3 placeholder="Enter Comment"></textarea>'
+            '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to cancel this request?<br /><textarea id="cancel_comment" cols=30 rows=3 placeholder="Please provide the reason for cancellation"></textarea>'
         );
+        dialog_confirm.setRequired(<!--{$recordID|strip_tags|escape}-->, function() {
+            let comment = document.querySelector('#cancel_comment').value;
+            if(comment.trim() == '') {
+                return true;
+            }
+            return false;
+        });
 
         dialog_confirm.setSaveHandler(function() {
             let comment = $('#cancel_comment').val();

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -686,8 +686,10 @@ function doSubmit(recordID) {
     }
 
     function cancelRequest() {
+        dialog_confirm.setTitle('Confirm');
+        <!--{if $submitted > 0}-->
         dialog_confirm.setContent(
-            '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to cancel this request?<br /><textarea id="cancel_comment" cols=30 rows=3 placeholder="Please provide the reason for cancellation"></textarea>'
+            '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to cancel this request?<br style="clear: both" /><br />The following reason will be emailed as a notification:<br /><textarea id="cancel_comment" style="width: 100%" rows=3></textarea>'
         );
         dialog_confirm.setRequired(<!--{$recordID|strip_tags|escape}-->, function() {
             let comment = document.querySelector('#cancel_comment').value;
@@ -696,6 +698,11 @@ function doSubmit(recordID) {
             }
             return false;
         });
+        <!--{else}-->
+        dialog_confirm.setContent(
+            '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to cancel this request?'
+        );
+        <!--{/if}-->
 
         dialog_confirm.setSaveHandler(function() {
             let comment = $('#cancel_comment').val();
@@ -716,8 +723,9 @@ function doSubmit(recordID) {
                 cache: false
             });
         });
-        dialog_confirm.show();
-        $('#cancel_comment').focus();
+        dialog_confirm.show().then(() => {
+            $('#cancel_comment').focus();
+        });
     }
 
     function changeTitle() {

--- a/LEAF_Request_Portal/templates/site_elements/generic_confirm_xhrDialog.tpl
+++ b/LEAF_Request_Portal/templates/site_elements/generic_confirm_xhrDialog.tpl
@@ -2,7 +2,7 @@
 <form id="confirm_record" enctype="multipart/form-data" action="javascript:void(0);">
     <div>
         <div id="confirm_loadIndicator" style="visibility: hidden; position: absolute; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; height: 100px; width: 360px">Loading... <img src="images/largespinner.gif" alt="" title="loading..." /></div>
-        <div id="confirm_xhr" style="font-size: 130%; width: 400px; height: 120px; padding: 16px; overflow: auto"></div>
+        <div id="confirm_xhr" style="font-size: 130%; width: 400px; min-height: 120px; padding: 16px; overflow: auto"></div>
         <div style="position: absolute; left: 10px; font-size: 140%"><button class="buttonNorm" id="confirm_button_cancelchange"><img src="dynicons/?img=edit-undo.svg&amp;w=32" alt="" title="No" /> No</button></div>
         <div style="text-align: right; padding-right: 6px"><button class="buttonNorm" id="confirm_button_save"><img src="dynicons/?img=dialog-apply.svg&amp;w=32" alt="" title="Yes" /><span id="confirm_saveBtnText"> Yes</span></button></div><br />
     </div>

--- a/x-test/API-tests/form_test.go
+++ b/x-test/API-tests/form_test.go
@@ -113,7 +113,7 @@ func TestForm_IsMaskable(t *testing.T) {
 	}
 }
 
-func TestForm_NonadminCannotCancelOwnSubmittedRecord(t *testing.T) {
+func TestForm_NonadminCannotCancelOwnResolvedRecord(t *testing.T) {
 	// Setup conditions
 	postData := url.Values{}
 	postData.Set("CSRFToken", CsrfToken)
@@ -133,11 +133,26 @@ func TestForm_NonadminCannotCancelOwnSubmittedRecord(t *testing.T) {
 		t.Errorf("Could not create record for TestForm_NonadminCannotCancelOwnSubmittedRecord: " + err.Error())
 	}
 
+	// Submit the form
 	postData = url.Values{}
 	postData.Set("CSRFToken", CsrfToken)
 	client.PostForm(RootURL+`api/form/`+strconv.Itoa(recordID)+`/submit`, postData)
 
-	// Non-admin shouldn't be able to cancel a submitted record
+	// Move to last step
+	postData = url.Values{}
+	postData.Set("CSRFToken", CsrfToken)
+	postData.Set("stepID", "4")
+	postData.Set("comment", "")
+	client.PostForm(RootURL+`api/formWorkflow/`+strconv.Itoa(recordID)+`/step`, postData)
+
+	// Take the last action and resolve the workflow
+	postData = url.Values{}
+	postData.Set("CSRFToken", CsrfToken)
+	postData.Set("actionType", "approve")
+	postData.Set("dependencyID", "-3")
+	client.PostForm(RootURL+`api/formWorkflow/`+strconv.Itoa(recordID)+`/apply`, postData)
+
+	// Non-admin shouldn't be able to cancel a resolved record
 	postData = url.Values{}
 	postData.Set("CSRFToken", CsrfToken)
 


### PR DESCRIPTION
This changes the rules when cancelling requests and updates the relevant email template.
 
     * Only admins should be able to cancel resolved records.
     * Requestors can cancel at any time.
     * People with access to the current step can cancel.
     * 
     * A comment must be provided for cancellation unless it's an unsubmitted request.

Previously, only admins were allowed to cancel submitted records. Cancelling a request in the middle of processing can cause confusion if people are expecting to see the record, however the notification provided via https://github.com/department-of-veterans-affairs/LEAF/pull/2423 mitigates this.

This also changes the dialogController.js .show() method to return a Promise to enable focusing on the cancellation's comment field.

Other changes:
- The email sender for cancellations and reminders was changed to the actual sender instead of "leaf.noreply@va.gov". This makes it obvious who triggered the email.
- getDirectory() was ported into Form.php from FormWorkflow.php to reduce duplicate initializations of VAMC_Directory.
- The Confirm dialog template was changed from `height: 120px` height to `min-height: 120px`.


## Potential Impact
- The new rules can cause confusion, and they need to be explained to the community.

## Testing
[ ] Automated tests pass
[ ] The rules above work
[ ] Dialog boxes work normally
