### PR TITLE
LEAF 4363 fix potential workflow copy issue

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2426,7 +2426,7 @@
     }
 
     function buildRoutesList(stepID, workflowID) {
-        let allRoutes = [...routes];
+        let allRoutes = structuredClone(routes);
         let hasSubmit = false;
         allRoutes.forEach(r => {
             if(r.actionType === "sendback") {

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -377,7 +377,10 @@ class Workflow
             return 'Restricted command.';
         }
 
-        if ($action == 'sendback') {
+        if ($action === 'sendback') {
+            if ($nextStepID !== 0) { //correct for potential copy issue.  requestor is sometimes referred to by -1 in the editor
+                $nextStepID = 0;
+            }
             $required = json_encode(array ('required' => false));
         } else {
             $required = '';


### PR DESCRIPTION
Fixes an issue that could cause the next step ID for a copied workflow to be -1 if the Step Info modal action list was used to connect sendback routes prior to copying the workflow.

This will also need some timely follow-up to look for and correct requests stuck in a -1 workflow state.

**Testing / Impact**

Workflow Editor

To reproduce this issue, complete the following steps without refreshing the page.

- select a workflow.  
- if the WF does not yet have one, add a route back to requestor
- click a mid-workflow step to open the step info modal
- use the left menu tools Copy Workflow button to copy the workflow 
- in Adminer, note that the nextStepID field for the new workflow is -1 instead of 0

Copies made on the fixed branch should copy as expected.  Adding routes with either the connectors or the action list should continue to work as expected.
