### PR TITLE
LEAF-4426: VAPO Automated Emails

### DIFF
--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024062000-2024071100.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024062000-2024071100.sql
@@ -1,0 +1,18 @@
+START TRANSACTION;
+
+ALTER TABLE `sites` ADD COLUMN `isVAPO` varchar(8) NOT NULL DEFAULT 'false' AFTER `decommissionTimestamp`;
+ALTER TABLE `sites` ADD INDEX `isVAPO` (`isVAPO`);
+ALTER TABLE `sites` ADD INDEX `site_type` (`site_type`);
+
+UPDATE `settings` SET `data` = '2024071100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+ALTER TABLE `sites` DROP COLUMN `isVAPO`;
+
+UPDATE `settings` SET `data` = '2024062000' WHERE `settings`.`setting` = 'dbversion';
+COMMIT;
+*/

--- a/scripts/scheduled-task-commands/automatedEmailReminder.php
+++ b/scripts/scheduled-task-commands/automatedEmailReminder.php
@@ -8,7 +8,7 @@ $startTime = microtime(true);
 
 $db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
 $errorNotify = new App\Leaf\ErrorNotify();
-$siteList = $db->query("SELECT `site_path` FROM `sites` WHERE `site_type` = 'portal'");
+$siteList = $db->query("SELECT `site_path` FROM `sites` WHERE `site_type` = 'portal' AND `isVAPO` = 'false'");
 $dir = '/var/www/html';
 
 $failedArray = [];

--- a/scripts/scheduled-task-commands/automatedEmailReminderVAPO.php
+++ b/scripts/scheduled-task-commands/automatedEmailReminderVAPO.php
@@ -1,0 +1,34 @@
+<?php
+// this file will need to be added, Pete's destruction ticket has it already.
+require_once 'globals.php';
+require_once APP_PATH . '/Leaf/Db.php';
+require_once APP_PATH . '/Leaf/ErrorNotify.php';
+
+$startTime = microtime(true);
+
+$db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+$errorNotify = new App\Leaf\ErrorNotify();
+$siteList = $db->query("SELECT `site_path` FROM `sites` WHERE `site_type` = 'portal' AND `isVAPO` = 'true'");
+$dir = '/var/www/html';
+
+$failedArray = [];
+
+foreach ($siteList as $site) {
+    echo "Portal: " . $dir . $site['site_path'] . '/scripts/automated_email.php' . "\r\n";
+    if (is_file($dir . $site['site_path'] . '/scripts/automated_email.php')) {
+        $response =  exec('php ' . $dir . $site['site_path'] . '/scripts/automated_email.php');
+        if($response == '0'){
+            $failedArray[] = $site['site_path'].' (Failed)';
+        }
+    } else {
+        echo "File was not found\r\n";
+    }
+}
+
+$errorNotify->sendNotification('Automated Email Error',$failedArray);
+
+
+$endTime = microtime(true);
+$timeInMinutes = round(($endTime - $startTime) / 60, 2);
+echo "Emails processing took {$timeInMinutes} minutes";
+echo date('Y-m-d g:i:s a') . "\r\n";


### PR DESCRIPTION
This changes the automated email scripts that run daily to account for our VAPO migration when we will have two infrastructures operating at the same time. This is a preliminary action to avoid multiple emails going out from both infrastructures.


## Potential Impact
- Issues with automated emails going out

## Testing
- [ ] Automated tests pass
