### PR TITLE
LEAF 4437 - add back compat code to leaf-library for form preview

### DIFF
--- a/LEAF_Request_Portal/js/LeafPreview.js
+++ b/LEAF_Request_Portal/js/LeafPreview.js
@@ -5,13 +5,22 @@ var LeafPreview = function(domID) {
 
     $('#' + domID).html('');
 
+    /*
+    * Backward compatibility: certain name properties are pre-sanitized server-side, and must be decoded before rendering
+    * TODO: Migrate to markdown
+    */
+    function decodeHTMLEntities(txt) {
+       let tmp = document.createElement("textarea");
+       tmp.innerHTML = txt;
+       return tmp.value;
+    }
     function renderField(field, isChild) {
         var required = field.required == 1 ? '<span style="color: red">* Required</span>': '';
         var style_isChild = '';
         if(isChild == undefined) {
             style_isChild = 'font-weight: bold';
         }
-        var out = '<span style="'+style_isChild+'">' + field.name +'</span> '+ required + '<br />';
+        var out = '<span style="'+style_isChild+'">' + decodeHTMLEntities(field.name) +'</span> '+ required + '<br />';
         switch(field.format) {
             case 'textarea':
                 out += '<textarea style="width: 100%"></textarea>';


### PR DESCRIPTION
Adds a textarea filter for leaf library form preview to resolve back compatibility issues associated with some html tags

**Testing / Impact**

Admin Leaf Library

This item will need to be tested on preprod since we do not currently have local leaf-library forms.

Navigate to admin panel -> LEAF Form Library.
Use the search field to find the E-Clearance (Nursing) form.
Confirm that the form header tags display as expected.
Confirm that other forms continue to display as expected.
