### PR TITLE
LEAF-4462 Report HTTP 500 for DB update issues

### DIFF
--- a/LEAF_Nexus/admin/templates/admin_update_database.tpl
+++ b/LEAF_Nexus/admin/templates/admin_update_database.tpl
@@ -24,14 +24,14 @@
 $(function() {
     $('#groupList').html('<div style="border: 2px solid black; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; width: 95%">Loading... <img src="../images/largespinner.gif" alt="" /></div>');
 
-    $.ajax({
-        url: "../scripts/updateDatabase.php",
-        dataType: "text",
-        success: function(response) {
-            $('#groupList').html('<pre>' + response + '</pre>');
-        },
-        cache: false
-    });
+    fetch('../scripts/updateDatabase.php')
+        .then(res => res.text())
+        .then(data => {
+            $('#groupList').html('<pre>' + data + '</pre>');
+        })
+        .catch(err => {
+            $('#groupList').html('Error updating database. This issue has been automatically reported.');
+        });
 });
 
 /* ]]> */

--- a/LEAF_Request_Portal/admin/templates/admin_update_database.tpl
+++ b/LEAF_Request_Portal/admin/templates/admin_update_database.tpl
@@ -36,13 +36,14 @@
 $(function() {
     $('#groupList').html('<div style="border: 2px solid black; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; width: 95%">Loading... <img src="../images/largespinner.gif" alt="" /></div>');
 
-    $.ajax({
-    	type: 'GET',
-        url: "../scripts/updateDatabase.php",
-        success: function(response) {
-            $('#groupList').html('<pre>' + response + '</pre>');
-        }
-    });
+    fetch('../scripts/updateDatabase.php')
+        .then(res => res.text())
+        .then(data => {
+            $('#groupList').html('<pre>' + data + '</pre>');
+        })
+        .catch(err => {
+            $('#groupList').html('Error updating database. This issue has been automatically reported.');
+        });
 });
 
 /* ]]> */

--- a/app/Leaf/DbUpdate.php
+++ b/app/Leaf/DbUpdate.php
@@ -102,6 +102,7 @@ class DbUpdate
 
             if ($settings['dbversion'] == $this->current_version) {
                 $this->message .= ucwords($this->portal) . ' Db Update failed.' . $this->EOL . $this->EOL;
+                http_response_code(500);
             } else {
                 $this->message .= 'Database updated to: '. $settings['dbversion'] . $this->EOL . $this->EOL;
                 $this->initilize();

--- a/x-test/API-tests/dbsetup_test.go
+++ b/x-test/API-tests/dbsetup_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -82,10 +83,19 @@ func setupTestDB() {
 }
 
 func updateTestDBSchema() {
+	fmt.Print("Updating DB Schema: Request Portal... ")
 	res, _ := httpGet(RootURL + `scripts/updateDatabase.php`)
 	if strings.Contains(res, `Db Update failed`) {
-		log.Fatal(`Could not update database schema: ` + res)
+		log.Fatal(`Could not update Request Portal schema: ` + res)
 	}
+	fmt.Println("OK")
+
+	fmt.Print("Updating DB Schema: Nexus (Orgchart)... ")
+	res, _ = httpGet(NationalOrgchartURL + `scripts/updateDatabase.php`)
+	if strings.Contains(res, `Db Update failed`) {
+		log.Fatal(`Could not update Nexus (Orgchart) schema: ` + res)
+	}
+	fmt.Println("OK")
 }
 
 // teardownTestDB reroutes the standard LEAF dev environment back to the original configuration


### PR DESCRIPTION
DB updates will report HTTP 500 if there's an error, which improves observability.

Expanded the API test's `updateTestDBSchema()` to update the orgchart schema.

## Potential Impact
Negligible because:
- The only functional change is to augment the response code with HTTP 500 for failed updates
- The updated user-facing component is typically used only for diagnostic purposes

## Testing
- [ ] Automated tests pass
- [ ] Portal -> Admin Panel -> Update Database works
- [ ] Nexus -> OC Admin Panel -> Other Tools -> Update Database works
