### PR TITLE
LEAF-4461 Optimize hotspot: avoid multiple joins

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3269,11 +3269,11 @@ class Form
                             default:
                                 if (is_numeric($vars[':stepID' . $count]))
                                 {
-                                    $joins .= "LEFT JOIN (SELECT * FROM records_workflow_state
-                									WHERE stepID=:stepID{$count}) rj_stepID{$count}
-                									USING (recordID) ";
-                                    // Backwards Compatibility
-                                    $conditions .= "{$gate}rj_stepID{$count}.stepID = :stepID{$count}";
+                                    if (!str_contains($joins,'lj_records_workflow_state')) {
+                                        $joins .= "LEFT JOIN records_workflow_state lj_records_workflow_state USING (recordID) ";
+                                    }
+
+                                    $conditions .= "{$gate}lj_records_workflow_state.stepID = :stepID{$count}";
                                 }
                                 else
                                 {
@@ -3332,11 +3332,11 @@ class Form
                             default:
                                 if (is_numeric($vars[':stepID' . $count]))
                                 {
-                                    $joins .= "LEFT JOIN (SELECT * FROM records_workflow_state
-                									WHERE stepID != :stepID{$count}) rj_stepID{$count}
-                									USING (recordID) ";
-                                    // Backwards Compatibility
-                                    $conditions .= "{$gate}rj_stepID{$count}.stepID != :stepID{$count}";
+                                    if (!str_contains($joins,'lj_records_workflow_state')) {
+                                        $joins .= "LEFT JOIN records_workflow_state lj_records_workflow_state USING (recordID) ";
+                                    }
+
+                                    $conditions .= "{$gate}lj_records_workflow_state.stepID != :stepID{$count}";
                                 }
                                 else
                                 {

--- a/x-test/API-tests/formQuery_test.go
+++ b/x-test/API-tests/formQuery_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -193,6 +194,17 @@ func TestFormQuery_DescendingIndex(t *testing.T) {
 
 	if _, exists := res[6]; !exists {
 		t.Errorf(`Record ID should exist because VTRSHHZOFIA is the initiator. want = recordID is not null`)
+	}
+}
+
+// TestFormQuery_FindTwoSteps looks for records on stepID 3 OR -3
+func TestFormQuery_FindTwoSteps(t *testing.T) {
+	res, _ := getFormQuery(RootURL + `api/form/query/?q={"terms":[{"id":"stepID","operator":"=","match":"3","gate":"AND"},{"id":"stepID","operator":"=","match":"-3","gate":"OR"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":[],"sort":{}}&x-filterData=recordID,stepID`)
+
+	for _, record := range res {
+		if record.StepID != 3 && record.StepID != -3 {
+			t.Errorf(`RecordID #%v StepID = %v. want = stepID is 3 OR -3`, record.RecordID, record.StepID)
+		}
 	}
 }
 


### PR DESCRIPTION
This implements the same solution in #2452 to avoid multiple joins on `records_workflow_state` and resolves a similar problem where searches on multiple stepIDs creates exponential database work.

An automated test has also been added to help validate the accuracy of query results.

Before (4.5s):
```sql
SELECT * FROM records
LEFT JOIN (SELECT * FROM records_workflow_state WHERE stepID=141) rj_stepID0 USING (recordID) 
LEFT JOIN (SELECT * FROM records_workflow_state WHERE stepID=357) rj_stepID1 USING (recordID) 
LEFT JOIN services USING (serviceID) 
LEFT JOIN (SELECT * FROM records_workflow_state) lj_status USING (recordID) 
LEFT JOIN (SELECT stepID, stepTitle FROM workflow_steps) lj_steps ON (lj_status.stepID = lj_steps.stepID) 
WHERE (rj_stepID0.stepID = 141 OR rj_stepID1.stepID = 357) AND (deleted = 0) LIMIT 0,1000
```

After (0.008s):
```sql
SELECT * FROM records
LEFT JOIN records_workflow_state lj_records_workflow_state USING (recordID) 
LEFT JOIN services USING (serviceID) 
LEFT JOIN (SELECT * FROM records_workflow_state) lj_status USING (recordID) 
LEFT JOIN (SELECT stepID, stepTitle FROM workflow_steps) lj_steps ON (lj_status.stepID = lj_steps.stepID) 
WHERE (lj_records_workflow_state.stepID = 141 OR lj_records_workflow_state.stepID = 357) AND (deleted = 0) LIMIT 0,1000
```

## Potential Impact
Isolated to queries where users select specific Current Status = [Any custom step]

## Testing
- [ ] Automated tests pass
- [ ] Queries for Current Status = [Any custom step] return expected results