### PR TITLE
LEAF-4460 Improve syntax consistency

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1337,14 +1337,8 @@ class Employee extends Data
                     $this->log[] = 'Format Detected: Email';
                 }
                 
-                if(substr(strtolower($input), 0, 15) === 'email_disabled:') {
-                    $input = str_replace('email_disabled:', '', strtolower($input));
-                    $searchResult = $this->lookupEmail($input, true);
-                } else if (substr(strtolower($input), 0, 9) === 'disabled:'){
-                    $input = str_replace('disabled:', '', strtolower($input));
-                    $searchResult = $this->lookupEmail($input, true);
-                } else if (substr(strtolower($input), 0, 15) === 'disabled.email:'){
-                    $input = str_replace('disabled.email:', '', strtolower($input));
+                if(substr(strtolower($input), 0, 15) === 'email.disabled:') {
+                    $input = str_replace('email.disabled:', '', strtolower($input));
                     $searchResult = $this->lookupEmail($input, true);
                 } else {
                     $searchResult = $this->lookupEmail($input);
@@ -1368,28 +1362,12 @@ class Employee extends Data
 
                 break;
             //explicit search for disabled accounts
-            case substr(strtolower($input), 0, 18) === 'username_disabled:':
+            case substr(strtolower($input), 0, 18) === 'username.disabled:':
                 if ($this->debug)
                 {
-                    $this->log[] = 'Format Detected: Loginname';
+                    $this->log[] = 'Format Detected: Loginname (disabled)';
                 }
-                $input = str_replace('username_disabled:', '', strtolower($input));
-                $searchResult = $this->lookupLogin($input, true);
-                break;
-            case substr(strtolower($input), 0, 9) === 'disabled:':
-                if ($this->debug)
-                {
-                    $this->log[] = 'Format Detected: Loginname';
-                }
-                $input = str_replace('disabled:', '', strtolower($input));
-                $searchResult = $this->lookupLogin($input, true);
-                break;
-            case substr(strtolower($input), 0, 14) === 'disabled.user:':
-                if ($this->debug)
-                {
-                    $this->log[] = 'Format Detected: Loginname';
-                }
-                $input = str_replace('disabled.user:', '', strtolower($input));
+                $input = str_replace('username.disabled:', '', strtolower($input));
                 $searchResult = $this->lookupLogin($input, true);
                 break;
             // Format: ID number

--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -797,7 +797,7 @@ function findAssociatedRequests(empSel, empSelNew) {
         taskType: ''
     }
 
-    document.getElementById(`${empSel.prefixID}input`).value = `username_disabled:${oldAccount}`;
+    document.getElementById(`${empSel.prefixID}input`).value = `username.disabled:${oldAccount}`;
     document.getElementById(`${empSelNew.prefixID}input`).value = `username:${newAccount}`;
 
     document.getElementById('run').style.display = 'none';


### PR DESCRIPTION
This changes some prefixes when searching employees.

Before:
- username_disabled
- disabled
- disabled.user

After:
- username.disabled

## Potential Impact
Are the old prefixes used anywhere else?

## Testing
- [ ] Portal -> Admin Panel -> New Account Updater continues to work normally
