### PR TITLE
Leaf 4449 - orgchart refresh plus tests

### DIFF
--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -15,6 +15,7 @@ define("PHONEIID", 5);
 define("EMAILIID", 6);
 define("LOCATIONIID", 8);
 define("ADTITLEIID", 23);
+define("DELETEDDATE", 'deleted_' . gmdate('my', time()) . '_');
 
 require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 
@@ -72,7 +73,7 @@ function updateUserInfo(string $userName, int $empUID)
     #used to disable if not found in national
     $sql3 = "UPDATE `employee`
             SET `deleted` = :deleted,
-                `userName` = CONCAT('deleted_', `userName`)
+                `userName` = CONCAT(".DELETEDDATE.", `userName`)
             WHERE `userName` = :userName";
 
     $sql4 = "SELECT `userName`, `deleted`, `lastUpdated`
@@ -120,9 +121,9 @@ function updateUserInfo(string $userName, int $empUID)
                 ':userName' => $userName
             );
             $sql = "UPDATE `employee`
-                SET `deleted` = :deleted,
-                    `userName` = CONCAT('deleted_', `userName`)
-                WHERE `userName` = :userName";
+                    SET `deleted` = :deleted,
+                        `userName` = CONCAT(".DELETEDDATE.", `userName`)
+                    WHERE `userName` = :userName";
 
             $db->prepared_query($sql4, $vars);
         }
@@ -258,7 +259,7 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
     $deletedEmployeesImplode = implode(",", array_fill(1, count($localDeletedEmployees), '?'));
     $deletedEmployeesSql = "UPDATE `employee`
                             SET `deleted` = UNIX_TIMESTAMP(NOW()),
-                                `userName` = CONCAT('deleted_', `userName`)
+                                `userName` = CONCAT(".DELETEDDATE.", `userName`)
                             WHERE `userName` IN (" . $deletedEmployeesImplode . ")";
 
     if (!empty($localDeletedEmployees)) {

--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -26,7 +26,6 @@ $oc_login->loginUser();
 if (@strtolower($oc_config->dbName) == strtolower(DIRECTORY_DB)) {
     echo 1; // success value
 } else {
-
     if (!empty($_GET['userName']) && !empty($_GET['empUID'])) {
         updateUserInfo($_GET['userName'], $_GET['empUID']);
         echo 1;
@@ -153,10 +152,12 @@ function updateLocalOrgchartBatch()
     // chunk it so we can go over this data.
     $localEmployeeUsernamesChunked = array_chunk($localEmployeeUsernames, 100);
     $loopDidnotFail = true;
+
     // loop over the chunked names so we can limit how much data this will be inserting at a time.
     foreach ($localEmployeeUsernamesChunked as $localEmployeeUsernames) {
         // get employees from the nexus based on the username
         $returnStatus = updateEmployeeDataBatch($localEmployeeUsernames);
+
         if ($returnStatus == false) {
             $loopDidnotFail = false;
         }
@@ -180,6 +181,7 @@ function getEmployeeUIDs(array $localEmployeeUsernames): array
     $localEmpUIDs = $oc_db->prepared_query($localEmployeeSql,$localEmployeeUsernames);
 
     $localEmpArray = [];
+
     foreach ($localEmpUIDs as $localUsername) {
         $localEmpArray[strtoupper($localUsername['userName'])] = $localUsername['empUID'];
     }
@@ -291,7 +293,6 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
     list($localEmpUIDs,$localEmpArray) = getEmployeeUIDs($localEmployeeUsernames);
 
     foreach ($orgEmployeeDataRes as $orgEmployeeData) {
-
         // if this user is not found, we will skip adding data for them.
         if (empty($localEmpArray[strtoupper($orgEmployeeData['userName'])])) {
             continue;
@@ -304,8 +305,6 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
                 'timestamp' => $orgEmployeeData['timestamp'],
             ];
         }
-
-
     }
 
     // make sure data array has data before attempting to insert data

--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -15,7 +15,7 @@ define("PHONEIID", 5);
 define("EMAILIID", 6);
 define("LOCATIONIID", 8);
 define("ADTITLEIID", 23);
-define("DELETEDDATE", 'deleted_' . gmdate('my', time()) . '_');
+define("DELETEDDATE", 'disabled_' . time() . '_');
 
 require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 

--- a/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
+++ b/LEAF_Nexus/scripts/refreshOrgchartEmployees.php
@@ -31,7 +31,6 @@ if (@strtolower($oc_config->dbName) == strtolower(DIRECTORY_DB)) {
         updateUserInfo($_GET['userName'], $_GET['empUID']);
         echo 1;
     } else {
-
         $startTime = time();
         // echo "Refresh Orgchart Employees Start\n";
         $success = updateLocalOrgchartBatch();
@@ -54,31 +53,33 @@ function updateUserInfo(string $userName, int $empUID)
 
     $vars = array(':userName' => htmlspecialchars_decode($userName, ENT_QUOTES)); //for users with apostrophe in name
 
-    $sql = "SELECT empUID, userName, lastName,
-            firstName, middleName, phoneticLastName,
-            phoneticFirstName, domain, deleted, lastUpdated
-			FROM employee
-			WHERE userName=:userName";
+    $sql = "SELECT `empUID`, `userName`, `lastName`, `firstName`, `middleName`,
+                `phoneticLastName`, `phoneticFirstName`, `domain`, `deleted`,
+                `lastUpdated`
+			FROM `employee`
+			WHERE `userName` = :userName";
 
-    $sql2 = "UPDATE employee
-            SET lastName=:lastName,
-            firstName=:firstName,
-            middleName=:midInit,
-            phoneticFirstName=:phoneticFname,
-            phoneticLastName=:phoneticLname,
-            domain=:domain,
-            deleted=:deleted,
-            lastUpdated=:lastUpdated
-            WHERE userName=:userName";
+    $sql2 = "UPDATE `employee`
+            SET `lastName` = :lastName,
+                `firstName` = :firstName,
+                `middleName` = :midInit,
+                `phoneticFirstName` = :phoneticFname,
+                `phoneticLastName` = :phoneticLname,
+                `domain` = :domain,
+                `deleted` = :deleted,
+                `lastUpdated` = :lastUpdated
+            WHERE `userName` = :userName";
 
     #used to disable if not found in national
-    $sql3 = "UPDATE employee
-            SET deleted=:deleted
-            WHERE userName=:userName";
+    $sql3 = "UPDATE `employee`
+            SET `deleted` = :deleted,
+                `userName` = CONCAT('deleted_', `userName`)
+            WHERE `userName` = :userName";
 
-    $sql4 = "SELECT userName, deleted, lastUpdated
-             FROM employee
-             WHERE userName=:userName AND lastUpdated > 0";
+    $sql4 = "SELECT `userName`, `deleted`, `lastUpdated`
+             FROM `employee`
+             WHERE `userName` = :userName
+             AND `lastUpdated` > 0";
 
     $res = $globalDB->prepared_query($sql, $vars);
 
@@ -119,9 +120,10 @@ function updateUserInfo(string $userName, int $empUID)
                 ':deleted' => $currentTime,
                 ':userName' => $userName
             );
-            $sql = "UPDATE employee
-                SET deleted=:deleted
-                WHERE userName=:userName";
+            $sql = "UPDATE `employee`
+                SET `deleted` = :deleted,
+                    `userName` = CONCAT('deleted_', `userName`)
+                WHERE `userName` = :userName";
 
             $db->prepared_query($sql4, $vars);
         }
@@ -133,7 +135,8 @@ function updateLocalOrgchartBatch()
     global $oc_db, $globalDB;
 
     // replace the separate function for getting employee
-    $localEmployeeSql = "SELECT userName FROM employee";
+    $localEmployeeSql = "SELECT `userName`
+                         FROM `employee`";
     $localEmployees = $oc_db->query($localEmployeeSql);
 
     if (count($localEmployees) == 0) {
@@ -154,7 +157,7 @@ function updateLocalOrgchartBatch()
     foreach ($localEmployeeUsernamesChunked as $localEmployeeUsernames) {
         // get employees from the nexus based on the username
         $returnStatus = updateEmployeeDataBatch($localEmployeeUsernames);
-        if($returnStatus == false){
+        if ($returnStatus == false) {
             $loopDidnotFail = false;
         }
     }
@@ -162,20 +165,23 @@ function updateLocalOrgchartBatch()
     return $loopDidnotFail;
 }
 /**
- * @param getEmployeeUIDs array $localEmployeeUsernames
+ * @param array $localEmployeeUsernames
  * @return [$localEmpUIDs,$localEmpArray]
  */
-function getEmployeeUIDs(array $localEmployeeUsernames): array {
+function getEmployeeUIDs(array $localEmployeeUsernames): array
+{
     global $oc_db;
 
-    // get local empuids, need to gather employees that have been added. 
+    // get local empuids, need to gather employees that have been added.
     $localEmployeeImplode = implode(",",array_fill(1, count($localEmployeeUsernames), '?'));
-    $localEmployeeSql = "SELECT empUID, userName FROM employee WHERE userName IN (". $localEmployeeImplode .")";
+    $localEmployeeSql = "SELECT `empUID`, `userName`
+                         FROM `employee`
+                         WHERE `userName` IN (". $localEmployeeImplode .")";
     $localEmpUIDs = $oc_db->prepared_query($localEmployeeSql,$localEmployeeUsernames);
 
     $localEmpArray = [];
     foreach ($localEmpUIDs as $localUsername) {
-        $localEmpArray[$localUsername['userName']] = $localUsername['empUID'];
+        $localEmpArray[strtoupper($localUsername['userName'])] = $localUsername['empUID'];
     }
 
     return [$localEmpUIDs,$localEmpArray];
@@ -201,9 +207,12 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
     // STEP 1: Get the employees updated
     // get org employees
     $orgEmployeeImplode = implode(",", array_fill(1, count($localEmployeeUsernames), '?'));
-    $orgEmployeeSql = "SELECT empUID, userName, lastName, firstName, middleName, phoneticLastName, phoneticFirstName, domain, deleted, lastUpdated
-    		FROM employee
-    		WHERE userName IN (" . $orgEmployeeImplode . ")";
+    $orgEmployeeSql =
+        "SELECT `empUID`, `userName`, `lastName`, `firstName`,
+            `middleName`, `phoneticLastName`, `phoneticFirstName`,
+            `domain`, `deleted`, `lastUpdated`
+    	 FROM `employee`
+    	 WHERE `userName` IN (" . $orgEmployeeImplode . ")";
 
     $orgEmployeeRes = $globalDB->prepared_query($orgEmployeeSql, $localEmployeeUsernames);
 
@@ -214,28 +223,41 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
     if (empty($orgEmployeeRes)) {
         return FALSE;
     }
-    
-    foreach ($orgEmployeeRes as $orgEmployee) {
 
+    $noEmpUID = array();
+
+    foreach ($orgEmployeeRes as $orgEmployee) {
         $nationalEmpUIDs[] = (int) $orgEmployee['empUID'];
 
-        $localEmployeeArray[] = [
-            'empUID' => (empty($localEmpArray[$orgEmployee['userName']]) ? null : $localEmpArray[$orgEmployee['userName']]),
-            'userName' => $orgEmployee['userName'],
-            'lastName' => $orgEmployee['lastName'],
-            'firstName' => $orgEmployee['firstName'],
-            'middleName' => $orgEmployee['middleName'],
-            'phoneticFirstName' => $orgEmployee['phoneticFirstName'],
-            'phoneticLastName' => $orgEmployee['phoneticLastName'],
-            'domain' => $orgEmployee['domain'],
-            'deleted' => $orgEmployee['deleted'],
-            'lastUpdated' => $orgEmployee['lastUpdated']
-        ];
+        if (!empty($localEmpArray[strtoupper($orgEmployee['userName'])])) {
+            $localEmployeeArray[] = [
+                'empUID' => $localEmpArray[strtoupper($orgEmployee['userName'])],
+                'userName' => $orgEmployee['userName'],
+                'lastName' => $orgEmployee['lastName'],
+                'firstName' => $orgEmployee['firstName'],
+                'middleName' => $orgEmployee['middleName'],
+                'phoneticFirstName' => $orgEmployee['phoneticFirstName'],
+                'phoneticLastName' => $orgEmployee['phoneticLastName'],
+                'domain' => $orgEmployee['domain'],
+                'deleted' => $orgEmployee['deleted'],
+                'lastUpdated' => $orgEmployee['lastUpdated']
+            ];
+        } else {
+            $noEmpUID[] = $orgEmployee['userName'];
+        }
+    }
+
+    if (!empty($noEmpUID)) {
+        error_log(print_r(__DIR__, true), 3, '/var/www/php-logs/refresh.log');
+        error_log(print_r($noEmpUID, true), 3, '/var/www/php-logs/refresh.log');
     }
 
     $localDeletedEmployees = array_diff(array_column($localEmpUIDs, 'userName'), array_column($orgEmployeeRes, 'userName'));
     $deletedEmployeesImplode = implode(",", array_fill(1, count($localDeletedEmployees), '?'));
-    $deletedEmployeesSql = "UPDATE employee SET deleted=UNIX_TIMESTAMP(NOW()) WHERE userName IN (" . $deletedEmployeesImplode . ")";
+    $deletedEmployeesSql = "UPDATE `employee`
+                            SET `deleted` = UNIX_TIMESTAMP(NOW()),
+                                `userName` = CONCAT('deleted_', `userName`)
+                            WHERE `userName` IN (" . $deletedEmployeesImplode . ")";
 
     if (!empty($localDeletedEmployees)) {
         $oc_db->prepared_query($deletedEmployeesSql,array_values($localDeletedEmployees));
@@ -246,10 +268,11 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
     // STEP 2: Get employee_data updated
     // get the employee data, we will need to get the employee ids first
 
-    $orgEmployeeDataSql = "SELECT empUID, employee.userName, indicatorID, data, author, timestamp
-    				FROM employee_data
-				LEFT JOIN employee USING (empUID)
-				WHERE empUID IN ('" . implode("','", $nationalEmpUIDs) . "') AND indicatorID IN (:PHONEIID,:EMAILIID,:LOCATIONIID,:ADTITLEIID)";
+    $orgEmployeeDataSql = " SELECT `empUID`, `employee`.`userName`, `indicatorID`, `data`, `author`, `timestamp`
+    				        FROM `employee_data`
+                            LEFT JOIN `employee` USING (`empUID`)
+                            WHERE `empUID` IN ('" . implode("','", $nationalEmpUIDs) . "')
+                            AND `indicatorID` IN (:PHONEIID,:EMAILIID,:LOCATIONIID,:ADTITLEIID)";
 
     $orgEmployeeDataVars = [
         ':PHONEIID' => PHONEIID,
@@ -270,13 +293,11 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
     foreach ($orgEmployeeDataRes as $orgEmployeeData) {
 
         // if this user is not found, we will skip adding data for them.
-        if (empty($localEmpArray[$orgEmployeeData['userName']])) {
+        if (empty($localEmpArray[strtoupper($orgEmployeeData['userName'])])) {
             continue;
-        }
-        else
-        {
+        } else {
             $localEmployeeDataArray[] = [
-                'empUID' => $localEmpArray[$orgEmployeeData['userName']],
+                'empUID' => $localEmpArray[strtoupper($orgEmployeeData['userName'])],
                 'indicatorID' => $orgEmployeeData['indicatorID'],
                 'data' => $orgEmployeeData['data'],
                 'author' => $orgEmployeeData['author'],
@@ -284,7 +305,7 @@ function updateEmployeeDataBatch(array $localEmployeeUsernames = [])
             ];
         }
 
-        
+
     }
 
     // make sure data array has data before attempting to insert data
@@ -304,11 +325,10 @@ function updateEmployeeData($nationalEmpUID, $localEmpUID)
 {
     global $oc_db, $globalDB;
 
-    $sql = "SELECT empUID, indicatorID, data, author, timestamp
-            FROM employee_data
-            WHERE empUID=:nationalEmpUID
-            AND indicatorID
-            IN (:PHONEIID,:EMAILIID,:LOCATIONIID,:ADTITLEIID)";
+    $sql = "SELECT `empUID`, `indicatorID`, `data`, `author`, `timestamp`
+            FROM `employee_data`
+            WHERE `empUID` = :nationalEmpUID
+            AND `indicatorID` IN (:PHONEIID,:EMAILIID,:LOCATIONIID,:ADTITLEIID)";
 
     $selectVars = array(
         ':nationalEmpUID' => $nationalEmpUID,
@@ -322,11 +342,11 @@ function updateEmployeeData($nationalEmpUID, $localEmpUID)
 
     if (count($res) > 0) {
         for ($i = 0; $i < count($res); $i++) {
-            $sql2 = "INSERT INTO employee_data (empUID, indicatorID, data, author, timestamp)
+            $sql2 = "INSERT INTO `employee_data` (`empUID`, `indicatorID`, `data`,
+                        `author`, `timestamp`)
 				     VALUES (:empUID, :indicatorID, :data, :author, :timestamp)
-				     ON DUPLICATE KEY UPDATE data=:data,
-					 author=:author,
-					 timestamp=:timestamp";
+				     ON DUPLICATE KEY UPDATE `data` = :data, `author` = :author,
+					    `timestamp` = :timestamp";
 
             $vars = array(
                 ':empUID' => $localEmpUID,

--- a/x-test/API-tests/database/portal_test_db.sql
+++ b/x-test/API-tests/database/portal_test_db.sql
@@ -6777,7 +6777,7 @@ INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `prio
 (505,	1694021485,	0,	'VTRGBKJEANNINE',	'Requestor is not tester',	0,	'Submitted',	1694021504,	0,	0,	1),
 (506,	1694021485,	0,	'tester',	'Available for test case',	0,	'Note',	1694021504,	0,	0,	1),
 (507,	1695395480,	15,	'tester',	'Complex',	0,	'Submitted',	1695395485,	0,	0,	1),
-(508,	1697229337,	201,	'VTRPAZMICKIE0',	'Test backup of initiator',	0,	'Submitted',	1697554108,	0,	0,	1),
+(508,	1697229337,	201,	'VTRVVTELLIE',	'Test backup of initiator',	0,	'Submitted',	1697554108,	0,	0,	1),
 (509,	1699044418,	0,	'tester',	'Available for test case',	0,	'Submitted',	1699044434,	0,	0,	1),
 (510,	1699044418,	0,	'tester',	'Available for test case',	0,	'Submitted',	1699044434,	0,	0,	1),
 (511,	1699044418,	0,	'tester',	'Available for test case',	0,	'Submitted',	1699044434,	0,	0,	1),

--- a/x-test/API-tests/formQuery_test.go
+++ b/x-test/API-tests/formQuery_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -86,8 +87,12 @@ func TestFormQuery_NonadminQueryActionable(t *testing.T) {
 		t.Errorf("Record 503 should be actionable because tester is backup of person designated")
 	}
 
-	if _, exists := res[504]; !exists {
-		t.Errorf("Record 504 should be actionable because tester is backup of initiator")
+	if _, exists := res[504]; exists {
+		t.Errorf("Record 504 should not be actionable because initiator is disabled")
+	}
+
+	if _, exists := res[508]; !exists {
+		t.Errorf("Record 508 should be actionable because tester is backup of initiator")
 	}
 
 	if _, exists := res[505]; exists {


### PR DESCRIPTION
Summary:
The nightly orgchart refresh was causing the employee's empUID to increment even though there wasn't a new record added. It was determined that this was because that table has an auto increment as well as a separate column that was unique. Testing the current script revealed that there were instances where the userName from the national orgchart and local orgchart were spelled differently case wise. This was causing an issue where the empUID from the local orgchart was not being included in the update query. So when MySql hit this record it would increment the db auto increment but when it tried to insert it hit the unique index and found a match and therefore updated that record. The auto increment still increased but would not be noticeable until a new employee was added.
The changes made here make the userName all upper case when looping through so that they will match every time. Running this change resulted in no userNames without an empUID.
Adding deleted_ to the front of userNames that are deleted or absent from the national orgchart is also in this script.

Potential Impact:
The main impact here will be that the db's will not hit the upper limit of the mediumint for the empUID in the employee table. With adding deleted_ to the front of userNames will prevent recycled userNames from being used for the wrong person. A person that has been disabled (deleted_ added to the beginning of their userName) will cause read issues with requests. (Specifically, when initiator is disabled the backup will not be able to take action on their requests)

Testing:
This can not be tested locally, it needs to be pushed to staging and tested there.
When testing, run the script. If there is a problem a file will be created here /var/www/php-logs/refresh.log. If no file is created then everything should be good.
API tests have been updated to include a test for disabled initiator.