### PR TITLE
LEAF-4466 Hotfix/inbox

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -512,11 +512,13 @@
         formGrid.setDataBlob(res);
         formGrid.hideIndex();
         formGrid.setHeaders(headers);
+        let tGridData = [];
         let hasServices = false;
         recordIDs.forEach(recordID => {
             if (res[recordID].service != null) {
                 hasServices = true;
             }
+            tGridData.push(res[recordID]);
         });
         // remove service column if there's no services
         if (hasServices == false) {
@@ -528,6 +530,7 @@
             }
             formGrid.setHeaders(tHeaders);
         }
+        formGrid.setData(tGridData);
         const priorityHeader = formGrid.headers().find(h => h.indicatorID === 'priority') || null;
         if (priorityHeader === null) {
             formGrid.sort('recordID', 'asc');


### PR DESCRIPTION
Resolves Inbox issue: When building the list of records, use the list of recordIDs provided by the function instead of using the full dataset.

## Potential Impact
Changes are isolated on the Inbox

## Testing
- [ ] In the Inbox, "View X records" only shows the appropriate X records in the list.