### PR TITLE
LEAF 4467 fix step id checking

### DIFF
--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -378,9 +378,6 @@ class Workflow
         }
 
         if ($action === 'sendback') {
-            if ($nextStepID !== 0) { //correct for potential copy issue.  requestor is sometimes referred to by -1 in the editor
-                $nextStepID = 0;
-            }
             $required = json_encode(array ('required' => false));
         } else {
             $required = '';


### PR DESCRIPTION
Removes the check for a non-zero nextStepID during workflow copy, since other IDs are also valid for the 'sendback' (Return to Requestor) action type.
The bug associated with a potential -1 value should no longer be an issue.


**Testing / Impact**

Workflow Editor

Use a workflow with multiple steps.  If it does not have Return to Requestor actions to both Requestor and another step, add them.  Test adding the action with the connectors as well as with the step actions select box.

Open any step info modal.

Without refreshing the page, copy the workflow.

Confirm in adminer that the new workflow copied as expected (portal workflow_routes table).
nextStepID should be 0 if routed to the Requestor
nextStepID should be that of the step it routes to

Confirm API tests still pass

  