### PR TITLE
LEAF-4469 (assoc 4463) add customTemplate call for admin menu

### DIFF
--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -359,7 +359,6 @@ switch ($action) {
         {
             $main->assign('body', $t_form->fetch('admin_sync_services.tpl'));
         }
-
         else
         {
             $main->assign('body', 'You require System Administrator level access to view this section.');

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -33,6 +33,7 @@ if (!$login->checkGroup(1))
     echo 'You must be in the administrator group to access this section.';
     exit();
 }
+$hasCustomCode = file_exists("./templates/custom_override/view_admin_menu.tpl");
 
 $main = new Smarty;
 $t_login = new Smarty;
@@ -357,8 +358,13 @@ switch ($action) {
 
         if ($login->checkGroup(1))
         {
-            $main->assign('body', $t_form->fetch('admin_sync_services.tpl'));
+            if($hasCustomCode) {
+                $main->assign('body', '<h3>Sync has been prevented to avoid potential issues.</h3>');
+            } else {
+                $main->assign('body', $t_form->fetch('admin_sync_services.tpl'));
+            }
         }
+
         else
         {
             $main->assign('body', 'You require System Administrator level access to view this section.');
@@ -639,6 +645,7 @@ $main->assign('leafSecure', XSSHelpers::sanitizeHTML($settings['leafSecure']));
 $main->assign('login', $t_login->fetch('login.tpl'));
 $t_menu->assign('action', $action);
 $t_menu->assign('orgchartPath', $site_paths['orgchart_path']);
+$t_menu->assign('hasCustomCode', $hasCustomCode ? "1" : "0");
 $t_menu->assign('name', XSSHelpers::sanitizeHTML($login->getName()));
 $t_menu->assign('siteType', XSSHelpers::xscrub($settings['siteType']));
 $o_menu = $t_menu->fetch('menu.tpl');

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -33,7 +33,6 @@ if (!$login->checkGroup(1))
     echo 'You must be in the administrator group to access this section.';
     exit();
 }
-$hasCustomCode = file_exists("./templates/custom_override/view_admin_menu.tpl");
 
 $main = new Smarty;
 $t_login = new Smarty;
@@ -358,11 +357,7 @@ switch ($action) {
 
         if ($login->checkGroup(1))
         {
-            if($hasCustomCode) {
-                $main->assign('body', '<h3>Sync has been prevented to avoid potential issues.</h3>');
-            } else {
-                $main->assign('body', $t_form->fetch('admin_sync_services.tpl'));
-            }
+            $main->assign('body', $t_form->fetch('admin_sync_services.tpl'));
         }
 
         else
@@ -645,10 +640,9 @@ $main->assign('leafSecure', XSSHelpers::sanitizeHTML($settings['leafSecure']));
 $main->assign('login', $t_login->fetch('login.tpl'));
 $t_menu->assign('action', $action);
 $t_menu->assign('orgchartPath', $site_paths['orgchart_path']);
-$t_menu->assign('hasCustomCode', $hasCustomCode ? "1" : "0");
 $t_menu->assign('name', XSSHelpers::sanitizeHTML($login->getName()));
 $t_menu->assign('siteType', XSSHelpers::xscrub($settings['siteType']));
-$o_menu = $t_menu->fetch('menu.tpl');
+$o_menu = $t_menu->fetch(customTemplate('menu.tpl'));
 $main->assign('menu', $o_menu);
 $tabText = $tabText == '' ? '' : $tabText . '&nbsp;';
 $main->assign('tabText', $tabText);

--- a/LEAF_Request_Portal/admin/templates/menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/menu.tpl
@@ -76,9 +76,7 @@
                     <li><a href="?a=mod_templates_reports">LEAF Programmer</a></li>
                     <li><a href="?a=mod_file_manager">File Manager</a></li>
                     <li><a href="../?a=search">Search Database</a></li>
-                    <!--{if $hasCustomCode == 0}-->
                     <li><a href="?a=admin_sync_services">Sync Services</a></li>
-                    <!--{/if}-->
                     <li><a href="?a=admin_update_database">Update Database</a></li>
                 </ul>
             </li>

--- a/LEAF_Request_Portal/admin/templates/menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/menu.tpl
@@ -76,7 +76,9 @@
                     <li><a href="?a=mod_templates_reports">LEAF Programmer</a></li>
                     <li><a href="?a=mod_file_manager">File Manager</a></li>
                     <li><a href="../?a=search">Search Database</a></li>
+                    <!--{if $hasCustomCode == 0}-->
                     <li><a href="?a=admin_sync_services">Sync Services</a></li>
+                    <!--{/if}-->
                     <li><a href="?a=admin_update_database">Update Database</a></li>
                 </ul>
             </li>


### PR DESCRIPTION
Adds a customTemplate function call for menu.tpl, which is the template associated with the top admin nav.
This will allow an alternate custom template for this menu on the small number of sites that need it.

**Testing / Impact**

Admin Top navigation menu.

- There should be no change if portal/admin/templates/custom_override/ does not contain a file called menu.tpl.
- When this file **is** present, the admin top nav should reflect the custom_override file and not the base file.