### PR TITLE
Leaf 4468 - updated disabled userName

### DIFF
--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -240,7 +240,7 @@ class VAMCActiveDirectory
     private function preventRecycledUserName(): void
     {
         $sql = 'UPDATE `employee`
-                SET `userName` = concat("disabled_", ' . time() . '_,  `userName`)
+                SET `userName` = concat("disabled_", UNIX_TIMESTAMP(NOW()), "_",  `userName`)
                 WHERE `deleted` > 0
                 AND LEFT(`userName`, 9) <> "disabled_"';
 

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -240,9 +240,9 @@ class VAMCActiveDirectory
     private function preventRecycledUserName(): void
     {
         $sql = 'UPDATE `employee`
-                SET `userName` = concat("deleted_", `userName`)
+                SET `userName` = concat("disabled_", ' . time() . '_,  `userName`)
                 WHERE `deleted` > 0
-                AND LEFT(`userName`, 8) <> "deleted_"';
+                AND LEFT(`userName`, 9) <> "disabled_"';
 
         $this->db->prepared_query($sql, array());
     }


### PR DESCRIPTION
Summary:
After initial deployment of the refresh orgchart refactor it was observed that we could end up with a db unique key violation should a userName be recycled more than once. This is to ensure that doesn't happen.

Potential Impact:
This addresses the potential of a duplicate userName being attempted to be created. No other impact is known at this time.

Testing:
Testing is not possible on local. Extensive testing will need to be accomplished on staging before implementing on prod.