### PR TITLE
End to end testing: Report Builder column order

### DIFF
--- a/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -23,10 +23,11 @@ test('navigate to Workflow Editor and create a travel workflow', async ({ page }
   // Workaround: Since the drag handles can overlap sometimes (maybe due to async rendering
   // in the jsPlumb library?), we'll move the requestor step out of the way first.
   // TODO: fix the workflow editor since end-users might have the same issue
-  await expect(page.getByLabel('workflow step: Requestor', { exact: true })).toBeInViewport();
-  await page.getByLabel('workflow step: Requestor', { exact: true }).hover();
+  await expect(page.getByLabel('workflow step: Step 1')).not.toBeInViewport();
+  // Workaround: Set specific position because the workflow step's drag handle overlaps with the connector's handle
+  await page.getByLabel('workflow step: Requestor', { exact: true }).hover({position: {x: 16, y: 16}});
   await page.mouse.down();
-  await page.mouse.move(0, 150);
+  await page.mouse.move(250, 400);
   await page.mouse.up();
 
   await page.getByRole('button', { name: 'New Step' }).click();

--- a/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -18,6 +18,7 @@ test('navigate to Workflow Editor and create a travel workflow', async ({ page }
   await page.getByRole('button', { name: 'Save' }).click();
 
   // wait for async request to finish saving
+  await expect(page.getByRole('button', { name: 'Save' })).not.toBeVisible();
   await expect(page.locator('a').filter({ hasText: uniqueText })).toBeVisible();
 
   // Workaround: Since the drag handles can overlap sometimes (maybe due to async rendering

--- a/x-test/end2end/tests/reportBuilder.spec.ts
+++ b/x-test/end2end/tests/reportBuilder.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 // When the underlying issue is fixed, we should expect this test to pass.
 // Tests should be tagged with an associated ticket or PR reference
-test.fail('column order is maintained after modifying the search filter', {tag: '@LEAF-4482'}, async ({ page }, testInfo) => {
+test.fail('column order is maintained after modifying the search filter', {tag: '@issue:LEAF-4482'}, async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJBghmXEAGhDQDsM0BjfAeygEkARbAVmJFoAdo6psAPBxj4qAC2wBOAAyyOAc3wRsAQQByLAL5F0WRDggAbCJCwluvMPWwBeYaImJpJRZFUaQmgLokAVrXIEFB8QOHowJGBtEHkTJnxCFBAAFg4ARjSOdhDDNBg0CMQ02WcQXPywAHkAM2q4EyRpTSA%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAgBZmtBvjABZAK4kiAAhLQyy5GQAeHam3Qc8ARl79YCFBhwzjxyfUatoAc3Kr1mnXtbt8AJjNICyFrUTAAVgdpAgA5eQZ0BGYDIwBmbgBdIA%3D%3D&sort=N4Ig1gpgniBcIFYQBoQHsBOATCG4hwGcBjEAXyA%3D');
 
   await expect(page.getByLabel('Sort by Numeric')).toBeInViewport();

--- a/x-test/end2end/tests/reportBuilder.spec.ts
+++ b/x-test/end2end/tests/reportBuilder.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 // When the underlying issue is fixed, we should expect this test to pass.
 // Tests should be tagged with an associated ticket or PR reference
-test.fail('column order is maintained after modifying the search filter', {tag: '@LEAF-????'}, async ({ page }, testInfo) => {
+test.fail('column order is maintained after modifying the search filter', {tag: '@LEAF-4482'}, async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJBghmXEAGhDQDsM0BjfAeygEkARbAVmJFoAdo6psAPBxj4qAC2wBOAAyyOAc3wRsAQQByLAL5F0WRDggAbCJCwluvMPWwBeYaImJpJRZFUaQmgLokAVrXIEFB8QOHowJGBtEHkTJnxCFBAAFg4ARjSOdhDDNBg0CMQ02WcQXPywAHkAM2q4EyRpTSA%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAgBZmtBvjABZAK4kiAAhLQyy5GQAeHam3Qc8ARl79YCFBhwzjxyfUatoAc3Kr1mnXtbt8AJjNICyFrUTAAVgdpAgA5eQZ0BGYDIwBmbgBdIA%3D%3D&sort=N4Ig1gpgniBcIFYQBoQHsBOATCG4hwGcBjEAXyA%3D');
 
   await expect(page.getByLabel('Sort by Numeric')).toBeInViewport();

--- a/x-test/end2end/tests/reportBuilder.spec.ts
+++ b/x-test/end2end/tests/reportBuilder.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+// When the underlying issue is fixed, we should expect this test to pass.
+// Tests should be tagged with an associated ticket or PR reference
+test.fail('column order is maintained after modifying the search filter', {tag: '@LEAF-????'}, async ({ page }, testInfo) => {
+  await page.goto('https://host.docker.internal/Test_Request_Portal/?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJBghmXEAGhDQDsM0BjfAeygEkARbAVmJFoAdo6psAPBxj4qAC2wBOAAyyOAc3wRsAQQByLAL5F0WRDggAbCJCwluvMPWwBeYaImJpJRZFUaQmgLokAVrXIEFB8QOHowJGBtEHkTJnxCFBAAFg4ARjSOdhDDNBg0CMQ02WcQXPywAHkAM2q4EyRpTSA%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAgBZmtBvjABZAK4kiAAhLQyy5GQAeHam3Qc8ARl79YCFBhwzjxyfUatoAc3Kr1mnXtbt8AJjNICyFrUTAAVgdpAgA5eQZ0BGYDIwBmbgBdIA%3D%3D&sort=N4Ig1gpgniBcIFYQBoQHsBOATCG4hwGcBjEAXyA%3D');
+
+  await expect(page.getByLabel('Sort by Numeric')).toBeInViewport();
+  await expect(page.locator('th').nth(4)).toContainText('Numeric');
+  // Screenshot the original state
+  let screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+  await page.getByRole('button', { name: 'Modify Search' }).click();
+  await page.getByLabel('text', { exact: true }).click();
+  await page.getByLabel('text', { exact: true }).fill('8000');
+  await page.getByRole('button', { name: 'Next Step' }).click();
+  await expect(page.getByText('Develop search filter')).not.toBeInViewport();
+
+  await page.getByRole('button', { name: 'Generate Report' }).click();
+  await expect(page.getByText('Select Data Columns')).not.toBeInViewport();
+  // this is not necessary, but it makes the screenshot look cleaner
+  await expect(page.getByRole('button', { name: 'Generate Report' })).not.toBeInViewport();
+
+  await expect(page.getByLabel('Sort by Numeric')).toBeInViewport();
+  // Screenshot the new state. The column order should be the same.
+  screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+  await expect(page.locator('th').nth(4)).toContainText('Numeric');
+});


### PR DESCRIPTION
This adds a test that covers a known issue with the Report Builder, where we expect the report columns to maintain their order after modifying the report's filter.

Other minor changes:
- Improve the test locator for the `lifecycleSimpleTravel` test to improve repeatability.

This also serves as an example for how tests should be documented in situations where development of tests advances beyond the current UI development backlog.

- Since the underlying issue is unresolved, the test is implemented with the failing condition `test.fail` and annotated with a tag that references the issue.
- The tag must be prefixed with `issue:` to make it easier to search and identify.
  - This prefix must not be used in the test's title.
  - The example includes an actual issue #. To reduce development friction, it may be appropriate to tag tests with `LEAF-????` if a formal issue hasn't been documented yet. This would only be appropriate if the test is well documented.
- When the issue has been resolved, we would expect the test to pass and simply remove the `.fail`, as well as the tag.
- Screenshots should be strategically included to simplify communication and discussion of the problem.


## Potential Impact
Minimal impact, because this does not include changes to runtime code.

## Testing
- [ ] Automated tests pass