### PR TITLE
LEAF 4385 rm button roles and add aria label to table

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -40,9 +40,9 @@ var LeafFormGrid = function (containerID, options) {
       <div id="${prefixID}gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div>
     </div>
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
-      aria-label="Search Results" aria-live="assertive">
+      aria-label="" aria-live="assertive">
     </span>
-    <table id="${prefixID}table" class="leaf_grid">
+    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results, press escape to use table navigation options from a header cell.">
       <thead id="${prefixID}thead" style="position: sticky; top: 0px"></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot" class="leaf_grid-loading"></tfoot>
@@ -223,7 +223,7 @@ var LeafFormGrid = function (containerID, options) {
     headers = headersIn;
     let temp = `<tr id="${prefixID}thead_tr">`;
     if (showIndex) {
-      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" role="button" aria-label="Sort by unique ID">
+      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" aria-label="Sort by unique ID">
         UID
         <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
       </th>`;
@@ -252,7 +252,7 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" role="button" aria-label="Sort by ${headers[i].name}">
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" aria-label="Sort by ${headers[i].name}">
         ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
         </th>`);
 

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -40,9 +40,9 @@ var LeafFormGrid = function (containerID, options) {
       <div id="${prefixID}gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div>
     </div>
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
-      aria-label="Search Results" aria-live="assertive">
+      aria-label="" aria-live="assertive">
     </span>
-    <table id="${prefixID}table" class="leaf_grid">
+    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results, press escape to use table navigation options from a header cell.">
       <thead id="${prefixID}thead" style="position: sticky; top: 0px"></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot" class="leaf_grid-loading"></tfoot>
@@ -223,7 +223,7 @@ var LeafFormGrid = function (containerID, options) {
     headers = headersIn;
     let temp = `<tr id="${prefixID}thead_tr">`;
     if (showIndex) {
-      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" role="button">
+      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" aria-label="Sort by unique ID">
         UID
         <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
       </th>`;
@@ -252,7 +252,7 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" role="button">
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" aria-label="Sort by ${headers[i].name}">
         ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
         </th>`);
 
@@ -369,21 +369,24 @@ var LeafFormGrid = function (containerID, options) {
   function sort(key, order, callback) {
     sortDirection[key] = order;
     const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
-    const headerText = document.querySelector(headerSelector)?.innerText || "";
+    let headerText = '';
+    for(let i in headers) {
+      if(headers[i].indicatorID == key) {
+        headerText = headers[i].name;
+        break;
+      }
+    }
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
 
     $("." + prefixID + "sort").css("display", "none");
-    $(`th[id*="${prefixID}header_"]`).removeAttr('aria-sort');
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", ascending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
-      $(headerSelector).attr('aria-sort', 'ascending');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", descending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>');
-      $(headerSelector).attr('aria-sort', 'descending');
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];

--- a/libs/js/LEAF/formGrid.js
+++ b/libs/js/LEAF/formGrid.js
@@ -40,9 +40,9 @@ var LeafFormGrid = function (containerID, options) {
       <div id="${prefixID}gridToolbar" style="display: none; width: 90px; margin: 0 0 0 auto; text-align: right"></div>
     </div>
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
-      aria-label="Search Results" aria-live="assertive">
+      aria-label="" aria-live="assertive">
     </span>
-    <table id="${prefixID}table" class="leaf_grid">
+    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results, press escape to use table navigation options from a header cell.">
       <thead id="${prefixID}thead" style="position: sticky; top: 0px"></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot" class="leaf_grid-loading"></tfoot>
@@ -223,7 +223,7 @@ var LeafFormGrid = function (containerID, options) {
     headers = headersIn;
     let temp = `<tr id="${prefixID}thead_tr">`;
     if (showIndex) {
-      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" role="button">
+      temp += `<th scope="col" tabindex="0" id="${prefixID}header_UID" style="text-align: center" aria-label="Sort by unique ID">
         UID
         <span id="${prefixID}header_UID_sort" class="${prefixID}sort"></span>
       </th>`;
@@ -252,7 +252,7 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" role="button">
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" aria-label="Sort by ${headers[i].name}">
         ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
         </th>`);
 
@@ -369,21 +369,24 @@ var LeafFormGrid = function (containerID, options) {
   function sort(key, order, callback) {
     sortDirection[key] = order;
     const headerSelector = "#" + prefixID + "header_" + (key === "recordID" ? "UID" : key);
-    const headerText = document.querySelector(headerSelector)?.innerText || "";
+    let headerText = '';
+    for(let i in headers) {
+      if(headers[i].indicatorID == key) {
+        headerText = headers[i].name;
+        break;
+      }
+    }
     if (key != "recordID" && currLimit != Infinity) {
       renderBody(0, Infinity);
     }
 
     $("." + prefixID + "sort").css("display", "none");
-    $(`th[id*="${prefixID}header_"]`).removeAttr('aria-sort');
     if (order.toLowerCase() == "asc") {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", ascending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▲</span>');
-      $(headerSelector).attr('aria-sort', 'ascending');
     } else {
       $("#table_sorting_info").attr("aria-label", "sorted by " + (key === "recordID" ? "unique ID" : headerText) + ", descending.");
       $(headerSelector + "_sort").html('<span class="sort_icon_span" aria-hidden="true">▼</span>');
-      $(headerSelector).attr('aria-sort', 'descending');
     }
     $(headerSelector + "_sort").css("display", "inline");
     var array = [];


### PR DESCRIPTION
- Removes a button role from table headers - this role did not completely resolve header issues and also made it difficult for screen-readers to identify the table.

- Adds an aria-label to the table tag to provide additional information about table layer navigation.  Screen reader users will be notified that they should first press escape to enter table later navigation if they are on a header. 

- Brings the other formGrid files up to date with the one in portal/js

**Testing / Impact**

LEAF Form Grid tables (Report Builder reports, homepage results etc)


On the master branch, if user attempts to enter table navigation from a header, the arrow keys cannot be used, and user is told that they are not in a table cell.  If escape is pressed nothing changes.
 
Test with NVDA (free), and JAWS (if you have it).  On the updated branch, upon first navigating to the table, reader will provide information about pressing escape to use table layer navigation from header cells.  After pressing escape, user can enter table layer nav as expected (see below instructions). Users will need to re-enter table layer navigation after sorting headers.  However, this behavior is consistent with W3 ARIA examples where table headers use buttons to mediate events.

NVDA screen-reader table layer nav is used with ctrl + alt + arrow keys.
JAWS screen-reader table layer nav is entered with space + insert, then T.  Arrow keys are used once in the table layer.