### PR TITLE
Leaf 4465 - Nexus 508 updates

### DIFF
--- a/LEAF_Nexus/js/ui/position.js
+++ b/LEAF_Nexus/js/ui/position.js
@@ -5,30 +5,30 @@
 */
 
 function position(positionID) {
-  this.positionID = positionID;
-  this.rootID = 0;
-  this.parentID = 0;
-  this.parentContainerID;
-  this.containerHeader;
+  this.positionID = positionID
+  this.rootID = 0
+  this.parentID = 0
+  this.parentContainerID
+  this.containerHeader
 
-  this.prefixID = "pos" + Math.floor(Math.random() * 1000) + "_";
-  this.data = new Object();
+  this.prefixID = 'pos' + Math.floor(Math.random() * 1000) + '_'
+  this.data = new Object()
 }
 
 position.prototype.initialize = function (parentContainerID) {
-  var t = this;
-  this.parentContainerID = parentContainerID;
+  var t = this
+  this.parentContainerID = parentContainerID
 
-  var prefixedPID = this.prefixID + this.positionID;
-  this.containerHeader = prefixedPID + "_title";
-  var buffer = "";
+  var prefixedPID = this.prefixID + this.positionID
+  this.containerHeader = prefixedPID + '_title'
+  var buffer = ''
   buffer =
     `<div id="${prefixedPID}" class="positionSmall">` +
-      `<div id="${prefixedPID}_numFTE" class="fteCounter"></div>` +
-      `<div tabindex="0" role="button" id="${prefixedPID}_title" class="positionSmall_title"
+    `<div id="${prefixedPID}_numFTE" class="fteCounter"></div>` +
+    `<div tabindex="0" role="button" id="${prefixedPID}_title" class="positionSmall_title"
         aria-expanded="false" aria-controls="${prefixedPID}_controls">
       </div>` +
-      `<div id="${prefixedPID}_container" class="positionSmall_data">
+    `<div id="${prefixedPID}_container" class="positionSmall_data">
         <div id="${prefixedPID}_content"></div>
         <div id="${prefixedPID}_controls" style="visibility: hidden; display: none">
           <a class="button buttonNorm" href="?a=view_position&amp;positionID=${this.positionID}">
@@ -37,171 +37,216 @@ position.prototype.initialize = function (parentContainerID) {
           <button type="button" class="button buttonNorm" onclick="addSubordinate(${this.positionID})">
             <img src="dynicons/?img=list-add.svg&amp;w=32" alt="" /> Add Subordinate
           </button>
+          <button type="button" class="button buttonNorm" onclick='moveCoordinates("${this.prefixID}", "${this.positionID}")'>
+            <img src="dynicons/?img=list-add.svg&amp;w=32" alt="" /> Move Coordinates
+          </button>
         </div>
       </div>
-    </div>`;
-  $("#" + parentContainerID).append(buffer);
+    </div>`
+  $('#' + parentContainerID).append(buffer)
 
-  $("#" + prefixedPID + "_title").on("click keydown mouseenter", function(ev) {
-    const currDisplay =  $("#" + prefixedPID + "_controls").css('display');
-    const isToggle =  [13, 32].includes(ev?.keyCode) || ev.type === "click";
-    if(ev.type === "mouseenter" || (currDisplay === 'none' && isToggle)) {
-        $("#" + prefixedPID + "_controls").css({
-            visibility: "visible",
-            display: "inline",
-        });
-        $("#" + prefixedPID).css("zIndex", "900");
-        $("#" + prefixedPID + "_title").attr("aria-expanded", true);
+  $('#' + prefixedPID + '_title').on('click keydown mouseenter', function (ev) {
+    const currDisplay = $('#' + prefixedPID + '_controls').css('display')
+    const isToggle = [13, 32].includes(ev?.keyCode) || ev.type === 'click'
+    if (ev.type === 'mouseenter' || (currDisplay === 'none' && isToggle)) {
+      $('#' + prefixedPID + '_controls').css({
+        visibility: 'visible',
+        display: 'inline'
+      })
+      $('#' + prefixedPID).css('zIndex', '900')
+      $('#' + prefixedPID + '_title').attr('aria-expanded', true)
     }
-    if(currDisplay === 'inline' && isToggle) {
-        t.unsetFocus();
+    if (currDisplay === 'inline' && isToggle) {
+      t.unsetFocus()
     }
-  });
+  })
 
-  $("#" + prefixedPID + "_container").on("mouseleave focusout", function (ev) {
-    if(ev.type === "mouseleave") {
-        t.unsetFocus();
+  document.querySelector('#' + prefixedPID + '_title').onmouseleave = function (
+    mouse
+  ) {
+    let edge = closestEdge(mouse, this)
+    if (edge === 'top') {
+      t.unsetFocus()
+    }
+  }
+
+  function closestEdge(mouse, elem) {
+    let elemBounding = elem.getBoundingClientRect()
+
+    let elementLeftEdge = elemBounding.left
+    let elementTopEdge = elemBounding.top
+    let elementRightEdge = elemBounding.right
+    let elementBottomEdge = elemBounding.bottom
+
+    let mouseX = mouse.pageX
+    let mouseY = mouse.pageY
+
+    let topEdgeDist = Math.abs(elementTopEdge - mouseY)
+    let bottomEdgeDist = Math.abs(elementBottomEdge - mouseY)
+    let leftEdgeDist = Math.abs(elementLeftEdge - mouseX)
+    let rightEdgeDist = Math.abs(elementRightEdge - mouseX)
+
+    let min = Math.min(topEdgeDist, bottomEdgeDist, leftEdgeDist, rightEdgeDist)
+
+    switch (min) {
+      case leftEdgeDist:
+        return 'left'
+      case rightEdgeDist:
+        return 'right'
+      case topEdgeDist:
+        return 'top'
+      case bottomEdgeDist:
+        return 'bottom'
+    }
+  }
+
+  $('#' + prefixedPID + '_container').on('mouseleave focusout', function (ev) {
+    if (ev.type === 'mouseleave') {
+      t.unsetFocus()
     } else {
-        const curTarget = ev.currentTarget || null;
-        const newTarget = ev.relatedTarget || null;
-        if(curTarget !== null && newTarget !== null) {
-            const containerID = curTarget.id;
-            const newTargetContainer = newTarget.closest('#' + containerID);
-            if(newTargetContainer === null) {
-                t.unsetFocus();
-            }
+      const curTarget = ev.currentTarget || null
+      const newTarget = ev.relatedTarget || null
+      if (curTarget !== null && newTarget !== null) {
+        const containerID = curTarget.id
+        const newTargetContainer = newTarget.closest('#' + containerID)
+        if (newTargetContainer === null) {
+          t.unsetFocus()
         }
+      }
     }
-  });
+  })
 
   //drag handles
-  $("#" + this.containerHeader).on("mouseenter", function () {
-    $("#" + this.containerHeader).addClass("positionSmall_title_drag");
-  });
-  $("#" + this.containerHeader).on("mouseleave", function () {
-    $("#" + this.containerHeader).removeClass("positionSmall_title_drag");
-  });
-};
+  $('#' + this.containerHeader).on('mouseenter', function () {
+    $('#' + this.containerHeader).addClass('positionSmall_title_drag')
+  })
+  $('#' + this.containerHeader).on('mouseleave', function () {
+    $('#' + this.containerHeader).removeClass('positionSmall_title_drag')
+  })
+}
 
-position.prototype.onLoad = function () {};
+position.prototype.onLoad = function () {}
 
-position.prototype.onDrawComplete = function () {};
+position.prototype.onDrawComplete = function () {}
 
 position.prototype.prepContent = function (response) {
-  this.data = response;
-  this.setNumFTE(response[11].data);
-  this.setTitle(response.title);
-  var pd = response[9].data != "" ? "PD#" + response[9].data : "";
+  this.data = response
+  this.setNumFTE(response[11].data)
+  this.setTitle(response.title)
+  var pd = response[9].data != '' ? 'PD#' + response[9].data : ''
   this.setContent(
     response[2].data +
-      " " +
+      ' ' +
       response[13].data +
-      "-" +
+      '-' +
       response[14].data +
-      "<br />" +
+      '<br />' +
       pd
-  );
-  if (response[15].data != "") {
-    var layout = $.parseJSON(response[15].data);
-    $("#" + this.prefixID + this.positionID).css("position", "absolute");
-    var y = 120;
-    var x = 40;
+  )
+  if (response[15].data != '') {
+    var layout = $.parseJSON(response[15].data)
+    $('#' + this.prefixID + this.positionID).css('position', 'absolute')
+    var y = 120
+    var x = 40
     if (layout[this.rootID] != undefined) {
       if (layout[this.rootID].y > 0) {
-        y = layout[this.rootID].y;
+        y = layout[this.rootID].y
       }
       if (layout[this.rootID].x > 0) {
-        x = layout[this.rootID].x;
+        x = layout[this.rootID].x
       }
     } else if (layout[this.parentID] != undefined) {
       if (layout[this.parentID].y > 0) {
-        y = layout[this.parentID].y;
+        y = layout[this.parentID].y
       }
       if (layout[this.parentID].x > 0) {
-        x = layout[this.parentID].x;
+        x = layout[this.parentID].x
       }
     }
 
-    this.setDomPosition(x, y);
+    this.setDomPosition(x, y)
   }
-};
+}
 
 position.prototype.draw = function (data) {
-  var t = this;
+  var t = this
   if (data == undefined) {
     $.ajax({
-      url: "./api/position/" + this.positionID,
+      url: './api/position/' + this.positionID,
       data: { q: this.q },
-      dataType: "json",
+      dataType: 'json',
       success: function (data) {
-        t.prepContent(data);
-        t.onLoad();
-        t.onDrawComplete();
+        t.prepContent(data)
+        t.onLoad()
+        t.onDrawComplete()
       },
-      cache: false,
-    });
+      cache: false
+    })
   } else {
-    t.data = data;
-    response = data;
-    t.prepContent(response);
-    t.onLoad();
-    t.onDrawComplete();
+    t.data = data
+    response = data
+    t.prepContent(response)
+    t.onLoad()
+    t.onDrawComplete()
   }
-};
+}
 
 position.prototype.getDomID = function () {
-  return this.prefixID + this.positionID;
-};
+  return this.prefixID + this.positionID
+}
 
 position.prototype.setDomPosition = function (x, y) {
-  $("#" + this.prefixID + this.positionID).css({
-    position: "absolute",
-    top: y + "px",
-    left: x + "px",
-  });
-};
+  $('#' + this.prefixID + this.positionID).css({
+    position: 'absolute',
+    top: y + 'px',
+    left: x + 'px'
+  })
+}
 
 position.prototype.getPositionID = function () {
-  return this.positionID;
-};
+  return this.positionID
+}
 
 position.prototype.setNumFTE = function (numFTE) {
-  $("#" + this.prefixID + this.positionID + "_numFTE").html(numFTE);
-};
+  $('#' + this.prefixID + this.positionID + '_numFTE').html(numFTE)
+}
 
 position.prototype.setTitle = function (title) {
-  if (title == "") {
-    title = "";
+  if (title == '') {
+    title = ''
   }
-  $("#" + this.prefixID + this.positionID + "_title").html(title);
-};
+  $('#' + this.prefixID + this.positionID + '_title').html(title)
+}
 
 position.prototype.setContent = function (content) {
-  $("#" + this.prefixID + this.positionID + "_content").html(content);
-};
+  $('#' + this.prefixID + this.positionID + '_content').html(content)
+}
 
 position.prototype.setRootID = function (rootID) {
-  this.rootID = rootID;
-};
+  this.rootID = rootID
+}
 
 position.prototype.setParentID = function (parentID) {
-  this.parentID = parentID;
-};
+  this.parentID = parentID
+}
 
 position.prototype.unsetFocus = function () {
-  $("#" + this.prefixID + this.positionID + "_controls").css(
-    "visibility",
-    "hidden"
-  );
-  $("#" + this.prefixID + this.positionID + "_controls").css("display", "none");
-  $("#" + this.prefixID + this.positionID).css("zIndex", "20");
-  $("#" + this.prefixID  + this.positionID + "_title").attr("aria-expanded", false);
-};
+  $('#' + this.prefixID + this.positionID + '_controls').css(
+    'visibility',
+    'hidden'
+  )
+  $('#' + this.prefixID + this.positionID + '_controls').css('display', 'none')
+  $('#' + this.prefixID + this.positionID).css('zIndex', '20')
+  $('#' + this.prefixID + this.positionID + '_title').attr(
+    'aria-expanded',
+    false
+  )
+}
 
 position.prototype.emptyControls = function () {
-  $("#" + this.prefixID + this.positionID + "_controls").empty();
-};
+  $('#' + this.prefixID + this.positionID + '_controls').empty()
+}
 
 position.prototype.addControl = function (control) {
-  $("#" + this.prefixID + this.positionID + "_controls").append(control);
-};
+  $('#' + this.prefixID + this.positionID + '_controls').append(control)
+}

--- a/LEAF_Nexus/templates/editor.tpl
+++ b/LEAF_Nexus/templates/editor.tpl
@@ -4,20 +4,20 @@ placeholder<br />
 
 <span id="editor_toolbar" class="noprint" style="float:right;">
     <span id="editor_tools">
-        <!-- <div onclick="alert('placeholder')"><img src="dynicons/?img=preferences-system-windows.svg&amp;w=32" style="vertical-align: middle" alt="" title="Add Sub-Group" /> Add Sub-Group</div> -->
+        <!-- <div onclick="alert('placeholder')"><img src="dynicons/?img=preferences-system-windows.svg&amp;w=32" style="vertical-align: middle" alt="" /> Add Sub-Group</div> -->
         <button type="button" class="buttonNorm" onclick="zoomIn();">
-            <img src="dynicons/?img=gnome-zoom-in.svg&amp;w=24" style="vertical-align: middle" alt="" title="Zoom In" /> Zoom In
+            <img src="dynicons/?img=gnome-zoom-in.svg&amp;w=24" style="vertical-align: middle" alt="" /> Zoom In
         </button>
         <button type="button" class="buttonNorm" onclick="zoomOut();">
-            <img src="dynicons/?img=gnome-zoom-out.svg&amp;w=24" style="vertical-align: middle" alt="" title="Zoom Out" /> Zoom Out
+            <img src="dynicons/?img=gnome-zoom-out.svg&amp;w=24" style="vertical-align: middle" alt="" /> Zoom Out
         </button>
         <!--{if $rootID != $topPositionID}-->
         <button type="button" class="buttonNorm" onclick="viewSupervisor();">
-            <img src="dynicons/?img=go-up.svg&amp;w=24" style="vertical-align: middle" alt="" title="Zoom Out" /> Go Up One Level
+            <img src="dynicons/?img=go-up.svg&amp;w=24" style="vertical-align: middle" alt="" /> Go Up One Level
         </button>
         <!--{/if}-->
         <button type="button" class="buttonNorm" onclick="window.location='mailto:?subject=FW:%20Org.%20Chart%20-%20&amp;body=Organizational%20Chart%20URL:%20<!--{if $smarty.server.HTTPS == on}-->https<!--{else}-->http<!--{/if}-->://<!--{$smarty.server.SERVER_NAME}--><!--{$smarty.server.REQUEST_URI|escape:'url'}-->%0A%0A'">
-            <img src="dynicons/?img=mail-forward.svg&amp;w=24" style="vertical-align: middle" alt="" title="Forward as Email" /> Forward as Email
+            <img src="dynicons/?img=mail-forward.svg&amp;w=24" style="vertical-align: middle" alt="" /> Forward as Email
         </button>
     </span>
 </span>
@@ -132,7 +132,7 @@ function viewSupervisor() {
 }
 
 function saveLayout(positionID) {
-	$('#busyIndicator').css('visibility', 'visible');
+    $('#busyIndicator').css('visibility', 'visible');
 	var position = $('#' + positions[positionID].getDomID()).offset();
 	var newPosition = new Object();
 	newPosition.x = position.left;
@@ -237,6 +237,54 @@ function addSupervisor(positionID) {
     });
 }
 
+function moveCoordinates(prefix, position) {
+    let card = document.getElementById(prefix + position);
+    let cardStyle = window.getComputedStyle(card);
+    let topOrg = cardStyle.getPropertyValue('top');
+    let leftOrg = cardStyle.getPropertyValue('left');
+    let topValue = cardStyle.getPropertyValue('top').replace("px", "");
+    let leftValue = cardStyle.getPropertyValue('left').replace("px", "");
+    let key;
+    let abort = false;
+
+    document.addEventListener('keydown', function moveCard(e) {
+        e.preventDefault();
+        switch (e.key) {
+            case "ArrowLeft":
+                leftValue = (Number(leftValue) - 10);
+                card.style.left = leftValue + "px";
+                break;
+            case "ArrowRight":
+                leftValue = (Number(leftValue) + 10);
+                card.style.left = leftValue + "px";
+                break;
+            case "ArrowUp":
+                topValue = (Number(topValue) - 10);
+                card.style.top = topValue + "px";
+                break;
+            case "ArrowDown":
+                topValue = (Number(topValue) + 10);
+                card.style.top = topValue + "px";
+                break;
+            case "Enter":
+                // save the coordinates as they are now
+                saveLayout(position);
+                abort = true;
+                break;
+            case "Escape":
+                // revert coordinates back to original
+                card.style.top = topOrg;
+                card.style.left = leftOrg;
+                abort = true;
+                break;
+        }
+
+        if (abort) {
+            document.removeEventListener('keydown', moveCard);
+            return;
+        }
+    });
+}
 
 function addSubordinate(parentID) {
 	positions[parentID].unsetFocus();
@@ -272,8 +320,8 @@ function addSubordinate(parentID) {
                 parentDomPosition.left += 0;
                 parentDomPosition.top += 80;
                 positions[response].setDomPosition(parentDomPosition.left, parentDomPosition.top);
-                positions[response].addControl('<button type="button" class="button buttonNorm" onclick="removePosition('+response+');"><img src="dynicons/?img=process-stop.svg&amp;w=32" alt="" title="Remove Position" /> Remove Position</button>');
-                positions[response].addControl('<button type="button" class="button buttonNorm" onclick="changeSupervisor('+response+');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" title="Change Supervisor" /> Change Supervisor</button>');
+                positions[response].addControl('<button type="button" class="button buttonNorm" onclick="removePosition('+response+');"><img src="dynicons/?img=process-stop.svg&amp;w=32" alt="" /> Remove Position</button>');
+                positions[response].addControl('<button type="button" class="button buttonNorm" onclick="changeSupervisor('+response+');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" /> Change Supervisor</button>');
                 // make position box draggable
                 draggableOptions.stop = function() {
                 	saveLayout(response);
@@ -317,14 +365,14 @@ function getSubordinates(positionID, level) {
 
         positions[subordinate[key].positionID].onLoad = function() {
         	var loadSubordinates = 1;
-        	var positionControls = '<button type="button" class="button buttonNorm" onclick="hideSubordinates('+subordinate[key].positionID+');"><img src="dynicons/?img=gnome-system-users.svg&amp;w=32" alt="" title="Hide" /> Hide Subordinates</button>';
+        	var positionControls = '<button type="button" class="button buttonNorm" onclick="hideSubordinates('+subordinate[key].positionID+');"><img src="dynicons/?img=gnome-system-users.svg&amp;w=32" alt="" /> Hide Subordinates</button>';
         	if(subordinate[key][15].data != '') {
                 var subData = $.parseJSON(subordinate[key][15].data);
                 if(subData[<!--{$rootID}-->] != undefined
                 	&& subData[<!--{$rootID}-->].hideSubordinates != undefined
                		&& subData[<!--{$rootID}-->].hideSubordinates == 1) {
 
-                	positionControls = '<button type="button" class="button buttonNorm" onclick="showSubordinates('+subordinate[key].positionID+');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" title="Show" /> Show Subordinates</button>';
+                	positionControls = '<button type="button" class="button buttonNorm" onclick="showSubordinates('+subordinate[key].positionID+');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" /> Show Subordinates</button>';
                 	loadSubordinates = 0;
                 }
         	}
@@ -352,7 +400,7 @@ function getSubordinates(positionID, level) {
         		   positions[subordinate[key].positionID].addControl(positionControls);
         	}
         	else {
-        		positions[subordinate[key].positionID].addControl('<button type="button" class="button buttonNorm" onclick="removePosition('+subordinate[key].positionID+');"><img src="dynicons/?img=process-stop.svg&amp;w=32" alt="" title="Remove Position" /> Remove Position</button>');
+        		positions[subordinate[key].positionID].addControl('<button type="button" class="button buttonNorm" onclick="removePosition('+subordinate[key].positionID+');"><img src="dynicons/?img=process-stop.svg&amp;w=32" alt="" /> Remove Position</button>');
         	}
 
         	var tPID = subordinate[key].positionID;
@@ -374,8 +422,8 @@ function getSubordinates(positionID, level) {
             	$('svg.editMode path').css({'stroke': '#d0d0d0'});
             });
 
-        	positions[subordinate[key].positionID].addControl('<button type="button" class="button buttonNorm" onclick="changeSupervisor('+subordinate[key].positionID+');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" title="Change Supervisor" /> Change Supervisor</button>');
-        	positions[subordinate[key].positionID].addControl('<a class="button buttonNorm" href="?a=editor&amp;rootID='+subordinate[key].positionID+'"><img src="dynicons/?img=system-search.svg&amp;w=32" alt="" title="Focus on this" /> Focus on This</a>');
+        	positions[subordinate[key].positionID].addControl('<button type="button" class="button buttonNorm" onclick="changeSupervisor('+subordinate[key].positionID+');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" /> Change Supervisor</button>');
+        	positions[subordinate[key].positionID].addControl('<a class="button buttonNorm" href="?a=editor&amp;rootID='+subordinate[key].positionID+'"><img src="dynicons/?img=system-search.svg&amp;w=32" alt="" /> Focus on This</a>');
 
             applyZoomLevel();
         };
@@ -509,7 +557,7 @@ $(function() {
     positions[<!--{$rootID}-->] = new position(<!--{$rootID}-->);
     positions[<!--{$rootID}-->].initialize('bodyarea');
     positions[<!--{$rootID}-->].setRootID(<!--{$rootID}-->);
-    positions[<!--{$rootID}-->].addControl('<button type="button" class="button buttonNorm" onclick="addSupervisor(\'<!--{$rootID}-->\');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" title="Add Supervisor" /> Add Supervisor</button>');
+    positions[<!--{$rootID}-->].addControl('<button type="button" class="button buttonNorm" onclick="addSupervisor(\'<!--{$rootID}-->\');"><img src="dynicons/?img=system-users.svg&amp;w=32" alt="" /> Add Supervisor</button>');
 
     draggableOptions.stop = function() {
         saveLayout(<!--{$rootID}-->);

--- a/LEAF_Nexus/templates/editor.tpl
+++ b/LEAF_Nexus/templates/editor.tpl
@@ -21,7 +21,7 @@ placeholder<br />
         </button>
     </span>
 </span>
-
+<div id="visual_alert_box" role="status" aria-live="assertive" aria-label="" style="position:absolute;opacity:0"></div>
 <div id="pageloadIndicator" style="visibility: visible">
     <div style="opacity: 0.8; z-index: 1000; position: absolute; background: #f3f3f3; height: 97%; width: 97%"></div>
     <div style="z-index: 1001; position: absolute; padding: 16px; width: 97%; text-align: center; font-size: 24px; font-weight: bold; background-color: white">Loading... <img src="images/largespinner.gif" alt="" /></div>
@@ -238,6 +238,13 @@ function addSupervisor(positionID) {
 }
 
 function moveCoordinates(prefix, position) {
+    $('#' + prefix + position).css('box-shadow', ' 0 0 6px #c00');
+    let alert_box = document.getElementById('visual_alert_box');
+    let title = document.getElementById(prefix + position + '_title');
+    let titleText = title.innerHTML;
+    alert_box.innerHTML = "You are moving the " + titleText + " card<br />Esc - return to original location<br />Enter - save current location";
+    $('#visual_alert_box').css('opacity', '100');
+
     let card = document.getElementById(prefix + position);
     let cardStyle = window.getComputedStyle(card);
     let topOrg = cardStyle.getPropertyValue('top');
@@ -280,6 +287,8 @@ function moveCoordinates(prefix, position) {
         }
 
         if (abort) {
+            $('#' + prefix + position).css('box-shadow', 'none');
+            $('#visual_alert_box').css('opacity', '0');
             document.removeEventListener('keydown', moveCard);
             return;
         }

--- a/LEAF_Nexus/templates/navigator.tpl
+++ b/LEAF_Nexus/templates/navigator.tpl
@@ -4,11 +4,11 @@ placeholder<br />
 
 <span id="editor_toolbar" class="noprint" style="float:right;">
     <span id="editor_tools">
-        <button type="button" class="buttonNorm" onclick="window.location='?a=editor&amp;rootID=<!--{$rootID}-->';"><img src="dynicons/?img=accessories-text-editor.svg&amp;w=24" style="vertical-align: middle" alt="" title="Edit Orgchart" /> Edit Orgchart</button>
+        <button type="button" class="buttonNorm" onclick="window.location='?a=editor&amp;rootID=<!--{$rootID}-->';"><img src="dynicons/?img=accessories-text-editor.svg&amp;w=24" style="vertical-align: middle" alt="" /> Edit Orgchart</button>
         <!--{if $rootID != $topPositionID}-->
         <button type="button" class="buttonNorm" onclick="viewSupervisor();"><img src="dynicons/?img=go-up.svg&amp;w=24" style="vertical-align: middle" alt="" title="Zoom Out" /> Go Up One Level</button>
         <!--{/if}-->
-        <button type="button" class="buttonNorm"  onclick="window.location='mailto:?subject=FW:%20Org.%20Chart%20-%20&amp;body=Organizational%20Chart%20URL:%20<!--{if $smarty.server.HTTPS == on}-->https<!--{else}-->http<!--{/if}-->://<!--{$smarty.server.SERVER_NAME}--><!--{$smarty.server.REQUEST_URI|escape:'url'}-->%0A%0A'"><img src="dynicons/?img=mail-forward.svg&amp;w=24" style="vertical-align: middle" alt="" title="Forward as Email" /> Forward as Email</button>
+        <button type="button" class="buttonNorm"  onclick="window.location='mailto:?subject=FW:%20Org.%20Chart%20-%20&amp;body=Organizational%20Chart%20URL:%20<!--{if $smarty.server.HTTPS == on}-->https<!--{else}-->http<!--{/if}-->://<!--{$smarty.server.SERVER_NAME}--><!--{$smarty.server.REQUEST_URI|escape:'url'}-->%0A%0A'"><img src="dynicons/?img=mail-forward.svg&amp;w=24" style="vertical-align: middle" alt="" /> Forward as Email</button>
     </span>
 </span>
 
@@ -223,7 +223,7 @@ $(function() {
     };
 
     positions[<!--{$rootID}-->].emptyControls();
-    positions[<!--{$rootID}-->].addControl('<a class="button buttonNorm" href="?a=view_position&amp;positionID=<!--{$rootID}-->"><img src="dynicons/?img=accessories-text-editor.svg&amp;w=32" alt="" title="View Details" /> View Details</a>');
+    positions[<!--{$rootID}-->].addControl('<a class="button buttonNorm" href="?a=view_position&amp;positionID=<!--{$rootID}-->"><img src="dynicons/?img=accessories-text-editor.svg&amp;w=32" alt="" /> View Details</a>');
     positions[<!--{$rootID}-->].draw();
     setPositionStyle(positions[<!--{$rootID}-->].prefixID + <!--{$rootID}-->, <!--{$rootID}-->);
 


### PR DESCRIPTION
Nexus Orgchart navigator and editor

Page needs a number of improvements

Additional info to user on overview page about what the page is conveying and what can be edited (brief ok)

Drag behavior in the editor should be available from keyboard

Tab order at least appears unintuitive.  There is a number associated with each cell that might mediate this.  Tabbing should be tree breadth so presentation alone might resolve this

Doublecheck how / when associated dropdowns collapse - tabbing away and full mouse off should close them

Potential Impact:
These changes should make it easier for people to navigate the orgchart navigator and editor with the keyboard.

Testing:
Open the orgchart and click browse.
using only the keyboard tab through the page. Once you get to the different positions they should tab in hierarchy order, Level 1 to level 2 to level 3 and so on.
If you press enter on the edit orgchart from the navigator page you enter the editor page. 
tabbing through the page again should tab through the hierarchy order. 
There is a new button name move coordinates for each of the positions.
Pressing enter on move coordinates will allow you to use the arrow keys to move the position around the screen.
Pressing Esc will return the position to it's original coordinates and exit the eventListener.
Pressing Enter will save the newcoordinates and exit the eventListener.