### PR TITLE
LEAF-4498 - Mitigate dialog button race condition

### DIFF
--- a/LEAF_Request_Portal/admin/templates/site_elements/generic_xhrDialog.tpl
+++ b/LEAF_Request_Portal/admin/templates/site_elements/generic_xhrDialog.tpl
@@ -12,12 +12,12 @@
 
             <aside class="leaf-buttonBar" role="complementary">
                 <div class="leaf-float-left">
-                    <button id="button_save" class="usa-button leaf-btn-med">
+                    <button id="button_save" class="usa-button leaf-btn-med" disabled>
                         Save
                     </button>
                 </div>
                 <div class="leaf-float-right">
-                    <button id="button_cancelchange" class="usa-button usa-button--outline leaf-btn-med">
+                    <button id="button_cancelchange" class="usa-button usa-button--outline leaf-btn-med" disabled>
                         Cancel
                     </button>
                 </div>

--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -39,6 +39,7 @@ function dialogController(containerID, contentID, loadIndicatorID, btnSaveID, bt
     $('#' + this.btnCancelID).on('click', function() {
     	t.hide();
     });
+	document.querySelector('#' + this.btnCancelID).removeAttribute('disabled');
     $('button.ui-dialog-titlebar-close').on('click', function() {
         t.hide();
     });
@@ -201,6 +202,7 @@ dialogController.prototype.setSaveHandler = function(funct) {
         	t.indicateIdle();
         }
     });
+	document.querySelector('#' + this.btnSaveID).removeAttribute('disabled');
 };
 
 dialogController.prototype.setCancelHandler = function(funct) {

--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -196,6 +196,7 @@ dialogController.prototype.setSaveHandler = function(funct) {
     this.dialogControllerXhrEvent = $('#' + this.btnSaveID).on('click', function() {
         if(t.isValid(true) == 1 && t.isComplete(true) == 1) {
         	funct();
+			document.querySelector('#' + this.btnSaveID).setAttribute('disabled', '');
         	$('#' + t.btnSaveID).off();
         }
         else {

--- a/x-test/end2end/playwright.config.ts
+++ b/x-test/end2end/playwright.config.ts
@@ -16,8 +16,7 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: 2,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -18,7 +18,6 @@ test('navigate to Workflow Editor and create a travel workflow', async ({ page }
   await page.getByRole('button', { name: 'Save' }).click();
 
   // wait for async request to finish saving
-  await expect(page.getByRole('button', { name: 'Save' })).not.toBeVisible();
   await expect(page.locator('a').filter({ hasText: uniqueText })).toBeVisible();
 
   // Workaround: Since the drag handles can overlap sometimes (maybe due to async rendering


### PR DESCRIPTION
This works towards resolving an issue identified during automated testing, and is described in more detail here: https://playwright.dev/docs/navigations#hydration

The issue is that buttons can be clicked before an event handler is assigned to it, which results in nothing happening when the button is clicked.

This updates one of the admin's dialog templates to implement the solution described in Playwright's documentation.

Additional minor changes in tests:
- Reduced an operation in `lifecycleSimpleTrave.spec.ts` that was used as a part of a workaround for the previously described issue.
- Enabled test retries (up to 2 total runs per test) in order to highlight potentially flaky tests and minimize their impact on dev velocity

## Future:
This solution will also need to be implemented in the remaining admin and non-admin dialog templates.

## Potential Impact:
Admin pages that utilize `xhrDialog` depend on the updated `dialogController.js` file to be up-to-date on client machines, which may be impacted by cache controls.


## Testing:
- [ ] Automated tests pass
- [ ] Dialog boxes work normally, such as the one in Admin Panel -> Workflow Editor -> New Workflow
