### PR TITLE
Resolve JS error (dev console approval), Improve tests

### DIFF
--- a/LEAF_Request_Portal/admin/templates/site_elements/generic_OkDialog.tpl
+++ b/LEAF_Request_Portal/admin/templates/site_elements/generic_OkDialog.tpl
@@ -1,6 +1,6 @@
 <div id="ok_xhrDialog" style="background-color: #feffd1; border: 1px solid black; visibility: hidden; display: none">
 <div>
     <div id="ok_xhr" style="font-size: 130%; width: 400px; height: 120px; padding: 16px; overflow: auto"></div>
-    <div style="text-align: right; padding-right: 6px"><button class="buttonNorm" id="confirm_button_ok"><img src="../dynicons/?img=dialog-apply.svg&amp;w=32" alt="" /><span id="confirm_saveBtnText"> Ok</span></button></div><br />
+    <div style="text-align: right; padding-right: 6px"><button class="buttonNorm" id="confirm_button_ok" disabled><img src="../dynicons/?img=dialog-apply.svg&amp;w=32" alt="" /><span id="confirm_saveBtnText"> Ok</span></button></div><br />
 </div>
 </div>

--- a/LEAF_Request_Portal/admin/templates/site_elements/generic_confirm_xhrDialog.tpl
+++ b/LEAF_Request_Portal/admin/templates/site_elements/generic_confirm_xhrDialog.tpl
@@ -12,11 +12,11 @@
 
             <aside class="leaf-buttonBar" role="complementary">
                 <div class="leaf-float-right">
-                    <button class="usa-button usa-button--outline" id="confirm_button_cancelchange">No</button>
+                    <button class="usa-button usa-button--outline" id="confirm_button_cancelchange" disabled>No</button>
                 </div>
 
                 <div class="leaf-float-left">
-                    <button class="usa-button" id="confirm_button_save"><span id="confirm_saveBtnText">Yes</span></button>
+                    <button class="usa-button" id="confirm_button_save" disabled><span id="confirm_saveBtnText">Yes</span></button>
                 </div>
             </aside>
         

--- a/LEAF_Request_Portal/admin/templates/site_elements/generic_simple_xhrDialog.tpl
+++ b/LEAF_Request_Portal/admin/templates/site_elements/generic_simple_xhrDialog.tpl
@@ -10,13 +10,13 @@
         
         <aside class="leaf-buttonBar" role="complementary">
             <div class="leaf-float-right">
-                <button id="simplebutton_cancelchange" class="usa-button usa-button--outline" style="display: none;">
+                <button id="simplebutton_cancelchange" class="usa-button usa-button--outline" style="display: none;" disabled>
                     Cancel
                 </button>
             </div>
 
             <div class="leaf-float-left">
-                <button id="simplebutton_save" class="usa-button" style="display: none">
+                <button id="simplebutton_save" class="usa-button" style="display: none" disabled>
                     Save
                 </button>
             </div>

--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -196,14 +196,18 @@ dialogController.prototype.setSaveHandler = function(funct) {
     this.dialogControllerXhrEvent = $('#' + this.btnSaveID).on('click', function() {
         if(t.isValid(true) == 1 && t.isComplete(true) == 1) {
         	funct();
-			document.querySelector('#' + this.btnSaveID).setAttribute('disabled', '');
+			if(document.querySelector('#' + this.btnSaveID) != undefined) {
+				document.querySelector('#' + this.btnSaveID).setAttribute('disabled', '');
+			}
         	$('#' + t.btnSaveID).off();
         }
         else {
         	t.indicateIdle();
         }
     });
-	document.querySelector('#' + this.btnSaveID).removeAttribute('disabled');
+	if(document.querySelector('#' + this.btnSaveID) != undefined) {
+		document.querySelector('#' + this.btnSaveID).removeAttribute('disabled');
+	}
 };
 
 dialogController.prototype.setCancelHandler = function(funct) {

--- a/LEAF_Request_Portal/templates/form.tpl
+++ b/LEAF_Request_Portal/templates/form.tpl
@@ -7,7 +7,7 @@
             <div id="progressArea" style="height: 34px; background-color: #feffd2; padding: 4px; border-bottom: 1px solid black">
                 <div id="progressControl" style="float: left">Form completion progress: <div tabIndex="0" id="progressBar" title="form progress bar" style="height: 14px; margin: 2px; border: 1px solid black; text-align: center"><div style="width: 300px; line-height: 120%; float: left; font-size: 12px" id="progressLabel"></div></div><div style="line-height: 30%"><!-- ie7 workaround --></div>
                 </div>
-                <div style="float: right"><button id="nextQuestion" type="button" class="buttonNorm nextQuestion"><img src="dynicons/?img=go-next.svg&amp;w=22" alt="" /> Next Question</button></div>
+                <div style="float: right"><button id="nextQuestion" type="button" class="buttonNorm nextQuestion" disabled><img src="dynicons/?img=go-next.svg&amp;w=22" alt="" /> Next Question</button></div>
                 <br style="clear: both" />
             </div>
             <div>
@@ -21,7 +21,7 @@
             </div>
             <div id="progressArea2" style="height: 34px; background-color: #feffd2; padding: 4px; border-top: 1px solid black">
                 <div style="float: left"><button id="prevQuestion" type="button" class="buttonNorm prevQuestion"><img src="dynicons/?img=go-previous.svg&amp;w=22" alt="" aria-label="Previous"/> Previous Question</button></div>
-                <div style="float: right"><button id="nextQuestion2" type="button" class="buttonNorm nextQuestion"><img src="dynicons/?img=go-next.svg&amp;w=22" alt="" aria-label="Next"/> Next Question</button></div>
+                <div style="float: right"><button id="nextQuestion2" type="button" class="buttonNorm nextQuestion" disabled><img src="dynicons/?img=go-next.svg&amp;w=22" alt="" aria-label="Next"/> Next Question</button></div>
             </div>
         </div>
         <br />
@@ -255,6 +255,9 @@ $(function() {
             updateProgress(true);
         });
         form.dialog().clickSave();
+    });
+    document.querySelectorAll('.nextQuestion').forEach(button => {
+        button.removeAttribute('disabled');
     });
 
     $('.prevQuestion').on('click', function() {

--- a/LEAF_Request_Portal/templates/reports/LEAF_start_leaf_dev_console_request.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_start_leaf_dev_console_request.tpl
@@ -4,7 +4,7 @@ $(function() {
     query.addTerm('categoryID', '=', 'leaf_devconsole');
     query.addTerm('stepID', '!=', 'resolved');
     query.onSuccess(function(data) {
-        if(data.length != 0) {
+        if(Object.keys(data).length != 0) {
             $('#rob_status>iframe').attr('src', './?a=printview&iframe=1&masquerade=nonAdmin&recordID=' + data[Object.keys(data)[0]].recordID);
 
             $('#rob_request').slideUp();
@@ -43,6 +43,7 @@ $(function() {
             }
         });
     });
+    document.querySelector('#startRequest').removeAttribute('disabled');
 });
 </script>
 <style>
@@ -132,7 +133,7 @@ $(function() {
     </div>
 
     <div style="width: 70%; margin: auto; text-align: center; margin-top: 16px">
-        <button class="buttonNorm" id="startRequest" style="font-size: 140%; padding: 8px"><img src="dynicons/?img=accessories-text-editor.svg&w=32" alt="" /> I understand and accept</button>
+        <button class="buttonNorm" id="startRequest" style="font-size: 140%; padding: 8px" disabled><img src="dynicons/?img=accessories-text-editor.svg&w=32" alt="" /> I understand and accept</button>
     </div>
 
 </div>

--- a/LEAF_Request_Portal/templates/site_elements/generic_OkDialog.tpl
+++ b/LEAF_Request_Portal/templates/site_elements/generic_OkDialog.tpl
@@ -1,6 +1,6 @@
 <div id="ok_xhrDialog" style="background-color: #feffd1; border: 1px solid black; visibility: hidden; display: none">
 <div>
     <div id="ok_xhr" style="font-size: 130%; width: 400px; height: 120px; padding: 16px; overflow: auto"></div>
-    <div style="text-align: right; padding-right: 6px"><button class="buttonNorm" id="confirm_button_ok"><img src="dynicons/?img=dialog-apply.svg&amp;w=32" alt="" /><span id="confirm_saveBtnText"> Ok</span></button></div><br />
+    <div style="text-align: right; padding-right: 6px"><button class="buttonNorm" id="confirm_button_ok" disabled><img src="dynicons/?img=dialog-apply.svg&amp;w=32" alt="" /><span id="confirm_saveBtnText"> Ok</span></button></div><br />
 </div>
 </div>

--- a/LEAF_Request_Portal/templates/site_elements/generic_confirm_xhrDialog.tpl
+++ b/LEAF_Request_Portal/templates/site_elements/generic_confirm_xhrDialog.tpl
@@ -3,8 +3,8 @@
     <div>
         <div id="confirm_loadIndicator" style="visibility: hidden; position: absolute; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; height: 100px; width: 360px">Loading... <img src="images/largespinner.gif" alt="" /></div>
         <div id="confirm_xhr" style="font-size: 130%; width: 400px; height: 120px; padding: 16px; overflow: auto"></div>
-        <div style="position: absolute; left: 10px; font-size: 140%"><button type="button" class="buttonNorm" id="confirm_button_cancelchange"><img src="dynicons/?img=edit-undo.svg&amp;w=32" alt="" /> No</button></div>
-        <div style="text-align: right; padding-right: 6px"><button type="button" class="buttonNorm" id="confirm_button_save"><img src="dynicons/?img=dialog-apply.svg&amp;w=32" alt="" /><span id="confirm_saveBtnText"> Yes</span></button></div><br />
+        <div style="position: absolute; left: 10px; font-size: 140%"><button type="button" class="buttonNorm" id="confirm_button_cancelchange" disabled><img src="dynicons/?img=edit-undo.svg&amp;w=32" alt="" /> No</button></div>
+        <div style="text-align: right; padding-right: 6px"><button type="button" class="buttonNorm" id="confirm_button_save" disabled><img src="dynicons/?img=dialog-apply.svg&amp;w=32" alt="" /><span id="confirm_saveBtnText"> Yes</span></button></div><br />
     </div>
 </form>
 </div>

--- a/LEAF_Request_Portal/templates/site_elements/generic_xhrDialog.tpl
+++ b/LEAF_Request_Portal/templates/site_elements/generic_xhrDialog.tpl
@@ -1,8 +1,8 @@
 <div id="xhrDialog" style="visibility: hidden; display: none; background-color: white; border-style: none solid solid; border-width: 0 1px 1px; border-color: #e0e0e0; padding: 4px">
 <form id="record" enctype="multipart/form-data" action="javascript:void(0);">
     <div>
-        <button type="button" id="button_cancelchange" class="buttonNorm" style="position: absolute; left: 10px"><img src="dynicons/?img=process-stop.svg&amp;w=16" alt="" /> Cancel</button>
-        <button type="button" id="button_save" class="buttonNorm" style="position: absolute; right: 10px"><img src="dynicons/?img=media-floppy.svg&amp;w=16" alt="" /> Save Change</button>
+        <button type="button" id="button_cancelchange" class="buttonNorm" style="position: absolute; left: 10px" disabled><img src="dynicons/?img=process-stop.svg&amp;w=16" alt="" /> Cancel</button>
+        <button type="button" id="button_save" class="buttonNorm" style="position: absolute; right: 10px" disabled><img src="dynicons/?img=media-floppy.svg&amp;w=16" alt="" /> Save Change</button>
         <div style="border-bottom: 2px solid black; line-height: 30px"><br /></div>
         <div id="loadIndicator" style="visibility: hidden; z-index: 9000; position: absolute; text-align: center; font-size: 24px; font-weight: bold; background-color: #f2f5f7; padding: 16px; height: 400px; width: 526px"><img src="images/largespinner.gif" alt="" /></div>
         <div id="xhr" style="min-width: 540px; min-height: 420px; padding: 8px; overflow: auto; font-size: 12px"></div>

--- a/x-test/end2end/README.md
+++ b/x-test/end2end/README.md
@@ -13,3 +13,8 @@ Debug tests:
 ```
 npx playwright test --ui
 ```
+
+View trace:
+```
+npx playwright show-trace [path to trace.zip]
+```

--- a/x-test/end2end/playwright.config.ts
+++ b/x-test/end2end/playwright.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: 2,
+  // repeatEach: 3, // only temporarily enable to find flaky tests
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
+++ b/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
@@ -9,5 +9,9 @@ test('no javascript errors on supervisor selection page', async ({ page }) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_start_leaf_dev_console_request');
   await page.getByRole('button', { name: 'I understand and accept' }).click();
   await page.getByRole('button', { name: 'Next Next Question' }).click();
+
+  // wait for async request to complete
+  await expect(page.locator('label')).toContainText('Supervisor* Required');
+
   expect(errors).toHaveLength(0);
 });

--- a/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
+++ b/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('no javascript errors on supervisor selection page', async ({ page }) => {
+  let errors = new Array<Error>;
+  page.on('pageerror', err => {
+    errors.push(err);
+  });
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_start_leaf_dev_console_request');
+  await page.getByRole('button', { name: 'I understand and accept' }).click();
+  await page.getByRole('button', { name: 'Next Next Question' }).click();
+  expect(errors).toHaveLength(0);
+});

--- a/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
+++ b/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
@@ -12,7 +12,7 @@ test('no javascript errors on supervisor selection page', async ({ page }, testI
   // Wait for load
   await expect(page.locator('#xhr')).toContainText('This is a request to access the LEAF Developer Console.');
 
-  await page.getByRole('button', { name: 'Next Next Question' }).click();
+  await page.getByRole('button', { name: 'Next Question' }).last().click();
 
   // wait for async request to complete
   await expect(page.getByText('Approval Officials', { exact: true })).toContainText('Approval Officials');

--- a/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
+++ b/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('no javascript errors on supervisor selection page', async ({ page }) => {
+test('no javascript errors on supervisor selection page', async ({ page }, testInfo) => {
   let errors = new Array<Error>;
   page.on('pageerror', err => {
     errors.push(err);
@@ -8,6 +8,10 @@ test('no javascript errors on supervisor selection page', async ({ page }) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_start_leaf_dev_console_request');
   await page.getByRole('button', { name: 'I understand and accept' }).click();
+
+  // Wait for load
+  await expect(page.locator('#xhr')).toContainText('This is a request to access the LEAF Developer Console.');
+
   await page.getByRole('button', { name: 'Next Next Question' }).click();
 
   // wait for async request to complete

--- a/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
+++ b/x-test/end2end/tests/lifecycleDeveloperConsoleApproval.spec.ts
@@ -11,7 +11,7 @@ test('no javascript errors on supervisor selection page', async ({ page }) => {
   await page.getByRole('button', { name: 'Next Next Question' }).click();
 
   // wait for async request to complete
-  await expect(page.locator('label')).toContainText('Supervisor* Required');
+  await expect(page.getByText('Approval Officials', { exact: true })).toContainText('Approval Officials');
 
   expect(errors).toHaveLength(0);
 });

--- a/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/x-test/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -12,18 +12,22 @@ test('navigate to Workflow Editor and create a travel workflow', async ({ page }
   await page.goto('https://host.docker.internal/Test_Request_Portal/admin/');
 
   await page.getByRole('button', { name: ' Workflow Editor Edit' }).click();
+
+  // wait for async request to finish loading the first workflow
+  await expect(page.getByLabel('workflow step: Group')).toBeInViewport();
+
   await page.getByRole('button', { name: 'New Workflow' }).click();
   await page.getByLabel('Workflow Title:').click();
   await page.getByLabel('Workflow Title:').fill(uniqueText);
   await page.getByRole('button', { name: 'Save' }).click();
 
   // wait for async request to finish saving
-  await expect(page.locator('a').filter({ hasText: uniqueText })).toBeVisible();
-
   // Workaround: Since the drag handles can overlap sometimes (maybe due to async rendering
   // in the jsPlumb library?), we'll move the requestor step out of the way first.
   // TODO: fix the workflow editor since end-users might have the same issue
-  await expect(page.getByLabel('workflow step: Step 1')).not.toBeInViewport();
+  await expect(page.getByLabel('workflow step: Group')).not.toBeInViewport();
+  await expect(page.locator('a').filter({ hasText: uniqueText })).toBeVisible();
+  await expect(page.locator('rect').first()).toBeInViewport();
   // Workaround: Set specific position because the workflow step's drag handle overlaps with the connector's handle
   await page.getByLabel('workflow step: Requestor', { exact: true }).hover({position: {x: 16, y: 16}});
   await page.mouse.down();


### PR DESCRIPTION
Note: This does not need to be rolled out as a hotfix, because functionality is not impacted.

This PR:
- Resolves an error message that shows up in the JS console during the LEAF Developer Console approval workflow
  - Added automated test that reproduces the issue, and checked for validity against `rc/2024-08-27/Sprint-80-c2`
  - Also resolves a JS warning on the same page
- Expands the work to mitigate page hydration issues from https://github.com/department-of-veterans-affairs/LEAF/pull/2532
- Reduces test flakiness
  - `x-test/end2end/tests/lifecycleSimpleTravel.spec.ts` now checks the results of a key async request. Previously, the UI would occasionally render two workflows on the screen during repeated test runs.

### Potential Impact
Similar to #2532: 
> pages that utilize [dialog templates] depend on the updated dialogController.js file to be up-to-date on client machines, which may be impacted by cache controls.

### Testing
- [ ] Automated tests pass