### PR TITLE
LEAF 4505 move aria label and address truncation issue

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -42,8 +42,8 @@ var LeafFormGrid = function (containerID, options) {
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
       aria-label="" aria-live="assertive">
     </span>
-    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results, press escape to use table navigation options from a header cell.">
-      <thead id="${prefixID}thead" style="position: sticky; top: 0px"></thead>
+    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results">
+      <thead id="${prefixID}thead" style="position: sticky; top: 0px" aria-label="Press escape to use table navigation options from a header cell."></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot" class="leaf_grid-loading"></tfoot>
     </table>`
@@ -60,6 +60,23 @@ var LeafFormGrid = function (containerID, options) {
   function hideIndex() {
     showIndex = false;
   }
+
+  /**
+   *
+   * @param {string} input content to remove potential html from.
+   * @returns
+   */
+  function scrubHTML(input) {
+    if(input == undefined) {
+        return '';
+    }
+    let t = new DOMParser().parseFromString(input, 'text/html').body;
+    while(input != t.textContent) {
+        return scrubHTML(t.textContent);
+    }
+    return t.textContent;
+  }
+
 
   /**
    * @param values (required) object of cells and names to generate grid
@@ -252,15 +269,17 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" aria-label="Sort by ${headers[i].name}">
-        ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
-        </th>`);
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0" style="text-align:${align}">` +
+        `${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>` +
+      `</th>`);
 
       if (headers[i].sortable == undefined || headers[i].sortable == true) {
         $("#" + prefixID + "header_" + headers[i].indicatorID).css(
           "cursor",
           "pointer"
         );
+        const txt = scrubHTML(headers[i].name).replace(/['"]+/g, "").trim();
+        $(`#${prefixID}header_${headers[i].indicatorID}`).attr('aria-label', `Sort by ${txt}`);
         $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click keydown",
           null,
@@ -372,7 +391,7 @@ var LeafFormGrid = function (containerID, options) {
     let headerText = '';
     for(let i in headers) {
       if(headers[i].indicatorID == key) {
-        headerText = headers[i].name;
+        headerText = scrubHTML(headers[i].name).replace(/['"]+/g, "").trim();
         break;
       }
     }

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -42,8 +42,8 @@ var LeafFormGrid = function (containerID, options) {
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
       aria-label="" aria-live="assertive">
     </span>
-    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results, press escape to use table navigation options from a header cell.">
-      <thead id="${prefixID}thead" style="position: sticky; top: 0px"></thead>
+    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results">
+      <thead id="${prefixID}thead" style="position: sticky; top: 0px" aria-label="Press escape to use table navigation options from a header cell."></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot" class="leaf_grid-loading"></tfoot>
     </table>`
@@ -60,6 +60,23 @@ var LeafFormGrid = function (containerID, options) {
   function hideIndex() {
     showIndex = false;
   }
+
+  /**
+   *
+   * @param {string} input content to remove potential html from.
+   * @returns
+   */
+  function scrubHTML(input) {
+    if(input == undefined) {
+        return '';
+    }
+    let t = new DOMParser().parseFromString(input, 'text/html').body;
+    while(input != t.textContent) {
+        return scrubHTML(t.textContent);
+    }
+    return t.textContent;
+  }
+
 
   /**
    * @param values (required) object of cells and names to generate grid
@@ -252,15 +269,17 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" aria-label="Sort by ${headers[i].name}">
-        ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
-        </th>`);
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0" style="text-align:${align}">` +
+        `${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>` +
+      `</th>`);
 
       if (headers[i].sortable == undefined || headers[i].sortable == true) {
         $("#" + prefixID + "header_" + headers[i].indicatorID).css(
           "cursor",
           "pointer"
         );
+        const txt = scrubHTML(headers[i].name).replace(/['"]+/g, "").trim();
+        $(`#${prefixID}header_${headers[i].indicatorID}`).attr('aria-label', `Sort by ${txt}`);
         $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click keydown",
           null,
@@ -372,7 +391,7 @@ var LeafFormGrid = function (containerID, options) {
     let headerText = '';
     for(let i in headers) {
       if(headers[i].indicatorID == key) {
-        headerText = headers[i].name;
+        headerText = scrubHTML(headers[i].name).replace(/['"]+/g, "").trim();
         break;
       }
     }

--- a/libs/js/LEAF/formGrid.js
+++ b/libs/js/LEAF/formGrid.js
@@ -42,8 +42,8 @@ var LeafFormGrid = function (containerID, options) {
     <span id="table_sorting_info" role="status" style="position:absolute;top: -40rem"
       aria-label="" aria-live="assertive">
     </span>
-    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results, press escape to use table navigation options from a header cell.">
-      <thead id="${prefixID}thead" style="position: sticky; top: 0px"></thead>
+    <table id="${prefixID}table" class="leaf_grid" aria-label="Search results">
+      <thead id="${prefixID}thead" style="position: sticky; top: 0px" aria-label="Press escape to use table navigation options from a header cell."></thead>
       <tbody id="${prefixID}tbody"></tbody>
       <tfoot id="${prefixID}tfoot" class="leaf_grid-loading"></tfoot>
     </table>`
@@ -60,6 +60,23 @@ var LeafFormGrid = function (containerID, options) {
   function hideIndex() {
     showIndex = false;
   }
+
+  /**
+   *
+   * @param {string} input content to remove potential html from.
+   * @returns
+   */
+  function scrubHTML(input) {
+    if(input == undefined) {
+        return '';
+    }
+    let t = new DOMParser().parseFromString(input, 'text/html').body;
+    while(input != t.textContent) {
+        return scrubHTML(t.textContent);
+    }
+    return t.textContent;
+  }
+
 
   /**
    * @param values (required) object of cells and names to generate grid
@@ -252,15 +269,17 @@ var LeafFormGrid = function (containerID, options) {
         continue;
       }
       var align = headers[i].align != undefined ? headers[i].align : "center";
-      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0"  style="text-align:${align}" aria-label="Sort by ${headers[i].name}">
-        ${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>
-        </th>`);
+      domThead.insertAdjacentHTML('beforeend', `<th scope="col" id="${prefixID}header_${headers[i].indicatorID}" tabindex="0" style="text-align:${align}">` +
+        `${headers[i].name}<span id="${prefixID}header_${headers[i].indicatorID}_sort" class="${prefixID}sort"></span>` +
+      `</th>`);
 
       if (headers[i].sortable == undefined || headers[i].sortable == true) {
         $("#" + prefixID + "header_" + headers[i].indicatorID).css(
           "cursor",
           "pointer"
         );
+        const txt = scrubHTML(headers[i].name).replace(/['"]+/g, "").trim();
+        $(`#${prefixID}header_${headers[i].indicatorID}`).attr('aria-label', `Sort by ${txt}`);
         $("#" + prefixID + "header_" + headers[i].indicatorID).on(
           "click keydown",
           null,
@@ -372,7 +391,7 @@ var LeafFormGrid = function (containerID, options) {
     let headerText = '';
     for(let i in headers) {
       if(headers[i].indicatorID == key) {
-        headerText = headers[i].name;
+        headerText = scrubHTML(headers[i].name).replace(/['"]+/g, "").trim();
         break;
       }
     }


### PR DESCRIPTION
We received feedback from the 508 audit team about a label being added to the formGrid tables to ensure screen-reader users knew that they need to press escape before trying to use table layer nav from a header.  They thought this _should_ be adequate but that it might be preferable if this aria-label were on the thead rather than the table element.

There is also an issue re-introduced at some point where aria-labels for sortable headers could contain html and/or quotes.  This can cause the label to read incorrectly and/or affect the header display if html is truncated.

**Testing / Impact**

Changes should be limited to screen-reader output and some rare custom header content.  General regression-testing of formGrid tables should still be undertaken.  Some testing requires a screen reader (NVDA screen reader is a free option).

- 'Press escape to use table navigation options from a header cell' should be announced once the table header is entered.  This is similar to what it does already, except that the label is on the thead element

- After pressing escape, confirm user can navigate the table layer as expected (for NVDA, this is ctrl + alt + arrows keys)

- Headers that are explicitly defined with 'sortable: false' are not read as 'sort by header name'.   Instead, the header cell content text should be read.

- Aria-label, when present, should not contain html or be truncated by quotes.
Custom headers can be added to the view_search template in the Template Editor.  Examples that could be used to test include:

        {name: 'Custom Header 1', indicatorID: 'custom1'},
        {name: '<h3 color="#c00;">Custom Header 2</h2?', indicatorID: 'custom2'},
        {name: '<h3 color="#c00;">Custom Header 3</h2?', indicatorID: 'custom3', sortable: false},

