### PR TITLE
LEAF 4476 prevent orgchart selector ID collision

### DIFF
--- a/LEAF_Nexus/js/employeeSelector.js
+++ b/LEAF_Nexus/js/employeeSelector.js
@@ -11,7 +11,7 @@ function employeeSelector(containerID) {
   this.selection = "";
 
   this.containerID = containerID;
-  this.prefixID = "empSel" + Math.floor(Math.random() * 1000) + "_";
+  this.prefixID = this.makePrefixID();
   this.timer = 0;
   this.q = "";
   this.isBusy = 1;
@@ -28,6 +28,12 @@ function employeeSelector(containerID) {
   this.emailHref = false; // create link for email
 
   this.numResults = 0;
+}
+
+employeeSelector.prototype.makePrefixID = function () {
+  const id = "empSel" + Math.floor(Math.random() * 1000) + "_";
+  const el = document.getElementById(id + 'result');
+  return (el !== null) ? this.makePrefixID() : id;
 }
 
 employeeSelector.prototype.initialize = function () {

--- a/LEAF_Nexus/js/groupSelector.js
+++ b/LEAF_Nexus/js/groupSelector.js
@@ -10,7 +10,7 @@ function groupSelector(containerID) {
   this.selection = "";
 
   this.containerID = containerID;
-  this.prefixID = "grpSel" + Math.floor(Math.random() * 1000) + "_";
+  this.prefixID = this.makePrefixID();
   this.timer = 0;
   this.q = "";
   this.isBusy = 1;
@@ -29,6 +29,12 @@ function groupSelector(containerID) {
   this.jsonResponse = null;
 
   this.numResults = 0;
+}
+
+groupSelector.prototype.makePrefixID = function () {
+  const id = "grpSel" + Math.floor(Math.random() * 1000) + "_";
+  const el = document.getElementById(id + 'result');
+  return (el !== null) ? this.makePrefixID() : id;
 }
 
 groupSelector.prototype.initialize = function () {

--- a/LEAF_Nexus/js/positionSelector.js
+++ b/LEAF_Nexus/js/positionSelector.js
@@ -10,7 +10,7 @@ function positionSelector(containerID) {
   this.selection = "";
 
   this.containerID = containerID;
-  this.prefixID = "posSel" + Math.floor(Math.random() * 1000) + "_";
+  this.prefixID = this.makePrefixID();
   this.timer = 0;
   this.q = "";
   this.isBusy = 1;
@@ -25,6 +25,12 @@ function positionSelector(containerID) {
   this.currRequest = null;
 
   this.numResults = 0;
+}
+
+positionSelector.prototype.makePrefixID = function () {
+  const id = "posSel" + Math.floor(Math.random() * 1000) + "_";
+  const el = document.getElementById(id + 'result');
+  return (el !== null) ? this.makePrefixID() : id;
 }
 
 positionSelector.prototype.initialize = function () {

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -960,7 +960,8 @@
                         resolve($.ajax({
                             type: 'GET',
                             url: "<!--{$orgchartPath}-->/js/groupSelector.js",
-                            dataType: 'script'
+                            dataType: 'script',
+                            async: false,
                         }).then(function() {
                             return initGroupSelector();
                         }));
@@ -1050,7 +1051,8 @@
                         resolve($.ajax({
                             type: 'GET',
                             url: "<!--{$orgchartPath}-->/js/positionSelector.js",
-                            dataType: 'script'
+                            dataType: 'script',
+                            async: false,
                         }).then(function() {
                             return initPositionSelector();
                         }));
@@ -1198,7 +1200,8 @@
                         resolve($.ajax({
                             type: 'GET',
                             url: "<!--{$orgchartPath}-->/js/nationalEmployeeSelector.js",
-                            dataType: 'script'
+                            dataType: 'script',
+                            async: false,
                         }).then(function() {
                             return initEmployeeSelector();
                         }));


### PR DESCRIPTION
Associated with Help Desk INC34511903, where a user noticed that some requests would contain the incorrect value for orgchart group questions that were prefilled using ifthen logic.  Issue was found to be independent of ifthen functionality and due to rare prefixID collision of the orgchart selectors.

This update adds a method to orgchart selectors that first checks that an element associated with a generated ID is not already in the DOM before returning it for use as the prefix ID.  AJAX option async: false was also added when an orgchart class needs to be imported (it would otherwise import multiple times).

**Testing / Impact**

Group, Position, and Employee selectors.

- Confirm these continue to work normally.  

- ID collision, it might be easiest to locally edit the value of the generated range in the groupSelectorjs file (eg 10 instead of 1000) and then use a form with ~7 or so orgchart group questions.  Each group selector should have a unique prefix associated with DOM element s with id= grpSel###_result

- Network tab.  On hard refresh, the org selector is imported once