### PR TITLE
Leaf 4501 - Database update

### DIFF
--- a/docker/mysql/db/db_upgrade/orgchart/Update_OC_DB_2023092100-2024092100 .sql
+++ b/docker/mysql/db/db_upgrade/orgchart/Update_OC_DB_2023092100-2024092100 .sql
@@ -1,0 +1,32 @@
+START TRANSACTION;
+
+ALTER TABLE `employee` CHANGE `userName` `userName` varchar(50) NOT NULL AFTER `empUID`;
+ALTER TABLE `employee_data` CHANGE `author` `author` varchar(50) NOT NULL AFTER `data`;
+ALTER TABLE `employee_data_history` CHANGE `author` `author` varchar(50) NOT NULL AFTER `data`;
+ALTER TABLE `group_data` CHANGE `author` `author` varchar(50) NOT NULL AFTER `data`;
+ALTER TABLE `group_data_history` CHANGE `author` `author` varchar(50) NOT NULL AFTER `data`;
+ALTER TABLE `position_data` CHANGE `author` `author` varchar(50) NOT NULL AFTER `data`;
+ALTER TABLE `position_data_history` CHANGE `author` `author` varchar(50) NOT NULL AFTER `data`;
+ALTER TABLE `relation_employee_backup` CHANGE `approverUserName` `approverUserName` varchar(50) NOT NULL AFTER `approved`;
+
+UPDATE `settings` SET `data` = '2024092100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `employee` CHANGE `userName` `userName` varchar(30) NOT NULL AFTER `empUID`;
+ALTER TABLE `employee_data` CHANGE `author` `author` varchar(30) NOT NULL AFTER `data`;
+ALTER TABLE `employee_data_history` CHANGE `author` `author` varchar(30) NOT NULL AFTER `data`;
+ALTER TABLE `group_data` CHANGE `author` `author` varchar(30) NOT NULL AFTER `data`;
+ALTER TABLE `group_data_history` CHANGE `author` `author` varchar(30) NOT NULL AFTER `data`;
+ALTER TABLE `position_data` CHANGE `author` `author` varchar(30) NOT NULL AFTER `data`;
+ALTER TABLE `position_data_history` CHANGE `author` `author` varchar(30) NOT NULL AFTER `data`;
+ALTER TABLE `relation_employee_backup` CHANGE `approverUserName` `approverUserName` varchar(30) NOT NULL AFTER `approved`;
+
+UPDATE `settings` SET `data` = '2023092100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
Summary:
This is to prepare the database to accept a longer userName for those that need to be disabled.

Potential Impact:
The biggest thing is this will allow us to keep users even after they are no longer with the VA and their userName is recycled and given to someone else.

Testing:
Go to the Nexus
Click on the OC Admin Panel
Click on Other Tools
Click on Update Database
Verify in the database that the field size was increased for expected tables.