### PR TITLE
LEAF-4487 - large queries code

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3060,9 +3060,10 @@ class Form
         }
 
         $externalProcessQuery = $this->isLargeQuery($query);
+        // is this a processes worthy of the external process and that we are on not wanting to actually run this query here.
         if ($externalProcessQuery === true && !empty($_SERVER['HTTP_X_NOLARGEQUERIES'])) {
             ob_end_clean();
-            http_response_code(504);
+            http_response_code(503);
             exit();
         }
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3017,6 +3017,33 @@ class Form
     }
 
     /**
+     * @param array $query - this is the decoded string used for query
+     * @return bool
+     */
+    private function isLargeQuery(array $query): bool
+    {
+        
+        $externalProcessQuery = false;
+        if (isset($query['limit']) && is_numeric($query['limit'])) {
+
+            // limit is > 10,000 records
+            if ($query['limit'] > 10000) {
+               
+                $externalProcessQuery = true;
+                // limit is <= 10,000 records AND more than 10 indicators are requested
+            } else if (!isset($query['limit']) && (!empty($query['getData']) && count($query['getData']) >= 10)) {
+                
+                $externalProcessQuery = true;
+            }
+        } else {
+            // no limit parameter set
+            $externalProcessQuery = true;
+        }
+    
+        return $externalProcessQuery;
+    }
+
+    /**
      * query parses a JSON formatted user query defined in formQuery.js.
      *
      * Returns an array on success, and string/int for malformed queries
@@ -3030,6 +3057,13 @@ class Form
         if ($query == null)
         {
             return 'Invalid query';
+        }
+
+        $externalProcessQuery = $this->isLargeQuery($query);
+        if ($externalProcessQuery === true && !empty($_SERVER['HTTP_X_NOLARGEQUERIES'])) {
+            ob_end_clean();
+            http_response_code(504);
+            exit();
         }
 
         $joinSearchAllData = false;

--- a/x-test/API-tests/largeFormQuery_test.go
+++ b/x-test/API-tests/largeFormQuery_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSmallQuery(t *testing.T) {
+	url := RootURL + `api/form/query/?q={"terms":[{"id":"stepID","operator":"!=","match":"resolved","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["status","initiatorName"],"sort":{},"limit":10000,"getData":["9","8","10","4","5","7","3","6","2"]}&x-filterData=recordID,title,stepTitle,lastStatus,lastName,firstName`
+
+	url = strings.Replace(url, " ", "%20", -1)
+	res, _ := client.Get(url)
+	b, _ := io.ReadAll(res.Body)
+
+	var formQueryResponse FormQueryResponse
+	_ = json.Unmarshal(b, &formQueryResponse)
+
+	if _, exists := formQueryResponse[958]; !exists {
+		t.Errorf("Record 958 should be readable")
+	}
+
+	if v, ok := res.Header["X-Nolargequeries"]; !ok || len(v) != 1 || v[0] != "transfer large queries to another server" {
+		t.Errorf("bad headers: %v", res.Header)
+	}
+}
+
+func TestLargeQuery(t *testing.T) {
+	url := RootURL + `api/form/query/?q={"terms":[{"id":"stepID","operator":"!=","match":"resolved","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["status","initiatorName"],"sort":{},"getData":["9","8","10","4","5","7","3","6","2"]}&x-filterData=recordID,title,stepTitle,lastStatus,lastName,firstName`
+
+	url = strings.Replace(url, " ", "%20", -1)
+	res, _ := client.Get(url)
+	b, _ := io.ReadAll(res.Body)
+
+	var formQueryResponse FormQueryResponse
+	_ = json.Unmarshal(b, &formQueryResponse)
+
+	if _, exists := formQueryResponse[958]; !exists {
+		t.Errorf("Record 958 should be readable")
+	}
+
+	if v, ok := res.Header["X-Apiserver"]; !ok || len(v) != 1 || v[0] != "am on api server" {
+		t.Errorf("bad headers: %v", res.Header)
+	}
+}


### PR DESCRIPTION
This is related to the branch shown in this pr: https://github.com/department-of-veterans-affairs/LEAF/pull/2546

This code should run on the normal docker containers as well as the custom ones setup in the pr above. The pr above allows for more memory and time to process queries. I have these branches separated since there is a lot of information that needs to be considered for the server side and the code side should be straight forward. I do have go tests written that are reliant on the docker changes to be in place.

### Additional options
Should we consider having a sites table option as well to determine if a site can in fact utilize the large queries servers. This would allow us to roll this out slowly and look at server loads. 

### What is a large query
A large query is a request that has 10 or more indicators being selected, more than 10k in its limit or no limit at all.

### The queries to look for

This query would be hit since there is no limit on the amount of data:
https://host.docker.internal/LEAF_Request_Portal/api/form/query/?q={%22terms%22:[{%22id%22:%22stepID%22,%22operator%22:%22!=%22,%22match%22:%22resolved%22,%22gate%22:%22AND%22},{%22id%22:%22deleted%22,%22operator%22:%22=%22,%22match%22:0,%22gate%22:%22AND%22}],%22joins%22:[%22status%22,%22initiatorName%22],%22sort%22:{},%22getData%22:[%229%22,%228%22,%2210%22,%224%22,%225%22,%227%22,%223%22,%226%22,%222%22]}&x-filterData=recordID,title,stepTitle,lastStatus,lastName,firstName
This query would be hit since there are 10 indicators to show:
https://host.docker.internal/Test_Request_Portal/api/form/query/?q={%22terms%22:[{%22id%22:%22stepID%22,%22operator%22:%22!=%22,%22match%22:%22resolved%22,%22gate%22:%22AND%22},{%22id%22:%22deleted%22,%22operator%22:%22=%22,%22match%22:0,%22gate%22:%22AND%22}],%22joins%22:[%22status%22,%22initiatorName%22],%22sort%22:{},%22limit%22:10000,%22getData%22:[%229%22,%228%22,%2210%22,%224%22,%225%22,%227%22,%223%22,%226%22,%222%22,%22-7%22]}&x-filterData=recordID,title,stepTitle,lastStatus,lastName,firstName