### PR TITLE
LEAF 4523 (INC35162350) fix workflow copy step title encoding

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -106,6 +106,8 @@
                         alert("Prerequisite action needed:\n\n" + res);
                         dialog_confirm.hide();
                     } else {
+                        let url = new URL(window.location.href);
+                        url.searchParams.delete('workflowID');
                         window.location.reload();
                     }
                 },
@@ -2572,7 +2574,7 @@
     function duplicateWorkflow() {
         $('.workflowStepInfo').css('display', 'none');
 
-        dialog.setTitle('Duplicate current workflow');
+        dialog.setTitle('Copy current workflow');
         dialog.setContent('<br /><label for="description">New Workflow Title: </label><input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
         dialog.setSaveHandler(function() {
             let old_steps = {};
@@ -2589,19 +2591,17 @@
             workflows[workflowID]['description'] = title;
             old_steps[-1] = -1;
 
+            let elFilter = document.createElement('div');
             for(let i in steps) {
                 // add step, if successful update that step
-                addStep(workflowID, steps[i].stepTitle, function(stepID) {
+                elFilter.innerHTML = steps[i].stepTitle;
+                addStep(workflowID, elFilter.textContent, function(stepID) {
 
                     if (isNaN(stepID)) {
                         console.log(stepID);
                     } else {
                         old_steps[steps[i].stepID] = stepID;
                         updatePosition(workflowID, stepID, steps[i].posX, steps[i].posY);
-
-                        updateTitle(steps[i].stepTitle, stepID, function(res) {
-                            // Alls well that ends well.
-                        });
 
                         if (steps[i].stepData != null) {
                             let auto = JSON.parse(steps[i].stepData);

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -108,6 +108,7 @@
                     } else {
                         let url = new URL(window.location.href);
                         url.searchParams.delete('workflowID');
+                        window.history.replaceState(null, "", url.toString());
                         window.location.reload();
                     }
                 },

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2372,8 +2372,8 @@
                     }
                     output += '<option value="' + res[i].workflowID + '" description = "' + res[i]
                         .description +
-                        '"><b>' + res[i].description +
-                        '</b> (ID: #' + res[i].workflowID + ')</option>';
+                        '">' + res[i].description +
+                        ' (ID: #' + res[i].workflowID + ')</option>';
                     count++;
                 }
                 if (count == 0) {
@@ -2575,7 +2575,7 @@
     function duplicateWorkflow() {
         $('.workflowStepInfo').css('display', 'none');
 
-        dialog.setTitle('Copy current workflow');
+        dialog.setTitle('Duplicate current workflow');
         dialog.setContent('<br /><label for="description">New Workflow Title: </label><input type="text" id="description"/><br /><br />The following will NOT be copied over:<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;Data fields that show up next to the workflow action buttons');
         dialog.setSaveHandler(function() {
             let old_steps = {};


### PR DESCRIPTION
Address an issue where a step title would have encoded characters when a workflow was copied.

Uncovered: fix error that would occur when a workflow was deleted due to url param for a workflow that no longer exists.


**Testing / Impact**

Workflow Editor - Copy Workflow feature

-Confirm API tests pass/regression
(if playwright has been recently updated, you might need to bash to playwright container and run npx playwright install.  Test trace will indicate if this is needed).

-Confirm workflow copying works as intended.

-There should be no console error when a workflow is deleted
