### PR TITLE
HOTFIX: LEAF 4450 - deprecated warnings

### DIFF
--- a/scripts/automatedEmailReminder.php
+++ b/scripts/automatedEmailReminder.php
@@ -1,6 +1,4 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
 
 require_once('timebracketcmd.php');
 echo date('Y-m-d g:i:s a') . "\r\n";

--- a/scripts/refreshOrgchartEmployees.php
+++ b/scripts/refreshOrgchartEmployees.php
@@ -1,6 +1,4 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
 
 require_once('timebracketcmd.php');
 echo date('Y-m-d g:i:s a') . "\r\n";


### PR DESCRIPTION
Remove the ini_set that was overriding system default for display errors. Also removed error_reporting line since this too overrode the server default setting.