### PR TITLE
Leaf 4549 - sync groups

### DIFF
--- a/LEAF_Request_Portal/scripts/sync_services.php
+++ b/LEAF_Request_Portal/scripts/sync_services.php
@@ -18,6 +18,6 @@ $tag = new Orgchart\Tag($oc_db, $login);
 $group_portal = new Portal\Group($db, $login);
 $service_portal = new Portal\Service($db, $login);
 $system_portal = new Portal\System($db, $login);
-$syncing = $system_portal->syncSystem($group);
+$syncing = $system_portal->syncSystem($group, $site_paths);
 
 echo $syncing;


### PR DESCRIPTION
Summary:
When a group is removed from the Nexus, a subsequent sync services on any portals with that group are not being removed, users in the group are gone but the group remains.

Potential Impact:
If this group is connected to a workflow it will show as null in the workflow.

Testing:
In a portal find a group that is no longer in the nexus.
If you can't find one create one and delete it from the nexus.
Run a sync services, the group should be removed from the portal at that point.