### PR TITLE
VAPO: Full Migration isVAPO true default

### DIFF
--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024100300-2024101500.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024100300-2024101500.sql
@@ -1,0 +1,17 @@
+START TRANSACTION;
+
+ALTER TABLE `sites` ALTER `isVAPO` SET DEFAULT 'true';
+
+UPDATE `settings` SET `data` = '2024101500' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `sites` ALTER `isVAPO` SET DEFAULT 'false';
+
+UPDATE `settings` SET `data` = '2024100300' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
**Description:**
This database change is intended for the final migration of launchpad.
Its purpose serves to make it so isVAPO boolean in the sites table is marked as true by default on portal creation.

**Impact:**
Minor Impact to LEAF site creation, avoid misinformation of portal creation.