### PR TITLE
LEAF-4559 account updater position list

### DIFF
--- a/LEAF_Nexus/js/employeeSelector.js
+++ b/LEAF_Nexus/js/employeeSelector.js
@@ -256,7 +256,7 @@ employeeSelector.prototype.search = function () {
                 : "";
             var positionTitle =
               response[i].positionData != undefined
-                ? response[i].positionData.positionTitle
+                ? response[i].positionData[0].positionTitle
                 : "";
             var groupTitle = "";
 

--- a/LEAF_Nexus/js/nationalEmployeeSelector.js
+++ b/LEAF_Nexus/js/nationalEmployeeSelector.js
@@ -302,7 +302,7 @@ nationalEmployeeSelector.prototype.runSearchQuery = function (query, domain) {
             : "";
         var positionTitle =
           response[i].positionData != undefined
-            ? response[i].positionData.positionTitle
+            ? response[i].positionData[0].positionTitle
             : "";
         positionTitle =
           positionTitle == "" && response[i].data[23] !== undefined

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1442,6 +1442,7 @@ class Employee extends Data
 
         if (count($searchResult) > 0)
         {
+            
             $empUID_list = '';
             foreach ($searchResult as $employee)
             {
@@ -1465,15 +1466,21 @@ class Employee extends Data
                 $tdata[$employeeData['empUID']] = $employeeData;
             }
 
-            foreach($searchResult as $i=>$sRes)
+            $tcount = count($searchResult);
+            for ($i = 0; $i < $tcount; $i++)
             {
-                $currEmpUID = $sRes['empUID'];
-                if (isset($tdata[$sRes['empUID']]))
+                $currEmpUID = $searchResult[$i]['empUID'];
+                if (isset($tdata[$searchResult[$i]['empUID']]))
                 {
-                    $finalResult[$currEmpUID]['positionData'] = $tdata[$sRes['empUID']];
+                    $finalResult[$currEmpUID]['positionData'] = $tdata[$searchResult[$i]['empUID']];
                     $finalResult[$currEmpUID]['serviceData'] = $position->getService($finalResult[$currEmpUID]['positionData']['positionID']);
                 }
-                $finalResult[$currEmpUID]['data'] = $this->getAllData($sRes['empUID']);
+                $finalResult[$currEmpUID]['data'] = $this->getAllData($searchResult[$i]['empUID']);
+            }
+            
+            // attach all the assigned positions
+            foreach ($result as $employeeData){
+                $finalResult[$employeeData['empUID']]['allPositionData'][] = $employeeData;
             }
         }
         return $finalResult;

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1465,16 +1465,15 @@ class Employee extends Data
                 $tdata[$employeeData['empUID']] = $employeeData;
             }
 
-            $tcount = count($searchResult);
-            for ($i = 0; $i < $tcount; $i++)
+            foreach($searchResult as $i=>$sRes)
             {
-                $currEmpUID = $searchResult[$i]['empUID'];
-                if (isset($tdata[$searchResult[$i]['empUID']]))
+                $currEmpUID = $sRes['empUID'];
+                if (isset($tdata[$sRes['empUID']]))
                 {
-                    $finalResult[$currEmpUID]['positionData'] = $tdata[$searchResult[$i]['empUID']];
+                    $finalResult[$currEmpUID]['positionData'] = $tdata[$sRes['empUID']];
                     $finalResult[$currEmpUID]['serviceData'] = $position->getService($finalResult[$currEmpUID]['positionData']['positionID']);
                 }
-                $finalResult[$currEmpUID]['data'] = $this->getAllData($searchResult[$i]['empUID']);
+                $finalResult[$currEmpUID]['data'] = $this->getAllData($sRes['empUID']);
             }
         }
         return $finalResult;

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1472,15 +1472,15 @@ class Employee extends Data
                 $currEmpUID = $searchResult[$i]['empUID'];
                 if (isset($tdata[$searchResult[$i]['empUID']]))
                 {
-                    $finalResult[$currEmpUID]['positionData'] = $tdata[$searchResult[$i]['empUID']];
-                    $finalResult[$currEmpUID]['serviceData'] = $position->getService($finalResult[$currEmpUID]['positionData']['positionID']);
+                    //$finalResult[$currEmpUID]['positionData'] = $tdata[$currEmpUID];
+                    $finalResult[$currEmpUID]['serviceData'] = $position->getService($tdata[$currEmpUID]['positionID']);
                 }
-                $finalResult[$currEmpUID]['data'] = $this->getAllData($searchResult[$i]['empUID']);
+                $finalResult[$currEmpUID]['data'] = $this->getAllData($currEmpUID);
             }
             
             // attach all the assigned positions
             foreach ($result as $employeeData){
-                $finalResult[$employeeData['empUID']]['allPositionData'][] = $employeeData;
+                $finalResult[$employeeData['empUID']]['positionData'][] = $employeeData;
             }
         }
         return $finalResult;

--- a/LEAF_Nexus/sources/Position.php
+++ b/LEAF_Nexus/sources/Position.php
@@ -757,11 +757,17 @@ class Position extends Data
 
             foreach ($employees as $temp)
             {
-                if (isset($temp['positionData']) && is_array($temp['positionData'])
-                    && $temp['positionData']['positionID'] > 0)
+                
+                if (isset($temp['allPositionData']) && is_array($temp['allPositionData']) )
                 {
-                    $tempResult[] = array('positionID' => $temp['positionData']['positionID'],
-                                          'positionTitle' => $temp['positionData']['positionTitle'], );
+                    
+                    foreach($temp['allPositionData'] as $allPositionData ){
+                        if($allPositionData['positionID'] > 0){
+                            $tempResult[] = array('positionID' => $allPositionData['positionID'],
+                            'positionTitle' => $allPositionData['positionTitle'], );
+                        }
+                    }
+                   
                 }
             }
 

--- a/LEAF_Nexus/sources/Position.php
+++ b/LEAF_Nexus/sources/Position.php
@@ -758,10 +758,10 @@ class Position extends Data
             foreach ($employees as $temp)
             {
                 
-                if (isset($temp['allPositionData']) && is_array($temp['allPositionData']) )
+                if (isset($temp['positionData']) && is_array($temp['positionData']) )
                 {
                     
-                    foreach($temp['allPositionData'] as $allPositionData ){
+                    foreach($temp['positionData'] as $allPositionData ){
                         if($allPositionData['positionID'] > 0){
                             $tempResult[] = array('positionID' => $allPositionData['positionID'],
                             'positionTitle' => $allPositionData['positionTitle'], );

--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -460,12 +460,12 @@ function searchGroupsOldAccount(accountAndTaskInfo, queue) {
 function searchPositionsOldAccount(accountAndTaskInfo, queue) {
     const { oldAccount, newAccount } = accountAndTaskInfo;
     return new Promise ((resolve, reject) => {
-        fetch(`${orgchartPath}/api/position/search?q=username:${oldAccount}&employeeSearch=1&noLimit=1`)
+        fetch(`${orgchartPath}/api/position/search?q=username.disabled:${oldAccount}&employeeSearch=1&noLimit=1`)
             .then(res => res.json())
             .then(data => {
                 let positionInfo = {};
                 const userPositions = data.filter(p => p.employeeList.some(emp => emp.userName === oldAccount));
-
+console.log(userPositions);
                 if (userPositions.length > 0) {
                     let recordIDs = '';
                     userPositions.forEach(ele => {

--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -460,7 +460,7 @@ function searchGroupsOldAccount(accountAndTaskInfo, queue) {
 function searchPositionsOldAccount(accountAndTaskInfo, queue) {
     const { oldAccount, newAccount } = accountAndTaskInfo;
     return new Promise ((resolve, reject) => {
-        fetch(`${orgchartPath}/api/position/search?noLimit=1`)
+        fetch(`${orgchartPath}/api/position/search?q=username:${oldAccount}&employeeSearch=1&noLimit=1`)
             .then(res => res.json())
             .then(data => {
                 let positionInfo = {};


### PR DESCRIPTION
**Issue:**

On account migrator the list that is used to check for positions pulls in all data instead of data just for the user. 

**Fix:**

Make all position data pull in for a single user instead of looping through all data to pull users out. This change will affect employee selectors that pull data from local org chart.

**Possible Breakages:** 

Anywhere we display position tile this could have a breakage. If it does fail it does seem like the code just give "undefined" as an error and does not completely break. I had to change how the data is pulled in, before it was a singular data point and not an array.

If something is found to be unacceptable, before the latest revision I tried pulling the data into a separate item leaving the original data pull intact and adjusted the data migration to read that data.

[LEAF-4559 - reworking the employee and position data, I am making a s… · department-of-veterans-affairs/LEAF@b6eb613 (github.com)](https://github.com/department-of-veterans-affairs/LEAF/commit/b6eb6130982affae63c55b84e3481225feaa8b28)

Note: I will need to work on tests, the main portion appears to be good test wise however tests to check if positions exist will need to be created. I created preliminary test under the test repo at bug/LEAF-4559/position-test 

** Locations not updated **
- https://host.docker.internal/Test_Nexus/?a=view_position&positionID=4 - nationalEmployeeSelector.js: 588 - Add Employee - This section uses ad title here. Positions are usually just reserved for local org charts. This code here does not appear to be used since position data is not returned on the api call
- viewhomepage.tpl : 265 - this pulls position information, not the same as what I was calling
