### PR TITLE
LEAF 4552 metadata field update optimizations

### DIFF
--- a/scripts/leaf-scripts/update_records_notes_dh_fields.php
+++ b/scripts/leaf-scripts/update_records_notes_dh_fields.php
@@ -12,191 +12,228 @@ require_once getenv('APP_LIBS_PATH') . '/../Leaf/Db.php';
 
 $log_file = fopen("batch_update_records_notes_dh_log.txt", "w") or die("unable to open file");
 $time_start = date_create();
-$tables_to_update = ["notes", "records", "data_history"];
-$fields_to_update = array(
-    "notes" => "userMetadata",
-    "records" => "userMetadata",
-    "data_history" => "userDisplay",
-);
 
 $db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
 
-//get records of each portal and assoc orgchart
-$q = "SELECT `portal_database`, `orgchart_database` FROM `sites`
-    WHERE `portal_database` IS NOT NULL AND `site_type`='portal' ORDER BY `orgchart_database`";
+//get records of each portal db.  Break out vdr for data_history updates.
+$q = "SELECT `portal_database` FROM `sites` WHERE `portal_database` IS NOT NULL AND " .
+    //"`portal_database` = 'Academy_Demo1' AND" .
+    "`site_type`='portal' ORDER BY id LIMIT 4000 OFFSET 0";
 
 $portal_records = $db->query($q);
 
 $total_portals_count = count($portal_records);
 $processed_portals_count = 0;
-
 $error_count = 0;
 
-//used during update query to limit query
-$caselimit = 2500;
+//get org info for enabled users from national.
+$orgchart_db = 'national_orgchart';
+$orgchart_time_start = date_create();
 $empMap = array();
 
-$orgchart_db = null;
-foreach($portal_records as $rec) {
+function getOrgchartBatch(&$db, $batch_count = 0) {
+    $limit = 50000; //handles this size ok
+    $offset = $batch_count * $limit;
 
-    //get org info up front for each new orgchart db.  reset and update empmap if changed
-    if(!isset($orgchart_db) || $orgchart_db !==  $rec['orgchart_database']) {
-        $empMap = array();
-        $orgchart_db = $rec['orgchart_database'];
-        $orgchart_time_start = date_create();
+    $qEmployees = "SELECT `employee`.`empUID`, `userName`, `lastName`, `firstName`, `middleName`, `deleted`, `data` AS `email` FROM `employee`
+        JOIN `employee_data` ON `employee`.`empUID`=`employee_data`.`empUID`
+        WHERE `deleted`=0 AND `indicatorID`=6 ORDER BY `employee`.`empUID` LIMIT $limit OFFSET $offset";
 
-        try {
-            //************ ORGCHART ************ */
-            $db->query("USE `{$orgchart_db}`");
+    return $db->query($qEmployees) ?? [];
+}
 
-            $qEmployees = "SELECT `employee`.`empUID`, `userName`, `lastName`, `firstName`, `middleName`, `deleted`, `data` AS `email` FROM `employee`
-                JOIN `employee_data` ON `employee`.`empUID`=`employee_data`.`empUID`
-                WHERE `indicatorID`=6";
+try {
+    $db->query("USE `{$orgchart_db}`");
 
-            $resEmployees = $db->query($qEmployees) ?? [];
-            foreach($resEmployees as $emp) {
-                $mapkey = strtoupper($emp['userName']);
-                $empMap[$mapkey] = $emp;
-            }
-
-            $orgchart_time_end = date_create();
-            $orgchart_time_diff = date_diff($orgchart_time_start, $orgchart_time_end);
-
-            fwrite(
-                $log_file,
-                "\r\nOrgchart " . $orgchart_db . " map info took: " . $orgchart_time_diff->format('%i min, %S sec, %f mcr') . "\r\n"
+    $org_batch = 0;
+    while(count($resEmployees = getOrgchartBatch($db, $org_batch)) > 0) {
+        $org_batch += 1;
+    
+        foreach($resEmployees as $emp) {
+            $mapkey = strtoupper($emp['userName']);
+            $empMap[$mapkey] = array(
+                'userDisplay' => $emp['firstName'] . " " . $emp['lastName'],
+                'userMetadata' => json_encode(
+                    array(
+                        'userName' => $emp['userName'],
+                        'firstName' => $emp['firstName'],
+                        'lastName' => $emp['lastName'],
+                        'middleName' => $emp['middleName'],
+                        'email' => $emp['email']
+                    )
+                ),
             );
-
-        } catch (Exception $e) {
-            fwrite(
-                $log_file,
-                "Caught Exception (orgchart connect): " . $orgchart_db . " " . $e->getMessage() . "\r\n"
-            );
-            $error_count += 1;
         }
     }
+    unset($resEmployees);
 
+    $orgchart_time_end = date_create();
+    $orgchart_time_diff = date_diff($orgchart_time_start, $orgchart_time_end);
+
+    fwrite(
+        $log_file,
+        "\r\nOrgchart " . $orgchart_db . " map info took: " . $orgchart_time_diff->format('%i min, %S sec, %f mcr') . "\r\n"
+    );
+
+} catch (Exception $e) {
+    fwrite(
+        $log_file,
+        "Caught Exception (orgchart connect): " . $orgchart_db . " " . $e->getMessage() . "\r\n"
+    );
+    $portal_records = array();
+}
+
+
+$tables_to_update = [
+    "notes",
+    "records",
+   // "data_history"
+];
+$fields_to_update = array(
+    "notes" => "userMetadata",
+    "records" => "userMetadata",
+    "data_history" => "userDisplay",
+);
+$json_empty = json_encode(
+    array(
+        "userName" => "",
+        "firstName" => "",
+        "lastName" => "",
+        "middleName" => "",
+        "email" => ""
+    )
+);
+$user_not_found_values = array(
+    "userMetadata" => $json_empty,
+    "userDisplay" => "",
+);
+
+
+//pull IDs to process.  If the table is more than 20k this will be done in batches
+function getUniqueIDBatch(&$db, $table_name, $field_name):array {
+    $getLimit = 20000;
+
+    $SQL = "SELECT `userID` FROM `$table_name` WHERE `$field_name` IS NULL LIMIT $getLimit";
+    $records = $db->query($SQL) ?? [];
+
+    //removing duplicates here since using DISTINCT complicates the query
+    $mapAdded = array();
+    foreach ($records as $rec) {
+        $userID = strtoupper($rec['userID']);
+        if(!isset($mapAdded[$userID])) {
+            $mapAdded[$userID] = 1;
+        }
+    }
+    return array_keys($mapAdded);
+}
+
+foreach($portal_records as $rec) {
     $portal_db = $rec['portal_database'];
-
     try {
-        //************ PORTAL ************ */
         $db->query("USE `{$portal_db}`");
-        $update_tracking = array(
+
+        $batch_tracking = array(
             "notes" => 0,
             "records" => 0,
             "data_history" => 0,
         );
-
-        /* loop through the tables to be updated */
-        foreach ($tables_to_update as $table_name) { //NOTE: table loop start
-            $field_name = $fields_to_update[$table_name];
-
-            try {
-                $usersQ = "SELECT DISTINCT `userID` FROM `$table_name` WHERE `$field_name` IS NULL";
-
-                $resUniqueIDs = $db->query($usersQ) ?? [];
-                $numIDs = count($resUniqueIDs);
-
-                if($numIDs > 0) {
-                    $portal_db = $rec['portal_database'];
-                    $portal_time_start = date_create();
-
-                    fwrite(
-                        $log_file,
-                        "\r\nUnique " . $table_name . " userID count for " . $portal_db . ": " . $numIDs . "\r\n"
-                    );
-
-                    $totalBatches = intdiv($numIDs, $caselimit);
-                    foreach(range(0, $totalBatches) as $batchcount) { //this will include the last partial batch
-                        $curr_ids_slice = array_slice($resUniqueIDs, $batchcount * $caselimit, $caselimit);
-
-                        //build and exec CASE statement for each batch
-                        $sqlUpdateMetadata = "UPDATE `$table_name`
-                            SET `$field_name` = CASE `userID` ";
-
-                        $metaVars = array();
-                        foreach ($curr_ids_slice as $idx => $userRec) {
-                            $userInfo = $empMap[strtoupper($userRec['userID'])] ?? null;
-                            /* If they are not in the orgchart info at all just don't do anything. If they are there but explicitly deleted 
-                            set empty metadata properties (info is not being used for inactive accounts since we don't want to assume accuracy) */
-                            if(isset($userInfo)) {
-                                $isActive = $userInfo['deleted'] === 0;
-
-                                if($table_name === "data_history") {
-                                    $metadata = $isActive ?  $userInfo['firstName'] . " " . $userInfo['lastName'] : "";
-                                } else {
-                                    $metadata = json_encode(
-                                        array(
-                                            'userName' => $isActive ? $userInfo['userName'] : '',
-                                            'firstName' => $isActive ? $userInfo['firstName'] : '',
-                                            'lastName' => $isActive ? $userInfo['lastName'] : '',
-                                            'middleName' => $isActive ? $userInfo['middleName'] : '',
-                                            'email' => $isActive ? $userInfo['email'] : ''
-                                        )
-                                    );
-                                }
-
-                                $metaVars[":user_" . $idx] = $userInfo['userName'];
-                                $metaVars[":meta_" . $idx] = $metadata;
-                                $sqlUpdateMetadata .= " WHEN :user_" . $idx . " THEN :meta_" . $idx;
-                            }
-                        }
-
-                        $sqlUpdateMetadata .= " END";
-                        $sqlUpdateMetadata .= " WHERE `$field_name` IS NULL";
-
-                        try {
-                            $db->prepared_query($sqlUpdateMetadata, $metaVars);
-                            $update_tracking[$table_name] += 1;
-
-                            fwrite(
-                                $log_file,
-                                $table_name . " ... batch: " . $batchcount
-                            );
-
-                        } catch (Exception $e) {
-                            fwrite(
-                                $log_file,
-                                "Caught Exception (update action_history usermetadata case batch): " . $e->getMessage() . "\r\n"
-                            );
-                            $error_count += 1;
-                        }
-                    }
-                    
-                    $portal_time_end = date_create();
-                    $portal_time_diff = date_diff($portal_time_start, $portal_time_end);
-
-                    fwrite(
-                        $log_file,
-                        "\r\nPortal " . $table_name . " update took: " . $portal_time_diff->format('%i min, %S sec, %f mcr') . "\r\n"
-                    );
-
-                }
-
-            } catch (Exception $e) {
-                fwrite(
-                    $log_file,
-                    "Caught Exception (query distinct ah userIDs): " . $e->getMessage() . "\r\n"
-                );
-                $error_count += 1;
-            }
-        
-        } //NOTE: table loop end
-
-        $processed_portals_count += 1;
-        $update_details = "records: " . $update_tracking["records"] . ", notes: " . $update_tracking["notes"] . ", data_history: " . $update_tracking["data_history"];
+        $portal_time_start = date_create();
         fwrite(
             $log_file,
-            "Portal " . $portal_db . " tables updated(1/0), " . $update_details  . "\r\n"
+            "\r\nProcessing " . $portal_db
         );
 
+        foreach ($tables_to_update as $table_name) {
+            $field_name = $fields_to_update[$table_name];
+            $table_time_start = date_create();
+            fwrite(
+                $log_file,
+                "\r\n" . $table_name . ": "
+            );
 
+            $id_batch = 0;
+            //simple array of upper case userID strings
+            while(count($resUniqueIDsBatch = getUniqueIDBatch($db, $table_name, $field_name)) > 0) {
+                $id_batch += 1;
 
+                $case_batch = 0;
+                //records and notes usually do not have high numbers of rows per user.
+                //ideally just want to batch a number that will not typically hit the post cap below.
+                //(casing in batches of 100 didn't result in a different memory profile - # in and of itself does not appear to matter)
+                $case_limit = $table_name != 'data_history' ? 1000 : 500;
+                while(count($slice = array_slice($resUniqueIDsBatch, $case_batch * $case_limit, $case_limit))) {
+                    $sqlUpdateMetadata = "UPDATE `$table_name` SET `$field_name` = CASE `userID` ";
+                    $metaVars = array();
+                    $case_batch += 1;
+                    foreach ($slice as $idx => $userID) {
+                        //use mapped info if present, otherwise use empty values.
+                        $userInfo = $empMap[$userID] ?? null;
+                        $metaVars[":user_" . $idx] = $userID;
+                        $metaVars[":meta_" . $idx] = isset($userInfo) ?
+                            $userInfo[$field_name] : $user_not_found_values[$field_name];
+
+                        $sqlUpdateMetadata .= " WHEN :user_" . $idx . " THEN :meta_" . $idx;
+                    }
+                    $sqlUpdateMetadata .= " END";
+
+                    //Limit rows updates.
+                    //A minority of portals have millions of table rows but only hundreds of unique users.
+                    //records not updated due to the limit will be re-pulled by another batch of nulls.
+                    $sqlUpdateMetadata .= " WHERE `$field_name` IS NULL LIMIT 25000;";
+
+                    try {
+                        $db->prepared_query($sqlUpdateMetadata, $metaVars);
+                        $batch_tracking[$table_name] += 1;
+
+                        fwrite(
+                            $log_file,
+                            $id_batch . "(" . $case_batch . "," . count($slice) . "), "
+                        );
+
+                    } catch (Exception $e) {
+                        fwrite(
+                            $log_file,
+                            "Caught Exception (update case batch): " . $e->getMessage() . "\r\n"
+                        );
+                        $error_count += 1;
+                    }
+                } //while remaining unprocessed unique IDs from ID batch
+
+            } //while remaining un-updated ids in table
+            
+            $table_time_end = date_create();
+            $table_time_diff = date_diff($table_time_start, $table_time_end);
+
+            fwrite(
+                $log_file,
+                "(" . $table_time_diff->format('%H hr, %i min, %S sec, %f mcr'). ")"
+            );
+
+        } //table loop end
+
+        $portal_time_end = date_create();
+        $portal_time_diff = date_diff($portal_time_start, $portal_time_end);
+        
+        fwrite(
+            $log_file,
+            "\r\nPortal update took: " . $portal_time_diff->format('%H hr, %i min, %S sec, %f mcr') . "\r\n"
+        );
+
+        $processed_portals_count += 1;
+        $update_details = "records: " . 
+            $batch_tracking["records"] . ", notes: " . 
+            $batch_tracking["notes"] . ", data_history: " . 
+            $batch_tracking["data_history"];
+        
+        fwrite(
+            $log_file,
+            "Portal " . $portal_db . " (" . $processed_portals_count . "): table batches, " . $update_details  . "\r\n"
+        );
 
     } catch (Exception $e) {
         fwrite(
             $log_file,
-            "Caught Exception (use portal connect): " . $e->getMessage() . "\r\n"
+            "Caught Exception (portal use): " . $portal_db . " " . $e->getMessage() . "\r\n"
         );
         $error_count += 1;
     }


### PR DESCRIPTION
Adjustments made to the script to update records.metadata, notes.metadata and data_history.userDisplay.

One batched pull to get required information from national instead of per orgchart (all updates here are associated with the userName value and do not require local nexus level queries).

Portals are ordered by sites.id to make multiple limited runs possible (currently still the tentative solution for the data_history table).  

Requests for userID rows and the number of updated rows have hard limits (previously, these queries affected a very highly variable number of rows).

Distinct / ordering is avoided SQL side to try to simplify the query. 

Memory impact SQL side is still significant for the data_history table.  
