### PR TITLE
LEAF-4572 - OOH Orgchart Permission - 

### DIFF
--- a/LEAF_Nexus/index.php
+++ b/LEAF_Nexus/index.php
@@ -343,6 +343,19 @@ switch ($action) {
         break;
     case 'view_permissions':
         $indicators = new Orgchart\Indicators($oc_db, $oc_login);
+        $employee = new Orgchart\Employee($oc_db, $oc_login);
+        // get our groups for the logged in user.
+        $ocEmployeeGroup = $employee->listGroups($oc_login->getEmpUID());
+        $isAdmin = FALSE;
+        
+        if(!empty($ocEmployeeGroup)){
+            foreach($ocEmployeeGroup as $egroup){
+                if($egroup['groupID'] == 1){
+                    $isAdmin = TRUE;
+                    break;
+                }
+            }
+        }
 
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
@@ -372,6 +385,7 @@ switch ($action) {
 
         $t_form->assign('indicatorID', (int)$_GET['indicatorID']);
         $t_form->assign('UID', (int)$_GET['UID']);
+        $t_form->assign('isAdmin', $isAdmin);
         $t_form->assign('indicator', $indicatorArray);
         $t_form->assign('permissions', $privilegesArray);
         $t_form->assign('CSRFToken', XSSHelpers::xscrub($_SESSION['CSRFToken']));
@@ -382,6 +396,19 @@ switch ($action) {
         break;
     case 'view_group_permissions':
         $group = new Orgchart\Group($oc_db, $oc_login);
+        $employee = new Orgchart\Employee($oc_db, $oc_login);
+        // get our groups for the logged in user.
+        $ocEmployeeGroup = $employee->listGroups($oc_login->getEmpUID());
+        $isAdmin = FALSE;
+        
+        if(!empty($ocEmployeeGroup)){
+            foreach($ocEmployeeGroup as $egroup){
+                if($egroup['groupID'] == 1){
+                    $isAdmin = TRUE;
+                    break;
+                }
+            }
+        }
 
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
@@ -401,6 +428,7 @@ switch ($action) {
                 'css/view_group.css', ));
 
         $groupID = isset($_GET['groupID']) ? (int)$_GET['groupID'] : 0;
+        $t_form->assign('isAdmin', $isAdmin);
         $t_form->assign('groupID', $groupID);
         $t_form->assign('groupTitle', $group->getTitle($groupID));
         $t_form->assign('permissions', $group->getPrivileges($groupID));
@@ -412,7 +440,19 @@ switch ($action) {
         break;
     case 'view_position_permissions':
         $position = new Orgchart\Position($oc_db, $oc_login);
-
+        $employee = new Orgchart\Employee($oc_db, $oc_login);
+        // get our groups for the logged in user.
+        $ocEmployeeGroup = $employee->listGroups($oc_login->getEmpUID());
+        $isAdmin = FALSE;
+        
+        if(!empty($ocEmployeeGroup)){
+            foreach($ocEmployeeGroup as $egroup){
+                if($egroup['groupID'] == 1){
+                    $isAdmin = TRUE;
+                    break;
+                }
+            }
+        }
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
         $t_form->right_delimiter = '}-->';
@@ -431,6 +471,7 @@ switch ($action) {
                 'css/view_group.css', ));
 
         $positionID = isset($_GET['positionID']) ? (int)$_GET['positionID'] : 0;
+        $t_form->assign('isAdmin', $isAdmin);
         $t_form->assign('positionID', $positionID);
         $t_form->assign('positionTitle', $position->getTitle($positionID));
         $t_form->assign('permissions', $position->getPrivileges($positionID));

--- a/LEAF_Nexus/index.php
+++ b/LEAF_Nexus/index.php
@@ -343,19 +343,7 @@ switch ($action) {
         break;
     case 'view_permissions':
         $indicators = new Orgchart\Indicators($oc_db, $oc_login);
-        $employee = new Orgchart\Employee($oc_db, $oc_login);
-        // get our groups for the logged in user.
-        $ocEmployeeGroup = $employee->listGroups($oc_login->getEmpUID());
-        $isAdmin = FALSE;
-        
-        if(!empty($ocEmployeeGroup)){
-            foreach($ocEmployeeGroup as $egroup){
-                if($egroup['groupID'] == 1){
-                    $isAdmin = TRUE;
-                    break;
-                }
-            }
-        }
+
 
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
@@ -383,9 +371,17 @@ switch ($action) {
             $privilegesArray[$key] = array_map('App\Leaf\XSSHelpers::sanitizeHTML', $privilegesArray[$key]);
         }
 
+        $memberships = $oc_login->getMembership();
+        $isAdmin = false;
+        if (isset($memberships['groupID'][1]))
+        {
+            $isAdmin = true;
+        }
+
+        $t_form->assign('is_admin', $isAdmin);
+
         $t_form->assign('indicatorID', (int)$_GET['indicatorID']);
         $t_form->assign('UID', (int)$_GET['UID']);
-        $t_form->assign('isAdmin', $isAdmin);
         $t_form->assign('indicator', $indicatorArray);
         $t_form->assign('permissions', $privilegesArray);
         $t_form->assign('CSRFToken', XSSHelpers::xscrub($_SESSION['CSRFToken']));
@@ -396,19 +392,7 @@ switch ($action) {
         break;
     case 'view_group_permissions':
         $group = new Orgchart\Group($oc_db, $oc_login);
-        $employee = new Orgchart\Employee($oc_db, $oc_login);
-        // get our groups for the logged in user.
-        $ocEmployeeGroup = $employee->listGroups($oc_login->getEmpUID());
-        $isAdmin = FALSE;
-        
-        if(!empty($ocEmployeeGroup)){
-            foreach($ocEmployeeGroup as $egroup){
-                if($egroup['groupID'] == 1){
-                    $isAdmin = TRUE;
-                    break;
-                }
-            }
-        }
+    
 
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
@@ -428,7 +412,15 @@ switch ($action) {
                 'css/view_group.css', ));
 
         $groupID = isset($_GET['groupID']) ? (int)$_GET['groupID'] : 0;
-        $t_form->assign('isAdmin', $isAdmin);
+
+        $memberships = $oc_login->getMembership();
+        $isAdmin = false;
+        if (isset($memberships['groupID'][1]))
+        {
+            $isAdmin = true;
+        }
+
+        $t_form->assign('is_admin', $isAdmin);
         $t_form->assign('groupID', $groupID);
         $t_form->assign('groupTitle', $group->getTitle($groupID));
         $t_form->assign('permissions', $group->getPrivileges($groupID));
@@ -440,19 +432,7 @@ switch ($action) {
         break;
     case 'view_position_permissions':
         $position = new Orgchart\Position($oc_db, $oc_login);
-        $employee = new Orgchart\Employee($oc_db, $oc_login);
-        // get our groups for the logged in user.
-        $ocEmployeeGroup = $employee->listGroups($oc_login->getEmpUID());
-        $isAdmin = FALSE;
-        
-        if(!empty($ocEmployeeGroup)){
-            foreach($ocEmployeeGroup as $egroup){
-                if($egroup['groupID'] == 1){
-                    $isAdmin = TRUE;
-                    break;
-                }
-            }
-        }
+
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
         $t_form->right_delimiter = '}-->';
@@ -471,7 +451,15 @@ switch ($action) {
                 'css/view_group.css', ));
 
         $positionID = isset($_GET['positionID']) ? (int)$_GET['positionID'] : 0;
-        $t_form->assign('isAdmin', $isAdmin);
+
+        $memberships = $oc_login->getMembership();
+        $isAdmin = false;
+        if (isset($memberships['groupID'][1]))
+        {
+            $isAdmin = true;
+        }
+
+        $t_form->assign('is_admin', $isAdmin);
         $t_form->assign('positionID', $positionID);
         $t_form->assign('positionTitle', $position->getTitle($positionID));
         $t_form->assign('permissions', $position->getPrivileges($positionID));

--- a/LEAF_Nexus/templates/view_group_permissions.tpl
+++ b/LEAF_Nexus/templates/view_group_permissions.tpl
@@ -35,7 +35,7 @@
             <td style="width: 100px" title="This allows permissions to be granted to others">Grant</td>
         </tr>
     <!--{foreach from=$permissions item=permission}-->
-        <!--{if $permission.UID == 2 || $permission.UID == 1}-->
+        <!--{if $isAdmin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
         <tr style="background-color: <!--{cycle values='#e0e0e0,#c4c4c4'}-->; opacity: 50%;">
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->" style="font-size: 14px; font-weight: bold"><img src="images/largespinner.gif" alt="" /> Loading <!--{$permission.categoryID|strip_tags}-->...</td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_read" style="font-size: 14px">

--- a/LEAF_Nexus/templates/view_group_permissions.tpl
+++ b/LEAF_Nexus/templates/view_group_permissions.tpl
@@ -35,7 +35,7 @@
             <td style="width: 100px" title="This allows permissions to be granted to others">Grant</td>
         </tr>
     <!--{foreach from=$permissions item=permission}-->
-        <!--{if $isAdmin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
+        <!--{if $is_admin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
         <tr style="background-color: <!--{cycle values='#e0e0e0,#c4c4c4'}-->; opacity: 50%;">
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->" style="font-size: 14px; font-weight: bold"><img src="images/largespinner.gif" alt="" /> Loading <!--{$permission.categoryID|strip_tags}-->...</td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_read" style="font-size: 14px">

--- a/LEAF_Nexus/templates/view_permissions.tpl
+++ b/LEAF_Nexus/templates/view_permissions.tpl
@@ -35,7 +35,8 @@
             <td style="width: 100px" title="This allows permissions to be granted to others">Grant</td>
         </tr>
     <!--{foreach from=$permissions item=permission}-->
-        <!--{if $permission.UID == 2 || $permission.UID == 1}-->
+    
+        <!--{if $isAdmin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
         <tr style="background-color: <!--{cycle values='#e0e0e0,#c4c4c4'}-->; opacity: 50%;">
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->" style="font-size: 14px; font-weight: bold"><img src="images/largespinner.gif" alt="" /> Loading <!--{$permission.categoryID|strip_tags}-->...</td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_read" style="font-size: 14px">
@@ -49,6 +50,7 @@
             </td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_write" style="font-size: 14px">
                 <div class="buttonNorm">
+                
                 <!--{if $permission.write == 1}-->
                 <img src="dynicons/?img=gnome-emblem-default.svg&amp;w=32" alt="" /> Yes
                 <!--{else}-->

--- a/LEAF_Nexus/templates/view_permissions.tpl
+++ b/LEAF_Nexus/templates/view_permissions.tpl
@@ -36,7 +36,7 @@
         </tr>
     <!--{foreach from=$permissions item=permission}-->
     
-        <!--{if $isAdmin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
+        <!--{if $is_admin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
         <tr style="background-color: <!--{cycle values='#e0e0e0,#c4c4c4'}-->; opacity: 50%;">
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->" style="font-size: 14px; font-weight: bold"><img src="images/largespinner.gif" alt="" /> Loading <!--{$permission.categoryID|strip_tags}-->...</td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_read" style="font-size: 14px">

--- a/LEAF_Nexus/templates/view_position_permissions.tpl
+++ b/LEAF_Nexus/templates/view_position_permissions.tpl
@@ -32,7 +32,7 @@
             <td style="width: 100px" title="This allows permissions to be granted to others">Grant</td>
         </tr>
     <!--{foreach from=$permissions item=permission}-->
-        <!--{if $isAdmin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
+        <!--{if $is_admin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
         <tr style="background-color: <!--{cycle values='#e0e0e0,#c4c4c4'}-->; opacity: 50%;">
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->" style="font-size: 14px; font-weight: bold"><img src="images/largespinner.gif" alt="" /> Loading <!--{$permission.categoryID|strip_tags}-->...</td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_read" style="font-size: 14px">

--- a/LEAF_Nexus/templates/view_position_permissions.tpl
+++ b/LEAF_Nexus/templates/view_position_permissions.tpl
@@ -32,7 +32,7 @@
             <td style="width: 100px" title="This allows permissions to be granted to others">Grant</td>
         </tr>
     <!--{foreach from=$permissions item=permission}-->
-        <!--{if $permission.UID == 2 || $permission.UID == 1}-->
+        <!--{if $isAdmin == FALSE && ($permission.UID == 2 || $permission.UID == 1)}-->
         <tr style="background-color: <!--{cycle values='#e0e0e0,#c4c4c4'}-->; opacity: 50%;">
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->" style="font-size: 14px; font-weight: bold"><img src="images/largespinner.gif" alt="" /> Loading <!--{$permission.categoryID|strip_tags}-->...</td>
             <td id="<!--{$permission.categoryID|strip_tags}-->_<!--{$permission.UID|strip_tags}-->_read" style="font-size: 14px">


### PR DESCRIPTION
Setup permissions to take into account if the user is a System Administrator and allow users in this group edit all permissions on groups, positions and individual employees. This was in the Community Of Practice and Open Office Hours on 10/22/24

**Testing** 
Steps go over position, this will affect positions, groups and individual employees.

- Go into the org chart
- Find a position and click on an option like `Pay Grade`
- Click on edit permission
- By default the sysadmin user should have full access
- Remove yourself from the admin group and try again, you should be able to edit things that are not `Everyone else` and `Sys Admin`