### PR TITLE
LEAF-4577 - Print to PDF Image

### DIFF
--- a/LEAF_Request_Portal/css/printer.css
+++ b/LEAF_Request_Portal/css/printer.css
@@ -186,6 +186,7 @@ table#tform td {
 
 .printmainform {
   border: 1px solid black;
+  clear: both;
 }
 
 .printformblock {
@@ -207,7 +208,7 @@ table#tform td {
   margin-right: 4px;
   font-size: 24px;
   font-weight: bold;
-  background-color: black;
+  background-color: transparent;
   color: white;
   float: left;
 }
@@ -384,4 +385,8 @@ table.table {
 #requestInfo {
   float: right;
   font-size: 12px;
+}
+
+#nav-skip-link{
+  display: none;
 }

--- a/LEAF_Request_Portal/css/printer.css
+++ b/LEAF_Request_Portal/css/printer.css
@@ -334,6 +334,11 @@ img {
   visibility: collapse;
 }
 
+.printResponse img{
+  display: initial;
+  visibility: initial;
+}
+
 div#tabcontainer_tablist {
   display: none;
   visibility: hidden;


### PR DESCRIPTION
**Issue**
Images were not allowed in the print to pdf, so for example the image upload would not show when printing a pdf using the browsers print to pdf functionality. 

**The fix**
Adjusted print style sheet to allow images within the request.

** Other Issues Fixed **
- Skip to content link
- First section item was pushed over

**New**
![image](https://github.com/user-attachments/assets/64394f56-80a0-4917-a369-4a1f2104b52c)

**Old**
![image](https://github.com/user-attachments/assets/1e81db21-4d08-46ea-8233-9d31afb7b49f)

**Testing**
- Upload an image to a form
- Using the browsers print preview you should now see the image in view to print