### PR TITLE
LEAF-4584 - Special Character in request email not displaying correctly

### DIFF
--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -415,7 +415,7 @@ class Email
     private function getHeaders(): string
     {
         $header = 'MIME-Version: 1.0';
-        $header .= "\r\nContent-type: text/html; charset=iso-8859-1";
+        $header .= "\r\nContent-type: text/html; charset=utf-8";
         if ($this->emailSender == '') {
             $header .= "\r\nFrom: {$this->emailFrom}";
         } else {

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1672,7 +1672,7 @@ class FormWorkflow
                 default:
                 break;
             }
-            $data = iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $data);
+            
             $formattedFields["content"][$field['indicatorID']] = $data !== "" ? $data : $field["default"];
             $formattedFields["to_cc_content"][$field['indicatorID']] = $emailValue;
         }


### PR DESCRIPTION
This was specifically in the title but it was anything in the content of the email. So text fields and other data that was requested to be shown could have this issue.

Windows Special Character Keyboard
https://www.theverge.com/22351023/windows-pc-special-characters-how-to

Linux Special Character Keyboard
https://forums.linuxmint.com/viewtopic.php?t=347624

Testing
- Setup a workflow that sends an email
- Make sure the form has a text field 
- Make sure the email has a text field and title in it
- Fill out a form and run it through the step that would send an email
- Check the email to make sure it shows proper text


Example Of Failure:
![image](https://github.com/user-attachments/assets/f412abcb-3dae-46ab-9b2d-bffa5eacfabf)

Example Of Success:
![image](https://github.com/user-attachments/assets/517e2996-e9da-4301-9007-84f562ffe4f1)
