### PR TITLE
LEAF 4585 prevent negative coordinates for workflow steps

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2249,13 +2249,21 @@
             type: 'GET',
             url: '../api/workflow/' + workflowID,
             success: function(res) {
-                var minY = 80;
-                var maxY = 80;
+                const minY = 80;
+                const minX = 0;
+                let maxY = 80;
+
+                let posY = 0;
+                let posX = 0;
                 for (let i in res) {
                     steps[res[i].stepID] = res[i];
                     posY = parseFloat(res[i].posY);
+                    posX = parseFloat(res[i].posX);
                     if (posY < minY) {
                         posY = minY;
+                    }
+                    if (posX < minX) {
+                        posX = minX;
                     }
 
                     let emailNotificationIcon = '';
@@ -2279,7 +2287,7 @@
                     );
 
                     $('#step_' + res[i].stepID).css({
-                        'left': parseFloat(res[i].posX) + 'px',
+                        'left': posX + 'px',
                         'top': posY + 'px',
                         'background-color': res[i].stepBgColor
                     });

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2087,11 +2087,11 @@
                 routes = res;
                 if (endPoints[-1] == undefined) {
                     endPoints[-1] = jsPlumb.addEndpoint('step_-1', {anchor: 'Continuous'}, endpointOptions);
-                    jsPlumb.draggable('step_-1');
+                    jsPlumb.draggable('step_-1', { allowNegative: false });
                 }
                 if (endPoints[0] == undefined) {
                     endPoints[0] = jsPlumb.addEndpoint('step_0', {anchor: 'Continuous'}, endpointOptions);
-                    jsPlumb.draggable('step_0');
+                    jsPlumb.draggable('step_0', { allowNegative: false });
                 }
 
                 // draw connector
@@ -2295,6 +2295,7 @@
                     if (endPoints[res[i].stepID] == undefined) {
                         endPoints[res[i].stepID] = jsPlumb.addEndpoint('step_' + res[i].stepID, {anchor: 'Continuous'}, endpointOptions);
                         jsPlumb.draggable('step_' + res[i].stepID, {
+                            allowNegative: false,
                             // save position of the box when moved
                             stop: function(stepID) {
                                 return function() {

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -303,10 +303,12 @@ class Workflow
             return 'Restricted command.';
         }
 
-        $vars = array(':workflowID' => $this->workflowID,
+        $vars = array(
+            ':workflowID' => $this->workflowID,
             ':stepID' => $stepID,
-            ':x' => $x,
-            ':y' => $y, );
+            ':x' => max(0, $x),
+            ':y' => max(0, $y),
+        );
         $res = $this->db->prepared_query('UPDATE workflow_steps
                                             SET posX=:x, posY=:y
         									WHERE workflowID=:workflowID


### PR DESCRIPTION
Applies a minimum value of 0 to the coordinates of workflow steps to resolve an issue where users could drag and save negative coordinates.

Server-side: 
-saved x and y positions have a minimum value of 0.

Front end:
-add a local minimum x value used for CSS positioning to handle any existing saved negative x values so that they display on the screen (a min y value was already present).

-add jsPlumb draggable config option 'allowNegative' with a false value to prevent dragging steps offscreen (left or top)


**Testing / Impact**

Workflow Editor

-steps cannot be dragged to negative coordinates (outside of left or top of screen)
-steps that have negative coordinates saved still show on screen (portal workflow_steps can be edited in adminer)

