### PR TITLE
LEAF  4601 - admin menu 508 fix

### DIFF
--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -89,7 +89,8 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE 6'))
 
 $main->assign('logo', '<img src="../images/VA_icon_small.png" alt="VA seal, U.S. Department of Veterans Affairs" />');
 
-$main->assign('name', $login->getName());
+$t_login->assign('name', $login->getName());
+$main->assign('display_name', $login->getName());
 
 $qrcodeURL = "https://" . HTTP_HOST . $_SERVER['REQUEST_URI'];
 $main->assign('qrcodeURL', urlencode($qrcodeURL));

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -606,6 +606,7 @@ switch ($action) {
             $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
             $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
             $t_form->assign('siteType', XSSHelpers::xscrub($settings['siteType']));
+            $main->assign('name', $login->getName());
 
             $main->assign('javascripts', array(APP_JS_PATH . '/jquery/jquery.min.js',
                                            APP_JS_PATH . '/jquery/jquery-ui.custom.min.js',

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -89,7 +89,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE 6'))
 
 $main->assign('logo', '<img src="../images/VA_icon_small.png" alt="VA seal, U.S. Department of Veterans Affairs" />');
 
-$t_login->assign('name', $login->getName());
+$main->assign('name', $login->getName());
 
 $qrcodeURL = "https://" . HTTP_HOST . $_SERVER['REQUEST_URI'];
 $main->assign('qrcodeURL', urlencode($qrcodeURL));
@@ -606,7 +606,6 @@ switch ($action) {
             $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
             $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
             $t_form->assign('siteType', XSSHelpers::xscrub($settings['siteType']));
-            $main->assign('name', $login->getName());
 
             $main->assign('javascripts', array(APP_JS_PATH . '/jquery/jquery.min.js',
                                            APP_JS_PATH . '/jquery/jquery-ui.custom.min.js',

--- a/LEAF_Request_Portal/admin/templates/main.tpl
+++ b/LEAF_Request_Portal/admin/templates/main.tpl
@@ -64,7 +64,7 @@
     </section>
     {/if}
 
-    <header id="header" class="usa-header site-header">
+    <header id="header" class="usa-header site-header" style="position:relative;">
         <div class="usa-navbar site-header-navbar">
             <div class="usa-logo site-logo" id="logo">
                 <em class="usa-logo__text">
@@ -77,6 +77,9 @@
                 {if $qrcodeURL != ''}
                     <div><img class="print nodisplay" style="width: 72px" src="{$abs_portal_path}/qrcode/?encode={$qrcodeURL}" alt="QR code" /></div>
                 {/if}
+            </div>
+            <div style="position:absolute;right:0;top:0;padding:0 0.75rem;font-size:14px;">
+                Welcome, <b>{$name|sanitize}</b>! | <a href="../?a=logout" style="color:#00bde3">Sign out</a>
             </div>
             <div class="leaf-header-right">
                 {$emergency}<!--{$login}-->

--- a/LEAF_Request_Portal/admin/templates/main.tpl
+++ b/LEAF_Request_Portal/admin/templates/main.tpl
@@ -79,7 +79,7 @@
                 {/if}
             </div>
             <div style="position:absolute;right:0;top:0;padding:0 0.75rem;font-size:14px;">
-                Welcome, <b>{$name|sanitize}</b>! | <a href="../?a=logout" style="color:#00bde3">Sign out</a>
+                Welcome, <b>{$display_name|sanitize}</b>! | <a href="../?a=logout" style="color:#00bde3">Sign out</a>
             </div>
             <div class="leaf-header-right">
                 {$emergency}<!--{$login}-->

--- a/LEAF_Request_Portal/admin/templates/main.tpl
+++ b/LEAF_Request_Portal/admin/templates/main.tpl
@@ -64,8 +64,8 @@
     </section>
     {/if}
 
-    <header id="header" class="usa-header site-header" style="position:relative;">
-        <div class="usa-navbar site-header-navbar">
+    <header id="header" class="usa-header site-header">
+        <div class="usa-navbar site-header-navbar" style="position:relative;">
             <div class="usa-logo site-logo" id="logo">
                 <em class="usa-logo__text">
                     <a tabindex="0" onclick="window.location='./'" title="Admin Home" class="leaf-cursor-pointer">

--- a/LEAF_Request_Portal/admin/templates/menu.tpl
+++ b/LEAF_Request_Portal/admin/templates/menu.tpl
@@ -98,16 +98,6 @@
 
     </li>
 
-    <li class="leaf-width-4rem leaf-mob-menu lev2">
-        <a href="javascript:void(0);" aria-label="user account menu" aria-expanded="false" role="button"
-            aria-controls="user_account_menu"><i class='fas fa-user-circle leaf-usericon'></i></a>
-        <ul class="leaf-usernavmenu" id="user_account_menu">
-            <li tabindex="0" style="padding-left:0.4rem;">User:<br/><span class="leaf-user-menu-name">{$name}</span></li>
-            <li tabindex="0" style="padding-left:0.4rem;">Primary Admin:<br/><span id="primary-admin" class="leaf-user-menu-name"></span></li>
-            <li><a href="../?a=logout">Sign Out</a></li>
-        </ul>
-    </li>
-
 </ul>
 
 <script>
@@ -220,27 +210,4 @@ $('li:has(ul)').on('mouseover click mouseleave focusout', function(e) {
 
 
 });
-</script>
-
-<script type="text/javascript">
-    $.ajax({
-        url: "../api/system/primaryadmin",
-        dataType: "json",
-        success: function(response) {
-            const emailString = response['Email'] != '' ? ' - <br><a href="mailto:' + response['Email'] + '" style="padding:0">' + response['Email'] + '</a>' : '';
-            if(response["Fname"] !== undefined)
-            {
-                $('#primary-admin').html(response['Fname'] + " " + response['Lname'] + emailString);
-            }
-            else if(response["userName"] !== undefined)
-            {
-                $('#primary-admin').html(response['userName']);
-            }
-            else
-            {
-                $('#primary-admin').html('Not Set');
-            }
-
-        }
-    });
 </script>


### PR DESCRIPTION

This will attempt to resolve a navigation consistency defect brought up by the most recent 508 audit.

Removes user menu and an associated script from the portal admin menu.
Adds Welcome and Sign Out link similar to that found on the non-admin portal pages.

Other/Comment:
Portal admin side 'login' template and its associated variables do not appear to be used, but this has been left untouched until further feedback

**Impact / Testing**

Portal admin side header - appearance and link functionality.