### PR TITLE
LEAF 4602 fix data visualizer addDataTerm param order

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Data_Visualizer.tpl
@@ -621,7 +621,7 @@ async function getDataBuildCharts(categoryID, customSearch) {
                     activeFilters += `<li>${param.id} ${param.operator} ${param.match}</li>`;
                 }
                 else {
-                    query.addDataTerm(param.indicatorID, param.id, param.operator, param.match);
+                    query.addDataTerm(param.id, param.indicatorID, param.operator, param.match);
 					activeFilters += `<li>${param.id}${param.indicatorID} ${param.operator} ${param.match}</li>`;
                 }
             }


### PR DESCRIPTION
Fixes parameter order for method 'addDataTerm' used in the Data Visualizer.

**Testing / Impact**

Data Visualizer

Portal Admin -> Data Visualizer

Choose a Form Type
Choose Edit Filter

Add Filter 'Data Field ...'
Test with 'Any Standard Data Field' or with a specific indicator selection (choose from updated dropdown)

Data Terms should be searchable and return expected results.




