### PR TITLE
LEAF-4604 update form progress checking to account for conditional logic

### DIFF
--- a/LEAF_Request_Portal/ajaxJSON.php
+++ b/LEAF_Request_Portal/ajaxJSON.php
@@ -32,7 +32,7 @@ switch ($action) {
            // this method does not exist in Form class
            // echo $form->getProgressJSON($_GET['recordID']);
            // but this one does
-           echo $form->getProgress($_GET['recordID']);
+           echo $form->getProgress((int)$_GET['recordID']);
 
            break;
     case 'getrecentactions':

--- a/LEAF_Request_Portal/api/controllers/FormController.php
+++ b/LEAF_Request_Portal/api/controllers/FormController.php
@@ -121,7 +121,7 @@ class FormController extends RESTfulResponse
         });
 
         $this->index['GET']->register('form/[digit]/progress', function ($args) use ($form) {
-            $return = $form->getProgress($args[0]);
+            $return = $form->getProgress((int)$args[0]);
             return $return;
         });
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1706,7 +1706,6 @@ class Form
             count_required($dataTable, $page, false, $requiredTotal, $requiredAnswered);
         }
 
-        error_log("R A: ".$requiredTotal." ".$requiredAnswered);
         if ($requiredTotal === 0) {
             $returnValue = 100;
         } else {

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1548,9 +1548,9 @@ class Form
                         $parentFormat = $c->parentFormat;
                         $conditionParentValue = preg_split('/\R/', $c->selectedParentValue) ?? [];
                         $currentParentDataValue = preg_replace('/&apos;/', '&#039;', $dataTable[$c->parentIndID] ?? '');
-                        if ($parentFormat === 'checkbox') { //single checkbox ifthen is either checked or not checked
+                        /* if ($parentFormat === 'checkbox') { //single checkbox ifthen is either checked or not checked (pending parent checkbox)
                             $currentParentDataValue = !empty($currentParentDataValue) && $currentParentDataValue !== 'no' ? '1' : '0';
-                        }
+                        } */
                         if (in_array($parentFormat, $multiChoiceParentFormats)) {
                             $currentParentDataValue = @unserialize($currentParentDataValue) === false ?
                                 array($currentParentDataValue) : unserialize($currentParentDataValue);
@@ -1733,7 +1733,7 @@ class Form
             return 100;
         }
 
-        $dataSQL = "SELECT `indicatorID`, `format`, `data` FROM `data`
+        $dataSQL = "SELECT `indicatorID`, `format`, TRIM(`data`) as `data` FROM `data`
             LEFT JOIN indicators USING (indicatorID)
             WHERE recordID=:recordID
             AND indicators.disabled = 0

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1527,7 +1527,7 @@ class Form
         int &$required_visible,
         int &$required_answered,
         int &$required_total,
-        int $res_max_required)
+        int $res_max_required): void
     {
         if((int)$formNode['required'] === 1) {
             $required_total += 1; //keep track to skip calls once all required questions are found.
@@ -1703,7 +1703,7 @@ class Form
      * @param int $recordID
      * @return int Percent completed
      */
-    public function getProgress($recordID)
+    public function getProgress(int $recordID): int
     {
         $subSQL = 'SELECT submitted, categoryID FROM records
             LEFT JOIN category_count USING (recordID)


### PR DESCRIPTION
The current Form getProgress method still compares a flat array of required questions with data entries in order to determine form progress percentage.  Individual questions account for direct conditional logic.  However, since there is no information about form structure, using conditional logic when the conditional indicator has required sub-questions is problematic / tedious because the logic needs to be repeated on the subquestion.

This update will take form structure into account (when needed) during the progress count so that any ancestor in a hidden state is sufficient.

**Front end:**
Updates to form.js to handle conditional display states and to toggle front end validation for required questions

**Server-Side:**
Updates to form method getProgress to account for structure.
Following a check for submission and for the number of required questions, method will progress with a depth search assessment of question display state, visible required question, and total required question totals.  Required questions that are not in a visible state because they OR one of their ancestors are hidden by conditional do not count towards the visible total.

**Impact / Testing.**

Associated go test PR
https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/20

This has high impact to the initial request submission process.
If the total is inaccurate
-data entry or submission could be prevented without a visible indication to the user as to why.
-submission could be allowed despite the user not having answered all required questions.

Test form data entry (initial request) and confirm that the percentage (form progress) reflects the percentage of answered required questions that are visible on the form.  Required questions hidden by ifthen logic directly, or because they are subquestions of hidden questions should not count towards the visible total.