### PR TITLE
LEAF 4597 - move orgchart keyboard info banner

### DIFF
--- a/LEAF_Nexus/css/editor.css
+++ b/LEAF_Nexus/css/editor.css
@@ -92,3 +92,31 @@
     background-color: #2372b0;
     color: white;
 }
+
+#visual_alert_box_container {
+    max-width: 354px;
+    box-sizing: border-box;
+    margin-left: auto;
+}
+#visual_alert_box {
+    text-align: left;
+    position: relative;
+    padding: 0.25em;
+    background-color:#fff;
+}
+#visual_alert_box_container label {
+    display: flex;
+    justify-content:flex-end;
+    padding-top: 0.25rem;
+}
+#visual_alert_box.hide, #visual_alert_box_container label.hide {
+    display: none;
+}
+
+#visual_alert_box_container label input {
+    margin: 0 0 0 0.25rem;
+}
+
+#visual_alert_box_title {
+    font-weight: bolder;
+}

--- a/LEAF_Nexus/js/ui/position.js
+++ b/LEAF_Nexus/js/ui/position.js
@@ -47,7 +47,8 @@ position.prototype.initialize = function (parentContainerID) {
   $("#" + prefixedPID + "_title").on("click keydown mouseenter", function(ev) {
     //if they are newly focusing an open card just update the tab focus
     const isNewFocus = document.activeElement !== ev.currentTarget;
-    if (ev.type === "click" && isNewFocus) {
+    const cardDataAttr = ev.currentTarget.parentNode.getAttribute('data-moving');
+    if (ev.type === "click" && isNewFocus || cardDataAttr === "true") {
       ev.currentTarget.focus();
       return;
     }

--- a/LEAF_Nexus/templates/editor.tpl
+++ b/LEAF_Nexus/templates/editor.tpl
@@ -19,9 +19,19 @@ placeholder<br />
         <button type="button" class="buttonNorm" onclick="window.location='mailto:?subject=FW:%20Org.%20Chart%20-%20&amp;body=Organizational%20Chart%20URL:%20<!--{if $smarty.server.HTTPS == on}-->https<!--{else}-->http<!--{/if}-->://<!--{$smarty.server.SERVER_NAME}--><!--{$smarty.server.REQUEST_URI|escape:'url'}-->%0A%0A'">
             <img src="dynicons/?img=mail-forward.svg&amp;w=24" style="vertical-align: middle" alt="" /> Forward as Email
         </button>
+        <div id="visual_alert_box_container">
+            <div id="visual_alert_box" class="hide">
+                You are moving the <span id="visual_alert_box_title"></span> card<br />
+                Esc - return to original location<br />
+                Enter - save current location
+            </div>
+            <label for="MovementInfoToggle" class="hide">Hide Movement Info
+                <input type="checkbox" id="MovementInfoToggle" onchange="toggleHideClass('visual_alert_box')">
+            </label>
+        </div>
     </span>
 </span>
-<div id="visual_alert_box" role="status" aria-live="assertive" aria-label="" style="position:absolute;opacity:0; z-index:999;background:#fff"></div>
+
 <div id="pageloadIndicator" style="visibility: visible">
     <div style="opacity: 0.8; z-index: 1000; position: absolute; background: #f3f3f3; height: 97%; width: 97%"></div>
     <div style="z-index: 1001; position: absolute; padding: 16px; width: 97%; text-align: center; font-size: 24px; font-weight: bold; background-color: white">Loading... <img src="images/largespinner.gif" alt="" /></div>
@@ -117,6 +127,17 @@ function applyZoomLevel() {
         default:
             setZoomLargest();
             break;
+    }
+}
+
+function toggleHideClass( elementID = '') {
+    let el = document.getElementById(elementID);
+    if(el !== null) {
+        if(el.classList.contains('hide')) {
+            el.classList.remove('hide');
+        } else {
+            el.classList.add('hide');
+        }
     }
 }
 
@@ -263,7 +284,7 @@ function moveCoordinates(prefix, position) {
         if (e.key === "Tab") {
             saveLayout(position);
             $('#' + prefix + position).css('box-shadow', 'none');
-            $('#visual_alert_box').css('opacity', '0');
+            $('#visual_alert_box').addClass('hide');
             document.removeEventListener('keydown', moveCard);
             return;
         } else if (controlKeys.includes(e.key)) {
@@ -300,7 +321,7 @@ function moveCoordinates(prefix, position) {
 
             if (abort) {
                 $('#' + prefix + position).css('box-shadow', 'none');
-                $('#visual_alert_box').css('opacity', '0');
+                $('#visual_alert_box').addClass('hide');
                 document.removeEventListener('keydown', moveCard);
                 return;
             }
@@ -308,11 +329,18 @@ function moveCoordinates(prefix, position) {
     };
     $('div.positionSmall').css('box-shadow', 'none');
     $('#' + prefix + position).css('box-shadow', ' 0 0 6px #c00');
-    let alert_box = document.getElementById('visual_alert_box');
+    let alert_box_card_title = document.getElementById('visual_alert_box_title');
     let title = document.getElementById(prefix + position + '_title');
     let titleText = title.innerHTML;
-    alert_box.innerHTML = "You are moving the " + titleText + " card<br />Esc - return to original location<br />Enter - save current location<br />Tab - Save and move to next card";
-    $('#visual_alert_box').css('opacity', '100');
+    alert_box_card_title.textContent = titleText;
+    if( $('#visual_alert_box_container label').hasClass('hide')) {
+        $('#visual_alert_box_container label').removeClass('hide');
+        $('#visual_alert_box').removeClass('hide');
+    } else {
+        if(document.getElementById('MovementInfoToggle').checked !== true) {
+            $('#visual_alert_box').removeClass('hide');
+        }
+    }
 
     let card = document.getElementById(prefix + position);
     let cardStyle = window.getComputedStyle(card);

--- a/LEAF_Nexus/templates/editor.tpl
+++ b/LEAF_Nexus/templates/editor.tpl
@@ -289,6 +289,17 @@ function moveCoordinates(prefix, position) {
             return;
         } else if (controlKeys.includes(e.key)) {
             e.preventDefault();
+            //only show extra info if keyboard is being used to move the card
+            if(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+                if( $('#visual_alert_box_container label').hasClass('hide')) {
+                    $('#visual_alert_box_container label').removeClass('hide');
+                    $('#visual_alert_box').removeClass('hide');
+                } else {
+                    if(document.getElementById('MovementInfoToggle').checked !== true) {
+                        $('#visual_alert_box').removeClass('hide');
+                    }
+                }
+            }
             switch (e.key) {
                 case "ArrowLeft":
                     leftValue = (Number(leftValue) - 10);
@@ -333,14 +344,6 @@ function moveCoordinates(prefix, position) {
     let title = document.getElementById(prefix + position + '_title');
     let titleText = title.innerHTML;
     alert_box_card_title.textContent = titleText;
-    if( $('#visual_alert_box_container label').hasClass('hide')) {
-        $('#visual_alert_box_container label').removeClass('hide');
-        $('#visual_alert_box').removeClass('hide');
-    } else {
-        if(document.getElementById('MovementInfoToggle').checked !== true) {
-            $('#visual_alert_box').removeClass('hide');
-        }
-    }
 
     let card = document.getElementById(prefix + position);
     let cardStyle = window.getComputedStyle(card);


### PR DESCRIPTION
This element displaying keyboard instructions has been moved to the right side under the editor buttons where it is less likely to overlap with position cards.  It will also not show unless a card is being moved by keyboard arrows.

When it is showing, there is a checkbox available to hide the additional information (pending some feedback - it might be fine to remove this since the keyboard info will not usually show)

Other:
minor UX update to re-paint connectors after a position is saved if a card has been moved by keyboard

**Testing / Impact**

This update is specific to the orgchart editor (Nexus -> browser -> edit orgchart)
Keyboard instruction location has been moved and should not display unless a card is being moved with keyboard arrow keys.  Confirm that card behaviors have not otherwise changed.
