### PR TITLE
LEAF 4455 metadata reading (ao 121224)

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3897,7 +3897,8 @@ class Form
                 $res2 = $this->db->prepared_query($actionHistorySQL, array());
                 foreach ($res2 as $item)
                 {
-                    $userMetadata = json_decode($item['userMetadata'], true);
+                    $item['userMetadata'] = json_decode($item['userMetadata'], true);
+                    $userMetadata = $item['userMetadata'];
                     $name = isset($userMetadata) && trim("{$userMetadata['firstName']} {$userMetadata['lastName']}") !== "" ?
                         "{$userMetadata['firstName']} {$userMetadata['lastName']}" : $item['userID'];
 

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3762,18 +3762,18 @@ class Form
         }
 
 
-        //joinInitiatorNames backwards compat - additional SQL for records.userMetadata replaces previous join with orgchart.employee.
-        //userMetadata properties are empty for accounts that were inactive when prior metadata values were updated.
-        //Alternatives here display 'userID (inactive user)' instead of 'null, null' if metadata is empty.
+        //joinInitiatorNames backwards compat - additional SQL for records.userMetadata replaces the previous join with orgchart.employee.
+        //userMetadata properties are empty for accounts that were inactive when prior metadata values were updated.  Use lastName to check if empty
+        //because userName might be removed in the future.  Display 'userID (inactive user)' instead of 'null, null' if metadata is empty.
         $initiatorNamesSQL = '';
         if ($joinInitiatorNames) {
             $initiatorNamesSQL = ',
                 IF(
-                    TRIM(JSON_VALUE(`userMetadata`, "$.userName")) != "",
+                    TRIM(JSON_VALUE(`userMetadata`, "$.lastName")) != "",
                     JSON_VALUE(`userMetadata`, "$.firstName"), "(inactive user)"
                 ) AS `firstName`,
                 IF(
-                    TRIM(JSON_VALUE(`userMetadata`, "$.userName")) != "",
+                    TRIM(JSON_VALUE(`userMetadata`, "$.lastName")) != "",
                     JSON_VALUE(`userMetadata`, "$.lastName"), `userID`
                 ) AS `lastName`';
         }

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -573,15 +573,16 @@ class Form
                 $form[$idx]['value'] = $this->fileToArray($data[0]['data']);
                 $form[$idx]['raw'] = $data[0]['data'];
             }
-            // special handling for org chart data types
+            // special handling for org chart data types (request header questions, edited report builder cells)
             else if ($data[0]['format'] == 'orgchart_employee'
                 && !empty($data[0]['data']))
             {
-                $empRes = $this->employee->lookupEmpUID($data[0]['data']);
-                if (!empty($empRes)) {
-                    $form[$idx]['displayedValue'] = "{$empRes[0]['firstName']} {$empRes[0]['lastName']}";
-                } else {
-                    $form[$idx]['displayedValue'] = '';
+                $form[$idx]['displayedValue'] = '';
+                if (isset($data[0]['metadata'])) {
+                    $orgchartInfo = json_decode($data[0]['metadata'], true);
+                    if(!empty(trim($orgchartInfo['lastName']))) {
+                        $form[$idx]['displayedValue'] = "{$orgchartInfo['firstName']} {$orgchartInfo['lastName']}";
+                    }
                 }
             }
             else if ($data[0]['format'] == 'orgchart_position'
@@ -1008,9 +1009,9 @@ class Form
             );
         }
 
-        $dir = new VAMC_Directory;
-        $user = $dir->lookupLogin($res[0]['userID']);
-        $name = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : $res[0]['userID'];
+        $userMetadata = json_decode($res[0]['userMetadata'], true);
+        $name = isset($userMetadata) && !empty(trim($userMetadata['lastName'])) ?
+            "{$userMetadata['firstName']} {$userMetadata['lastName']}" : $res[0]['userID'];
 
         $data = array('name' => $name,
                       'service' => $res[0]['service'],
@@ -2658,16 +2659,14 @@ class Form
                                 }
                             }
                             break;
-                        case 'orgchart_employee':
-                            $empRes = $this->employee->lookupEmpUID($item['data']);
-                            if (isset($empRes[0]))
-                            {
-                                $item['data'] = "{$empRes[0]['firstName']} {$empRes[0]['lastName']}";
-                                $item['dataOrgchart'] = $empRes[0];
-                            }
-                            else
-                            {
-                                $item['data'] = '';
+                        case 'orgchart_employee': //report builder cells
+                            $item['data'] = '';
+                            if (isset($item['metadata'])) {
+                                $orgchartInfo = json_decode($item['metadata'], true);
+                                if(!empty(trim($orgchartInfo['lastName']))) {
+                                    $item['data'] = "{$orgchartInfo['firstName']} {$orgchartInfo['lastName']}";
+                                    $item['dataOrgchart'] = $orgchartInfo;
+                                }
                             }
                             break;
                         case 'orgchart_position':
@@ -2785,14 +2784,14 @@ class Form
         } else {
             $vars = array(':recordID' => $recordID);
 
-            $sql = 'SELECT actionTextPasttense, comment, time, userID
+            $sql = 'SELECT actionTextPasttense, comment, time, userID, userMetadata
                     FROM action_history
                     LEFT JOIN dependencies USING (dependencyID)
                     LEFT JOIN actions USING (actionType)
                     WHERE recordID = :recordID
                     AND comment != ""
                     UNION
-                    SELECT "Note Added", note, timestamp, userID
+                    SELECT "Note Added", note, timestamp, userID, userMetadata
                     FROM notes
                     WHERE recordID = :recordID
                     AND deleted IS NULL
@@ -2800,13 +2799,12 @@ class Form
 
             $res = $this->db->prepared_query($sql, $vars);
 
-            $dir = new VAMC_Directory;
-
             $total = count($res);
-
             for ($i = 0; $i < $total; $i++) {
-                $user = $dir->lookupLogin($res[$i]['userID']);
-                $name = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : $res[$i]['userID'];
+                $userMetadata = json_decode($res[$i]['userMetadata'], true);
+                $name = isset($userMetadata) && !empty(trim($userMetadata['lastName'])) ?
+                    "{$userMetadata['firstName']} {$userMetadata['lastName']}" : $res[$i]['userID'];
+
                 $res[$i]['name'] = $name;
             }
 
@@ -2958,11 +2956,9 @@ class Form
                                             	userID=:userID, userMetadata=:userMetadata
                                             	WHERE recordID=:recordID', $vars);
 
-            // write log entry
-            $dir = new VAMC_Directory;
 
-            $user = $dir->lookupLogin($userID);
-            $name = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : $userID;
+            $newInitiatorInfo = json_decode($newInitiatorMetadata, true);
+            $name = "{$newInitiatorInfo['firstName']} {$newInitiatorInfo['lastName']}";
 
             $actionUserID = $this->login->getUserID();
             $actionUserMetadata  = $this->employee->getInfoForUserMetadata($actionUserID, false);
@@ -3765,14 +3761,27 @@ class Form
 									WHERE format = 'orgchart_employee') rj_OCEmployeeData ON (lj_data.indicatorID = rj_OCEmployeeData.indicatorID) ";
         }
 
-        if ($joinInitiatorNames)
-        {
-            $joins .= "LEFT JOIN (SELECT userName, lastName, firstName FROM {$this->oc_dbName}.employee) lj_OCinitiatorNames ON records.userID = lj_OCinitiatorNames.userName ";
+
+        //joinInitiatorNames backwards compat - additional SQL for records.userMetadata replaces previous join with orgchart.employee.
+        //userMetadata properties are empty for accounts that were inactive when prior metadata values were updated.
+        //Alternatives here display 'userID (inactive account)' instead of 'null, null' if metadata is empty.
+        $initiatorNamesSQL = '';
+        if ($joinInitiatorNames) {
+            $initiatorNamesSQL = ',
+                IF(
+                    JSON_EXTRACT(`userMetadata`, "$.userName") != "",
+                    TRIM(BOTH \'\"\' FROM JSON_EXTRACT(`userMetadata`, "$.firstName")), "(inactive account)"
+                ) AS `firstName`,
+                IF(
+                    JSON_EXTRACT(`userMetadata`, "$.userName") != "",
+                    TRIM(BOTH \'\"\' FROM JSON_EXTRACT(`userMetadata`, "$.lastName")), `userID`
+                ) AS `lastName`';
         }
+        $resSQL = 'SELECT * ' . $initiatorNamesSQL . ' FROM `records` ' . $joins . ' WHERE ' . $conditions . $sort . $limit;
 
         if(isset($_GET['debugQuery'])) {
             if($this->login->checkGroup(1)) {
-                $debugQuery = str_replace(["\r", "\n","\t", "%0d","%0a","%09","%20", ";"], ' ', 'SELECT * FROM records ' . $joins . 'WHERE ' . $conditions . $sort . $limit);
+                $debugQuery = str_replace(["\r", "\n","\t", "%0d","%0a","%09","%20", ";"], ' ', $resSQL);
                 $debugVars = [];
                 foreach($vars as $key => $value) {
                     if(strpos($key, ':data') !== false
@@ -3786,17 +3795,14 @@ class Form
 
                 header('X-LEAF-Query: '. str_replace(array_keys($debugVars), $debugVars, $debugQuery));
 
-                return $res = $this->db->prepared_query('EXPLAIN SELECT * FROM records
-                                                        ' . $joins . '
-                                                        WHERE ' . $conditions . $sort . $limit, $vars);
+                return $res = $this->db->prepared_query('EXPLAIN ' . $resSQL, $vars);
             }
             else {
                 return XSSHelpers::scrubObjectOrArray(json_decode(html_entity_decode(html_entity_decode($_GET['q'])), true));
             }
         }
-        $res = $this->db->prepared_query('SELECT * FROM records
-    										' . $joins . '
-                                            WHERE ' . $conditions . $sort . $limit, $vars);
+
+        $res = $this->db->prepared_query($resSQL, $vars);
 
         $data = array();
         $recordIDs = '';
@@ -3872,17 +3878,15 @@ class Form
 
             if ($joinActionHistory)
             {
-                $dir = new VAMC_Directory;
-
                 $actionHistorySQL =
-                       'SELECT recordID, stepID, userID, time, description,
+                       'SELECT recordID, stepID, userID, userMetadata, time, description,
                             actionTextPasttense, actionType, comment
                         FROM action_history
                         LEFT JOIN dependencies USING (dependencyID)
                         LEFT JOIN actions USING (actionType)
                         WHERE recordID IN (' . $recordIDs . ')
                         UNION
-                        SELECT recordID, "-5", userID, timestamp, "Note Added",
+                        SELECT recordID, "-5", userID, userMetadata, timestamp, "Note Added",
                              "Note Added", "LEAF_note", note
                         FROM notes
                         WHERE recordID IN (' . $recordIDs . ')
@@ -3892,8 +3896,10 @@ class Form
                 $res2 = $this->db->prepared_query($actionHistorySQL, array());
                 foreach ($res2 as $item)
                 {
-                    $user = $dir->lookupLogin($item['userID'], true);
-                    $name = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : $res[0]['userID'];
+                    $userMetadata = json_decode($item['userMetadata'], true);
+                    $name = isset($userMetadata) && trim("{$userMetadata['firstName']} {$userMetadata['lastName']}") !== "" ?
+                        "{$userMetadata['firstName']} {$userMetadata['lastName']}" : $item['userID'];
+
                     $item['approverName'] = $name;
 
                     $data[$item['recordID']]['action_history'][] = $item;
@@ -3931,9 +3937,7 @@ class Form
             }
 
             if ($joinRecordResolutionBy === true) {
-                $dir = new VAMC_Directory;
-
-                $recordResolutionBySQL = "SELECT recordID, action_history.userID as resolvedBy, action_history.stepID, action_history.actionType
+                $recordResolutionBySQL = "SELECT recordID, action_history.userID as resolvedBy, action_history.userMetadata, action_history.stepID, action_history.actionType
                 FROM action_history
                 LEFT JOIN records USING (recordID)
                 INNER JOIN workflow_routes USING (stepID)
@@ -3948,8 +3952,9 @@ class Form
                 $res2 = $this->db->prepared_query($recordResolutionBySQL, array());
 
                 foreach ($res2 as $item) {
-                    $user = $dir->lookupLogin($item['resolvedBy'], true);
-                    $nameResolved = isset($user[0]) ? "{$user[0]['Lname']}, {$user[0]['Fname']} " : $item['resolvedBy'];
+                    $userMetadata = json_decode($item['userMetadata'], true);
+                    $nameResolved =  isset($userMetadata) && trim("{$userMetadata['firstName']} {$userMetadata['lastName']}") !== "" ?
+                        "{$userMetadata['firstName']} {$userMetadata['lastName']} " : $item['resolvedBy'];
                     $data[$item['recordID']]['recordResolutionBy']['resolvedBy'] = $nameResolved;
                 }
             }
@@ -4361,7 +4366,7 @@ class Form
             {
                 $var = array(':series' => (int)$series,
                              ':recordID' => (int)$recordID, );
-                $res2 = $this->db->prepared_query('SELECT data, timestamp, indicatorID, groupID, userID FROM data
+                $res2 = $this->db->prepared_query('SELECT data, metadata, timestamp, indicatorID, groupID, userID FROM data
                 									LEFT JOIN indicator_mask USING (indicatorID)
                 									WHERE indicatorID IN (' . $indicatorList . ') AND series=:series AND recordID=:recordID', $var);
 
@@ -4369,6 +4374,7 @@ class Form
                 {
                     $idx = $resIn['indicatorID'];
                     $data[$idx]['data'] = isset($resIn['data']) ? $resIn['data'] : '';
+                    $data[$idx]['metadata'] = isset($resIn['metadata']) ? $resIn['metadata'] : null;
                     $data[$idx]['timestamp'] = isset($resIn['timestamp']) ? $resIn['timestamp'] : 0;
                     $data[$idx]['groupID'] = isset($resIn['groupID']) ? $resIn['groupID'] : null;
                     $data[$idx]['userID'] = isset($resIn['userID']) ? $resIn['userID'] : '';
@@ -4435,14 +4441,15 @@ class Form
                     $child[$idx]['value'] = $this->fileToArray($data[$idx]['data']);
                 }
 
-                // special handling for org chart data types
+                // special handling for org chart data types (request subquestions / child)
                 if ($field['format'] == 'orgchart_employee')
                 {
-                    $empRes = $this->employee->lookupEmpUID($data[$idx]['data']);
                     $child[$idx]['displayedValue'] = '';
-                    if (isset($empRes[0]))
-                    {
-                      $child[$idx]['displayedValue'] = ($child[$idx]['isMasked']) ? '[protected data]' : "{$empRes[0]['firstName']} {$empRes[0]['lastName']}";
+                    if (isset($data[$idx]['metadata'])) {
+                        $orgchartInfo = json_decode($data[$idx]['metadata'], true);
+                        if(!empty(trim($orgchartInfo['lastName']))) {
+                            $child[$idx]['displayedValue'] = "{$orgchartInfo['firstName']} {$orgchartInfo['lastName']}";
+                        }
                     }
                 }
                 if ($field['format'] == 'orgchart_position')

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3764,13 +3764,13 @@ class Form
 
         //joinInitiatorNames backwards compat - additional SQL for records.userMetadata replaces previous join with orgchart.employee.
         //userMetadata properties are empty for accounts that were inactive when prior metadata values were updated.
-        //Alternatives here display 'userID (inactive account)' instead of 'null, null' if metadata is empty.
+        //Alternatives here display 'userID (inactive user)' instead of 'null, null' if metadata is empty.
         $initiatorNamesSQL = '';
         if ($joinInitiatorNames) {
             $initiatorNamesSQL = ',
                 IF(
                     TRIM(JSON_VALUE(`userMetadata`, "$.userName")) != "",
-                    JSON_VALUE(`userMetadata`, "$.firstName"), "(inactive account)"
+                    JSON_VALUE(`userMetadata`, "$.firstName"), "(inactive user)"
                 ) AS `firstName`,
                 IF(
                     TRIM(JSON_VALUE(`userMetadata`, "$.userName")) != "",

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -3769,12 +3769,12 @@ class Form
         if ($joinInitiatorNames) {
             $initiatorNamesSQL = ',
                 IF(
-                    JSON_EXTRACT(`userMetadata`, "$.userName") != "",
-                    TRIM(BOTH \'\"\' FROM JSON_EXTRACT(`userMetadata`, "$.firstName")), "(inactive account)"
+                    TRIM(JSON_VALUE(`userMetadata`, "$.userName")) != "",
+                    JSON_VALUE(`userMetadata`, "$.firstName"), "(inactive account)"
                 ) AS `firstName`,
                 IF(
-                    JSON_EXTRACT(`userMetadata`, "$.userName") != "",
-                    TRIM(BOTH \'\"\' FROM JSON_EXTRACT(`userMetadata`, "$.lastName")), `userID`
+                    TRIM(JSON_VALUE(`userMetadata`, "$.userName")) != "",
+                    JSON_VALUE(`userMetadata`, "$.lastName"), `userID`
                 ) AS `lastName`';
         }
         $resSQL = 'SELECT * ' . $initiatorNamesSQL . ' FROM `records` ' . $joins . ' WHERE ' . $conditions . $sort . $limit;
@@ -3808,6 +3808,7 @@ class Form
         $recordIDs = '';
         foreach ($res as $item)
         {
+            $item['userMetadata'] = json_decode($item['userMetadata'], true);
             if(!isset($data[$item['recordID']])) {
                 $recordIDs .= $item['recordID'] . ',';
             }

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -447,7 +447,7 @@ class FormWorkflow
         $strSQL = "";
 
         if(!$selectUnfilled) {
-            $strSQL = "SELECT dependencyID, recordID, stepID, stepTitle, blockingStepID, workflowID, serviceID, filled, stepBgColor, stepFontColor, stepBorder, `description`, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, jsSrc, userID, requiresDigitalSignature FROM records_workflow_state
+            $strSQL = "SELECT dependencyID, recordID, stepID, stepTitle, blockingStepID, workflowID, serviceID, filled, stepBgColor, stepFontColor, stepBorder, `description`, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, jsSrc, userID, userMetadata, requiresDigitalSignature FROM records_workflow_state
                         LEFT JOIN records USING (recordID)
                         LEFT JOIN workflow_steps USING (stepID)
                         LEFT JOIN step_dependencies USING (stepID)
@@ -456,7 +456,7 @@ class FormWorkflow
                         WHERE recordID IN ({$recordIDs})";
         }
         else {
-            $strSQL = "SELECT dependencyID, recordID, stepTitle, serviceID, `description`, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, userID FROM records_workflow_state
+            $strSQL = "SELECT dependencyID, recordID, stepTitle, serviceID, `description`, indicatorID_for_assigned_empUID, indicatorID_for_assigned_groupID, userID, userMetadata FROM records_workflow_state
                         LEFT JOIN records USING (recordID)
                         LEFT JOIN workflow_steps USING (stepID)
                         LEFT JOIN step_dependencies USING (stepID)
@@ -494,8 +494,8 @@ class FormWorkflow
                         $approver = $dir->lookupLogin($res[$i]['userID']);
 
                         if (empty($approver[0]['Fname']) && empty($approver[0]['Lname'])) {
-                            $res[$i]['description'] = $res[$i]['stepTitle'] . ' (Requestor followup)';
-                            $res[$i]['approverName'] = '(Requestor followup)';
+                            $res[$i]['description'] = $res[$i]['stepTitle'] . ' (Inactive User)';
+                            $res[$i]['approverName'] = '(Inactive User)';
                             $res[$i]['approverUID'] = $res[$i]['userID'];
                         }
                         else {
@@ -543,8 +543,8 @@ class FormWorkflow
                     $dir = $this->getDirectory();
                     $approver = $dir->lookupLogin($res[$i]['userID']);
                     if (empty($approver[0]['Fname']) && empty($approver[0]['Lname'])) {
-                        $res[$i]['description'] = $res[$i]['stepTitle'] . ' (Requestor followup)';
-                        $res[$i]['approverName'] = '(Requestor followup)';
+                        $res[$i]['description'] = $res[$i]['stepTitle'] . ' (Inactive User)';
+                        $res[$i]['approverName'] = '(Inactive User)';
                         $res[$i]['approverUID'] = $res[$i]['userID'];
                     }
                     else {
@@ -716,11 +716,11 @@ class FormWorkflow
         if (isset($res[0])
             && $res[0]['dependencyID'] == -1)
         {
-            $dir = $this->getDirectory();
+            $approverMetadata = json_decode($res[0]['userMetadata'], true);
+            $display = isset($approverMetadata) && trim($approverMetadata['firstName'] . " " . $approverMetadata['lastName'] ) !== '' ?
+                $approverMetadata['firstName'] . " " . $approverMetadata['lastName'] : $res[0]['userID'];
 
-            $approver = $dir->lookupLogin($res[0]['userID']);
-
-            $res[0]['description'] = "{$approver[0]['firstName']} {$approver[0]['lastName']}";
+            $res[0]['description'] = $display;
         }
         // dependencyID -3 is for a group designated by the requestor
         if (isset($res[0])

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -476,6 +476,7 @@ class FormWorkflow
         $groupDesignatedRecords = []; // map of records using "group designated"
         $groupDesignatedIndicators = []; // map of indicators using "group designated"
         foreach ($res as $i => $record) {
+            $res[$i]['userMetadata'] = json_decode($res[$i]['userMetadata'], true);
             // override access if user is in the admin group
             $res[$i]['isActionable'] = $this->login->checkGroup(1); // initialize isActionable
 
@@ -711,12 +712,15 @@ class FormWorkflow
                 LIMIT 1';
             $res = $this->db->prepared_query($strSQL, $vars);
         }
+        if (isset($res[0])) {
+            $res[0]['userMetadata'] = json_decode($res[0]['userMetadata'], true);
+        }
 
         // dependencyID -1 is for a person designated by the requestor
         if (isset($res[0])
             && $res[0]['dependencyID'] == -1)
         {
-            $approverMetadata = json_decode($res[0]['userMetadata'], true);
+            $approverMetadata = $res[0]['userMetadata'];
             $display = isset($approverMetadata) && trim($approverMetadata['firstName'] . " " . $approverMetadata['lastName'] ) !== '' ?
                 $approverMetadata['firstName'] . " " . $approverMetadata['lastName'] : $res[0]['userID'];
 

--- a/LEAF_Request_Portal/sources/View.php
+++ b/LEAF_Request_Portal/sources/View.php
@@ -61,7 +61,7 @@ class View
 
             $vars = array(':recordID' => $recordID);
             $sql1 = 'SELECT time, description, actionText, stepTitle,
-                        dependencyID, comment, userID
+                        dependencyID, comment, userID, userMetadata
                      FROM action_history
                      LEFT JOIN dependencies USING (dependencyID)
                      LEFT JOIN workflow_steps USING (stepID)
@@ -69,13 +69,13 @@ class View
                      WHERE recordID=:recordID
                      UNION
                      SELECT timestamp, "Note Added", "N/A", "N/A",
-                        "N/A", note, userID
+                        "N/A", note, userID, userMetadata
                      FROM notes
                      WHERE recordID = :recordID
                      AND deleted IS NULL
                      UNION
                      SELECT `timestamp`, "Email Sent", "N/A", "N/A",
-                        "N/A", concat(`recipients`, "<br />", `subject`), ""
+                        "N/A", concat(`recipients`, "<br />", `subject`), "", ""
                      FROM `email_tracker`
                      WHERE recordID = :recordID
                      ORDER BY time ASC';
@@ -102,8 +102,12 @@ class View
                 $packet['comment'] = $tmp['comment'];
 
                 if (!empty($tmp['userID'])) {
-                    $user = $dir->lookupLogin($tmp['userID']);
-                    $name = isset($user[0]) ? "{$user[0]['Fname']} {$user[0]['Lname']}" : $tmp['userID'];
+                    $name = $tmp['userID'];
+                    if(isset($tmp['userMetadata'])) {
+                        $umd = json_decode($tmp['userMetadata'], true);
+                        $display =  trim($umd['firstName'] . " " . $umd['lastName']);
+                        $name = !empty($display) ? $display : $name;
+                    }
                     $packet['userName'] = $name;
                 }
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_Sitemap_Search.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Sitemap_Search.tpl
@@ -198,6 +198,7 @@ function addHeader(column) {
         case 'dateCancelled':
             filterData['deleted'] = 1;
             filterData['action_history.approverName'] = 1;
+            filterData['action_history.actionType'] = 1;
             leafSearch.getLeafFormQuery().join('action_history');
             headers.push({
                 name: 'Date Cancelled', indicatorID: 'dateCancelled', editable: false, callback: function(data, blob) {

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -140,6 +140,7 @@ function addHeader(column) {
         case 'dateCancelled':
             filterData['deleted'] = 1;
             filterData['action_history.approverName'] = 1;
+            filterData['action_history.actionType'] = 1;
             leafSearch.getLeafFormQuery().join('action_history');
             headers.push({
                 name: 'Date Cancelled', indicatorID: 'dateCancelled', editable: false, callback: function(data, blob) {

--- a/LEAF_Request_Portal/templates/view_status.tpl
+++ b/LEAF_Request_Portal/templates/view_status.tpl
@@ -26,12 +26,13 @@ Title of request: <a href="?a=printview&amp;recordID=<!--{$recordID|strip_tags|e
         <!--{$indicator.time|date_format:"%B %e, %Y. %l:%M %p"}-->
     </td>
     <td>
-<span><b><!--{$indicator.description|sanitize}--></b><!--{if $indicator.userName != ''}--> by <!--{/if}--><!--{$indicator.userName|sanitize}-->
+        <b><!--{$indicator.description|sanitize}--></b>
+        <!--{if $indicator.userName != ''}--> by <!--{/if}--><!--{$indicator.userName|sanitize}-->
         <!--{if $indicator.comment != ''}-->
             <!--{if $indicator.description|lower != 'email sent: '}-->
-                <br />Comment: <!--{$indicator.comment|sanitize}--></span>
+                <br />Comment: <!--{$indicator.comment|sanitize}-->
             <!--{else}-->
-                <br /><!--{$indicator.comment|sanitize}--></span>
+                <br /><!--{$indicator.comment|sanitize}-->
             <!--{/if}-->
         <!--{/if}-->
     </td>


### PR DESCRIPTION
Uses data saved in the new metadata and userMetadata columns to replace display related orgchart lookups.
Lookups are still used for requests pending direct action and for emailing.

**server side:**

Replaces lookupLogin calls with available metadata.
Replaces an orgchart join when getting initiator information with Report Builder queries

**front:**

data.metadata
Form print view, Report Builder. Display of user info associated with orgchart employee format data entries.
For orgchart_employee format entries with metadata, the entered user name will continue to display even if the associated account is disabled. Accounts disabled prior to metadata entry will continue to display disabled account information.

action_history.userMetadata
Request history modal, Report Builder (Approval History, Resolved By, Cancellation Date). Display of user names associated with workflow and admin actions.

notes.userMetadata
Notes panel. Request history modal (notes). Display of user names.

records.userMetadata
Form print view. Some workflow form fields (text only). Report Builder Initiator queries.
The previous join used for initiator information looked up disabled accounts. Records with empty records.userMetadata will display userID, (inactive user)

 
**Testing / Impact**

These updates should not impact access but do have high visibility.
Confirm no function changes or no unusual display changes.
See Jira LEAF-4455 for more details about the above listed areas.

Associated Test DB branch
https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/21
-brings the dev boilerplate up to date with a version containing all metadata columns and adds appropriate metadata values to initially inserted records
-adds tests for records initiator usermetadata values
-adds tests for action_history approver name and userMetadata values