### PR TITLE
Leaf 4486 - prevent user name recycle

### DIFF
--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -258,7 +258,11 @@ class Employee extends Data
 
             $this->prepareArrays($national_employee_uids, $local_array, $national_employees_list, $local_employee_array);
 
+            $users = $this->updateDisabledEmployees();
+
             $local_deleted_employees = array_diff(array_column($local_employees_uid, 'userName'), array_column($national_employees_list, 'userName'));
+
+            $local_deleted_employees = array_merge($local_deleted_employees, $users);
 
             if (!empty($local_deleted_employees)) {
                 $results[] = $this->disableEmployees($local_deleted_employees);
@@ -282,6 +286,25 @@ class Employee extends Data
         }
 
         return $results;
+    }
+
+    private function updateDisabledEmployees(): array
+    {
+        $vars = array();
+        $sql = 'SELECT `userName`
+                FROM `employee`
+                WHERE `deleted` > 0
+                AND LEFT(`userName`, 9) <> "disabled_"';
+
+        $res = $this->db->prepared_query($sql, $vars);
+
+        $userNames = array();
+
+        foreach ($res as $user) {
+            $userNames[] = $user['userName'];
+        }
+
+        return $userNames;
     }
 
     private function disablePortalTables(): void

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -1075,9 +1075,6 @@ class Employee extends Data
         $this->enableEmployee($res[0]['userName']);
         $this->enableAllTables($res[0]['userName']);
         $this->enableAllPortalTables($res[0]['userName']);
-        /* $res = $this->db->prepared_query('UPDATE employee
-                                            SET deleted=:time
-                                            WHERE empUID=:empUID', $vars); */
 
         return true;
     }

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -258,19 +258,6 @@ class Employee extends Data
 
             $this->prepareArrays($national_employee_uids, $local_array, $national_employees_list, $local_employee_array);
 
-            $users = $this->updateDisabledEmployees();
-
-            $local_deleted_employees = array_diff(array_column($local_employees_uid, 'userName'), array_column($national_employees_list, 'userName'));
-
-            $local_deleted_employees = array_merge($local_deleted_employees, $users);
-
-            if (!empty($local_deleted_employees)) {
-                $results[] = $this->disableEmployees($local_deleted_employees);
-
-                $this->disableAllTables();
-                $this->disablePortalTables();
-            }
-
             if (!empty($local_array)) {
                 $results[] = $this->batchEmployeeUpdate($local_array);
             }
@@ -283,6 +270,19 @@ class Employee extends Data
                 $results[] = $this->batchEmployeeDataUpdate($local_data_array);
             }
 
+            $users = $this->updateDisabledEmployees();
+
+            $local_deleted_employees = array_diff(array_column($local_employees_uid, 'userName'), array_column($national_employees_list, 'userName'));
+
+            $local_deleted_employees = array_merge($local_deleted_employees, $users);
+            error_log(print_r($local_deleted_employees, true), 3, '/var/www/php-logs/testing.log');
+
+            if (!empty($local_deleted_employees)) {
+                $results[] = $this->disableEmployees($local_deleted_employees);
+
+                $this->disableAllTables();
+                $this->disablePortalTables();
+            }
         }
 
         return $results;

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -344,7 +344,8 @@ class Employee extends Data
     {
         if (!empty($deleted_employees)) {
             $sql = "UPDATE `employee`
-                    SET `deleted` = UNIX_TIMESTAMP(NOW())
+                    SET `deleted` = UNIX_TIMESTAMP(NOW()),
+                        `userName` = concat('disabled_', `deleted`, '_',  `userName`)
                     WHERE `userName` IN (" . implode(",", array_fill(1, count($deleted_employees), '?')) . ")";
 
             $result = $this->db->prepared_query($sql, array_values($deleted_employees));
@@ -449,7 +450,8 @@ class Employee extends Data
     {
         $vars = array();
         $sql = 'SELECT LOWER(`userName`) AS `userName`
-                FROM `employee`';
+                FROM `employee`
+                WHERE `userName` NOT LIKE "disabled_%"';
 
         $result = $db->prepared_query($sql, $vars);
 
@@ -1442,7 +1444,7 @@ class Employee extends Data
 
         if (count($searchResult) > 0)
         {
-            
+
             $empUID_list = '';
             foreach ($searchResult as $employee)
             {
@@ -1477,7 +1479,7 @@ class Employee extends Data
                 }
                 $finalResult[$currEmpUID]['data'] = $this->getAllData($currEmpUID);
             }
-            
+
             // attach all the assigned positions
             foreach ($result as $employeeData){
                 $finalResult[$employeeData['empUID']]['positionData'][] = $employeeData;

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -586,14 +586,13 @@ class Employee extends Data
                         `userName` = concat('disabled_', `deleted`, '_',  `userName`)
                     WHERE `userName` IN (" . implode(",", array_fill(1, count($deleted_employees), '?')) . ")";
 
-            $result = $this->db->prepared_query($sql, array_values($deleted_employees));
+            $this->db->prepared_query($sql, array_values($deleted_employees));
 
             $return_value = array(
                 'status' => array(
                     'code' => 2,
                     'message' => ''
-                ),
-                'data' => $result
+                )
             );
         } else {
             $return_value = array(

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -258,7 +258,7 @@ class Employee extends Data
 
             $this->prepareArrays($national_employee_uids, $local_array, $national_employees_list, $local_employee_array);
 
-            $local_deleted_employees = array_diff(array_column($local_employees_uid, 'userName'), array_column($national_employees_list, 'userName'));
+            $local_deleted_employees = array_diff(array_column($local_employees_uid['data'], 'userName'), array_column($national_employees_list['data'], 'userName'));
 
             if (!empty($local_deleted_employees)) {
                 $results[] = $this->disableEmployees($local_deleted_employees);


### PR DESCRIPTION
Summary:
A way was needed to prevent Active Directory userNames from being recycled and showing data to the wrong person.

Potential Impact:
Currently there are userNames that have already been recycled. These will get missed and need to be done manually when they come up.
Disabling a user one at a time will use the same process but re-enabling them needs to be programmed yet.

Testing:
This will need to be done on staging. It is possible to set up local to do this I think but it is not currently done. Staging should be set and ready to do this.
To test just run the refreshOrgchartEmployees.php. All instances of userNames in all tables that store the userName in both the orgchart and any portals for that orgchart should be updated to the new format. disabled_ts_userName