### PR TITLE
LEAF 4623 address common logged errors (javascript)

### DIFF
--- a/LEAF_Request_Portal/js/dialogController.js
+++ b/LEAF_Request_Portal/js/dialogController.js
@@ -39,7 +39,9 @@ function dialogController(containerID, contentID, loadIndicatorID, btnSaveID, bt
     $('#' + this.btnCancelID).on('click', function() {
     	t.hide();
     });
-	document.querySelector('#' + this.btnCancelID).removeAttribute('disabled');
+	if(document.getElementById(this.btnCancelID) !== null) {
+		document.getElementById(this.btnCancelID).removeAttribute('disabled');
+	}
     $('button.ui-dialog-titlebar-close').on('click', function() {
         t.hide();
     });

--- a/LEAF_Request_Portal/sources/FormStack.php
+++ b/LEAF_Request_Portal/sources/FormStack.php
@@ -194,6 +194,10 @@ class FormStack
     {
         $indicatorPackage['categoryID'] = $categoryID;
         $indicatorPackage['parentID'] = $parentID;
+        //an issue on conditions editor release could cause some form packets to have 'null' instead of null.
+        if($indicatorPackage['conditions'] === 'null') {
+            $indicatorPackage['conditions'] = null;
+        }
 
         if (is_array($indicatorPackage['options']))
         {

--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -14,6 +14,7 @@
     <!--{foreach from=$form item=indicator}-->
                 <!--{if $indicator.conditions != '' && $indicator.conditions !== 'null'}-->
                 <script type="text/javascript">
+                    formPrintConditions = typeof formPrintConditions === 'undefined' ? {} : formPrintConditions;
                     formPrintConditions["id<!--{$indicator.indicatorID}-->"] = {
                         conditions:<!--{$indicator.conditions|strip_tags}-->,
                         format:'<!--{$indicator.format}-->'

--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -14,11 +14,12 @@
     <!--{foreach from=$form item=indicator}-->
                 <!--{if $indicator.conditions != '' && $indicator.conditions !== 'null'}-->
                 <script type="text/javascript">
-                    formPrintConditions = typeof formPrintConditions === 'undefined' ? {} : formPrintConditions;
-                    formPrintConditions["id<!--{$indicator.indicatorID}-->"] = {
-                        conditions:<!--{$indicator.conditions|strip_tags}-->,
-                        format:'<!--{$indicator.format}-->'
-                    };
+                    if (typeof formPrintConditions !== 'undefined') {
+                        formPrintConditions["id<!--{$indicator.indicatorID}-->"] = {
+                            conditions:<!--{$indicator.conditions|strip_tags}-->,
+                            format:'<!--{$indicator.format}-->'
+                        };
+                    }
                 </script>
                 <!--{/if}-->
                 <!--{if $indicator.format == null || $indicator.format == 'textarea'}-->

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -1237,7 +1237,7 @@
             <!--{$indicator.html}-->
         <!--{/if}-->
         <!--{include file=$subindicatorsTemplate form=$indicator.child depth=$depth+4 recordID=$recordID}-->
-        <!--{if $indicator.conditions != ''}-->
+        <!--{if $indicator.conditions != '' && $indicator.conditions != 'null'}-->
             <script type="text/javascript">
                 formConditions["id<!--{$indicator.indicatorID}-->"] = {
                     conditions:<!--{$indicator.conditions|strip_tags}-->,  //no quotes. send as object


### PR DESCRIPTION
Address some common errors logged in Dynatrace (frontend JS)

1) Prevent a ReferenceError in the LEAF Inbox that occurs if the quick view is displayed

2) Prevent a TypeError that can occur when the dialogController attempts to modify attributes of the cancel button.

3) Prevent a TypeError that could occur due to an incorrect indicators.conditions value.
When the Conditions Editor was released, a brief issue caused form packets to be exported with indicator.conditions set to 'null' instead of null.  This update handles this value for existing forms and prevents it from being set if a form packet that has the value is imported.

**Impact / Testing**

1) Inbox 
Open any form quick view.  Dev Console Reference Error should no longer occur.

2) Potentially anywhere dialogController is used.  This error can be re-produced by modifying a template that uses the dialog controller instance (For example, print_form) and misspelling the id passed for the cancel button.  Confirm that the error no longer occurs.

3) Form Editor - Import Form, Request Editing and Preview areas
Use Adminer to set an indicator's conditions to null (the string, not NULL from dropdown).
-Confirm that no error occurs in the console on the form editing or print views.
-Export the associated form, then re-import it.  Confirm that the value for the imported form is NULL and not 'null'.
