### PR TITLE
LEAF 4258 orgchart group and position, fix report builder display when not found

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2671,17 +2671,27 @@ class Form
                             }
                             break;
                         case 'orgchart_position':
-                            $positionTitle = $this->position->getTitle($item['data']);
-                            $positionData = $this->position->getAllData($item['data']);
-
-                            $item['dataOrgchart'] = $positionData;
-                            $item['dataOrgchart']['positionID'] = $item['data'];
-                            $item['data'] = "{$positionTitle} ({$positionData[2]['data']}-{$positionData[13]['data']}-{$positionData[14]['data']})";
+                            $dataDisplay = "";
+                            if(!empty(trim($item['data']))) {
+                                $positionTitle = $this->position->getTitle($item['data']);
+                                if ($positionTitle !== false) {
+                                    $positionData = $this->position->getAllData($item['data']);
+                                    $dataDisplay = "{$positionTitle} ({$positionData[2]['data']}-{$positionData[13]['data']}-{$positionData[14]['data']})";
+                                    $item['dataOrgchart'] = $positionData;
+                                    $item['dataOrgchart']['positionID'] = $item['data'];
+                                } else {
+                                    $dataDisplay = "Position #" . $item['data'] ." no longer available";
+                                }
+                            }
+                            $item['data'] = $dataDisplay;
                             break;
                         case 'orgchart_group':
-                            $groupTitle = $this->group->getTitle($item['data']);
-
-                            $item['data'] = $groupTitle;
+                            $dataDisplay = "";
+                            if(!empty(trim($item['data']))) {
+                                $groupTitle = $this->group->getTitle($item['data']);
+                                $dataDisplay = $groupTitle !== false ? $groupTitle : "Group #" . $item['data'] ." no longer available";
+                            }
+                            $item['data'] = $dataDisplay;
                             break;
                         case 'raw_data':
                             if($indicators[$item['indicatorID']]['htmlPrint'] != '') {

--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -979,39 +979,46 @@
             <div id="indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->" style="padding: 0px">
             <script>
             $(function() {
-                $.ajax({
-                    type: 'GET',
-                    url: "<!--{$orgchartPath}-->/api/position/<!--{$indicator.value|strip_tags}-->",
-                    dataType: 'json',
-                    success: function(data) {
-                        $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').html('<b>' + data.title + '</b>'
-                            /* Pay Plan, Series, Pay Grade */ + '<br />' + data[2].data + '-' + data[13].data + '-' + data[14].data);
+                const displayValue = '<!--{$indicator.displayedValue|strip_tags}-->';
+                if(displayValue !== '') {
+                    $.ajax({
+                        type: 'GET',
+                        url: "<!--{$orgchartPath}-->/api/position/<!--{$indicator.value|strip_tags}-->",
+                        dataType: 'json',
+                        success: function(data) {
+                            $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').html('<b>' + data.title + '</b>'
+                                /* Pay Plan, Series, Pay Grade */ + '<br />' + data[2].data + '-' + data[13].data + '-' + data[14].data);
 
-                        if(data[3].data != '') {
-                            for(i in data[3].data) {
-                                var pdLink = document.createElement('a');
-                                pdLink.innerHTML = data[3].data[i];
-                                pdLink.setAttribute('href', '<!--{$orgchartPath}-->/file.php?categoryID=2&UID=<!--{$indicator.value|strip_tags}-->&indicatorID=3&file=' + encodeURIComponent(data[3].data[i]));
-                                pdLink.setAttribute('class', 'printResponse');
-                                pdLink.setAttribute('target', '_blank');
+                            if(data[3].data != '') {
+                                for(i in data[3].data) {
+                                    var pdLink = document.createElement('a');
+                                    pdLink.innerHTML = data[3].data[i];
+                                    pdLink.setAttribute('href', '<!--{$orgchartPath}-->/file.php?categoryID=2&UID=<!--{$indicator.value|strip_tags}-->&indicatorID=3&file=' + encodeURIComponent(data[3].data[i]));
+                                    pdLink.setAttribute('class', 'printResponse');
+                                    pdLink.setAttribute('target', '_blank');
 
-                                $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append('<br />Position Description: ');
-                                $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append(pdLink);
+                                    $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append('<br />Position Description: ');
+                                    $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append(pdLink);
+                                }
                             }
-                        }
 
-                        br = document.createElement('br');
-                        $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append(br);
+                            br = document.createElement('br');
+                            $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append(br);
 
-                        var ocLink = document.createElement('div');
-                        ocLink.innerHTML = '<img src="dynicons/?img=preferences-system-windows.svg&w=32" alt="" /> View Details in Org. Chart';
-                        ocLink.setAttribute('onclick', "window.open('<!--{$orgchartPath}-->/?a=view_position&positionID=<!--{$indicator.value|strip_tags}-->','Resource_Request','width=870,resizable=yes,scrollbars=yes,menubar=yes');");
-                        ocLink.setAttribute('class', 'buttonNorm');
-                        ocLink.setAttribute('style', 'margin-top: 8px');
-                        $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append(ocLink);
-                    },
-                    cache: false
-                });
+                            var ocLink = document.createElement('div');
+                            ocLink.innerHTML = '<img src="dynicons/?img=preferences-system-windows.svg&w=32" alt="" /> View Details in Org. Chart';
+                            ocLink.setAttribute('onclick', "window.open('<!--{$orgchartPath}-->/?a=view_position&positionID=<!--{$indicator.value|strip_tags}-->','Resource_Request','width=870,resizable=yes,scrollbars=yes,menubar=yes');");
+                            ocLink.setAttribute('class', 'buttonNorm');
+                            ocLink.setAttribute('style', 'margin-top: 8px');
+                            $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').append(ocLink);
+                        },
+                        cache: false
+                    });
+                } else {
+                    $('#indata_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->').html(
+                        `Position #<!--{$indicator.value|strip_tags}--> no longer available`
+                    );
+                }
             });
             </script>
             Loading...


### PR DESCRIPTION
Orgchart group and orgchart position format questions can display incorrectly (false) or oddly (--) in the report builder if the group or position associated with the data entry is not found.

server-side:
Value that is set has been updated so that the Report Builder cells will display nothing if a group or position value is empty and 'group/pos #id no longer available' if it is not empty but the group/pos is not found by lookup.   For positions, further lookups are also not completed if the initial position title lookup does not find a position.

front:
Adds some logic to form editing areas to avoid additional lookups if a position title is not found and displays 'position #id no longer available' instead of 'false' and a position card with a link to a broken page.

**Testing / Impact**
Report Builder
Cells for groups should not display 'false' if a group value is empty or no longer available.
Cells for positions should not display (--) if a position is no longer available.

Form Editing areas
Position value should not display 'false' and a broken link if a position is no longer available.
