### PR TITLE
LEAF 4600 (INC36349916) - email editor CSS update

### DIFF
--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -26,11 +26,11 @@
     margin-bottom: 1px;
     height: 100vh !important;
 }
-#divSubject .CodeMirror,
+#divSubject .CodeMirror:not(.CodeMirror-fullscreen),
 #divSubject .CodeMirror-merge {
     height: 80px !important;
 }
-#emailBodyCode .CodeMirror,
+#emailBodyCode .CodeMirror:not(.CodeMirror-fullscreen),
 #emailBodyCode .CodeMirror-merge {
     height: 400px !important;
 }


### PR DESCRIPTION
Updates a CSS definition that had been causing email template subject and body full screen modes to display incorrectly.

**Testing / Impact**

Admin -> Email Template Editor
F11 (depending on computer, fn + F11), should toggle full screen display with 100 view height.