### PR TITLE
LEAF 4543 fix display property on file upload error response

### DIFF
--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -785,6 +785,7 @@
                                         statusEl.innerHTML = `${err?.responseText ? err?.responseText : ''}`;
                                     }
                                     statusEl.classList.add('status_error');
+                                    statusEl.style.display = 'block';
                                 },
                                 processData: false,
                                 contentType: false


### PR DESCRIPTION
Fixes an issue that caused error messages associated with file upload formats (files, images) to remain hidden.

**Testing / Impact**

File upload, images format request question types.

- Attempt to upload a file or image greater than 20MB
- Attempt to upload a file or image with a malformed suffix (for example .txtx, .pngg)

A suitable error message should be displayed for file upload related errors.
