### PR TITLE
Leaf 4624 - db update for disabled users

### DIFF
--- a/docker/mysql/db/db_upgrade/orgchart/Update_OC_DB_2024092100-2025013100.sql
+++ b/docker/mysql/db/db_upgrade/orgchart/Update_OC_DB_2024092100-2025013100.sql
@@ -1,0 +1,22 @@
+START TRANSACTION;
+
+ALTER TABLE `cache`
+CHANGE `data` `data` text COLLATE 'utf8mb4_general_ci' NOT NULL AFTER `cacheID`,
+COLLATE 'utf8mb4_general_ci';
+
+UPDATE `settings` SET `data` = '2025013100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+
+/**** Revert DB *****
+START TRANSACTION;
+
+ALTER TABLE `cache`
+CHANGE `data` `data` text COLLATE 'utf8mb3_general_ci' NOT NULL AFTER `cacheID`,
+COLLATE 'utf8mb3_general_ci';
+
+UPDATE `settings` SET `data` = '2024092100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
update cache table in the orgcharts to use utf8mb4 for the data field and table

testing:
once the update is complete the field should be utf8mb4 compatible.