### PR TITLE
LEAF 4620 import spreadsheet - new form

### DIFF
--- a/LEAF_Request_Portal/api/controllers/FormEditorController.php
+++ b/LEAF_Request_Portal/api/controllers/FormEditorController.php
@@ -177,7 +177,7 @@ class FormEditorController extends RESTfulResponse
                 return $formEditor->createForm(
                     XSSHelpers::sanitizeHTML($_POST['name']),
                     XSSHelpers::sanitizeHTML($_POST['description']),
-                    XSSHelpers::sanitizeHTML($_POST['parentID'])
+                    XSSHelpers::sanitizeHTML($_POST['parentID'] ?? "")
                 );
             });
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
@@ -509,6 +509,7 @@
                 formData.description,
                 function(categoryID) {
                     newCategoryID = categoryID.replace(/"/g, "");
+                    portalAPI.FormEditor.publishForm(newCategoryID); //this is not async
                     if (workflowID > 0) {
                         portalAPI.FormEditor.assignFormWorkflow(
                             newCategoryID.replace(/"/g, ""),
@@ -743,6 +744,7 @@
                     makeIndicator();
                 },
                 function (err) {
+                    console.log(err)
                 }
             );
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
@@ -509,7 +509,7 @@
                 formData.description,
                 function(categoryID) {
                     newCategoryID = categoryID.replace(/"/g, "");
-                    portalAPI.FormEditor.publishForm(newCategoryID); //this is not async
+                    portalAPI.FormEditor.setVisibility(newCategoryID); //this is not async, default visibility 0
                     if (workflowID > 0) {
                         portalAPI.FormEditor.assignFormWorkflow(
                             newCategoryID.replace(/"/g, ""),

--- a/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
@@ -509,7 +509,6 @@
                 formData.description,
                 function(categoryID) {
                     newCategoryID = categoryID.replace(/"/g, "");
-                    portalAPI.FormEditor.setVisibility(newCategoryID); //this is not async, default visibility 0
                     if (workflowID > 0) {
                         portalAPI.FormEditor.assignFormWorkflow(
                             newCategoryID.replace(/"/g, ""),

--- a/app/libs/js/portal/LEAFPortalAPI.js
+++ b/app/libs/js/portal/LEAFPortalAPI.js
@@ -434,37 +434,27 @@ var PortalFormEditorAPI = function (baseAPIURL) {
                 data: {
                     "name": name,
                     "description": description,
-                    "parentID": "",
                     CSRFToken: csrfToken
                 }
-            })
-                .done(function (msg) {
+            }).done(function (msg) {
+                const newCategoryID = msg.replace(/"/g, "");
+                $.ajax({
+                    method: 'POST',
+                    url: apiURL + '/formVisible',
+                    dataType: "text",
+                    data: {
+                        "categoryID": newCategoryID,
+                        "visible": 0,
+                        CSRFToken: csrfToken
+                    }
+                }).done(function() {
                     onSuccess(msg);
-                })
-                .fail(function (err) {
-                    onFail(err);
+                }).fail(function(err) {
+                    onFail(err)
                 });
-        },
 
-        setVisibility = function (categoryID, visibility = "0") {
-            var postURL = apiURL + '/formVisible';
-
-            $.ajax({
-                method: 'POST',
-                url: postURL,
-                dataType: "text",
-                data: {
-                    "categoryID": categoryID,
-                    "visible": visibility,
-                    CSRFToken: csrfToken
-                },
-                onSuccess(res) {
-                    console.log(res)
-                },
-                error(err) {
-                    console.log(err)
-                },
-                async: false
+            }).fail(function (err) {
+                onFail(err);
             });
         },
 
@@ -588,7 +578,6 @@ var PortalFormEditorAPI = function (baseAPIURL) {
         getBaseAPIURL: getBaseAPIURL,
         assignFormWorkflow: assignFormWorkflow,
         createCustomForm: createCustomForm,
-        setVisibility: setVisibility,
         createFormIndicator: createFormIndicator,
         getIndicator: getIndicator,
         getIndicatorEditor: getIndicatorEditor,

--- a/app/libs/js/portal/LEAFPortalAPI.js
+++ b/app/libs/js/portal/LEAFPortalAPI.js
@@ -434,6 +434,7 @@ var PortalFormEditorAPI = function (baseAPIURL) {
                 data: {
                     "name": name,
                     "description": description,
+                    "parentID": "",
                     CSRFToken: csrfToken
                 }
             })
@@ -443,6 +444,27 @@ var PortalFormEditorAPI = function (baseAPIURL) {
                 .fail(function (err) {
                     onFail(err);
                 });
+        },
+
+        publishForm = function (categoryID) {
+            var postURL = apiURL + '/formVisible';
+            $.ajax({
+                method: 'POST',
+                url: postURL,
+                dataType: "text",
+                data: {
+                    "categoryID": categoryID,
+                    "visible": "0",
+                    CSRFToken: csrfToken
+                },
+                onSuccess(res) {
+                    console.log(res)
+                },
+                error(err) {
+                    console.log(err)
+                },
+                async: false
+            });
         },
 
         /**
@@ -565,6 +587,7 @@ var PortalFormEditorAPI = function (baseAPIURL) {
         getBaseAPIURL: getBaseAPIURL,
         assignFormWorkflow: assignFormWorkflow,
         createCustomForm: createCustomForm,
+        publishForm: publishForm,
         createFormIndicator: createFormIndicator,
         getIndicator: getIndicator,
         getIndicatorEditor: getIndicatorEditor,

--- a/app/libs/js/portal/LEAFPortalAPI.js
+++ b/app/libs/js/portal/LEAFPortalAPI.js
@@ -446,15 +446,16 @@ var PortalFormEditorAPI = function (baseAPIURL) {
                 });
         },
 
-        publishForm = function (categoryID) {
+        setVisibility = function (categoryID, visibility = "0") {
             var postURL = apiURL + '/formVisible';
+
             $.ajax({
                 method: 'POST',
                 url: postURL,
                 dataType: "text",
                 data: {
                     "categoryID": categoryID,
-                    "visible": "0",
+                    "visible": visibility,
                     CSRFToken: csrfToken
                 },
                 onSuccess(res) {
@@ -587,7 +588,7 @@ var PortalFormEditorAPI = function (baseAPIURL) {
         getBaseAPIURL: getBaseAPIURL,
         assignFormWorkflow: assignFormWorkflow,
         createCustomForm: createCustomForm,
-        publishForm: publishForm,
+        setVisibility: setVisibility,
         createFormIndicator: createFormIndicator,
         getIndicator: getIndicator,
         getIndicatorEditor: getIndicatorEditor,


### PR DESCRIPTION
Add null coalesce to where parentID POST value is used.  At some point this started causing new form creation to fail (method seemed to be getting explicit null, and parentID cannot be null).

Add a call, abstracted within the portal API createCustomForm method, to update the form visible value to 0 after it is created.  New forms have a default visibility of -1 (unpublished) and requests cannot be made for them.


**Testing / Impact**
Admin -> Toolbox -> Import Spreadsheet

Confirm that new forms and associated requests can be created using the report interface and an excel template with headers and data.
Confirm requests for existing forms also continue to be created as expected.

