### PR TITLE
LEAF 4639 - custom data orgchart empUID

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2660,16 +2660,19 @@ class Form
                                 }
                             }
                             break;
-                        case 'orgchart_employee': //report builder cells
+                        case 'orgchart_employee': //report builder cells, form/query
                             $dataDisplay = "";
-                            if (isset($item['metadata'])) {
-                                $orgchartInfo = json_decode($item['metadata'], true);
-                                if(!empty(trim($orgchartInfo['lastName']))) {
-                                    $dataDisplay = "{$orgchartInfo['firstName']} {$orgchartInfo['lastName']}";
-                                    $item['dataOrgchart'] = $orgchartInfo;
-                                } else {
-                                    $dataDisplay = "Employee #" . $item['data'] ." no longer available";
+                            if(!empty($item['data'])) {
+                                $orgchartInfo = array('empUID' => (int)$item['data']);
+                                if (isset($item['metadata'])) {
+                                    $orgchartInfo = array_merge($orgchartInfo, json_decode($item['metadata'], true));
+                                    if(!empty(trim($orgchartInfo['lastName']))) {
+                                        $dataDisplay = "{$orgchartInfo['firstName']} {$orgchartInfo['lastName']}";
+                                    } else {
+                                        $dataDisplay = "Employee #" . $item['data'] ." no longer available";
+                                    }
                                 }
+                                $item['dataOrgchart'] = $orgchartInfo;
                             }
                             $item['data'] = $dataDisplay;
                             break;


### PR DESCRIPTION
Re-add empUID in custom data section.

Associated Go update is under
https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/36


**Testing / Impact**

Create a Report Builder report that gets orgchart formats (with entries).  Use JSON button to get query url and open it in a new tab.
empUID should exist on the associated id__orgchart objects.
Associated Go test above should pass on this branch.



