### PR TITLE
LEAF 4625 - history/approval info

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -1300,7 +1300,7 @@
             let workflows = '';
 
             for (let i in res.data) {
-                workflows += res.data[i].description + " (step#" + res.data[i].stepID + ")<br />";
+                workflows += res.data[i].description + "<br />";
             }
 
             if (res.status.code == 2 && res.data.length) {

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -1297,11 +1297,10 @@
     function deleteActionType(actionType) {
         // find out if this action is being used in a workflow currently
         getUsedActionType(actionType, function (res) {
-            console.log(res);
             let workflows = '';
 
             for (let i in res.data) {
-                workflows += res.data[i].description + "<br />";
+                workflows += res.data[i].description + " (step#" + res.data[i].stepID + ")<br />";
             }
 
             if (res.status.code == 2 && res.data.length) {

--- a/LEAF_Request_Portal/sources/View.php
+++ b/LEAF_Request_Portal/sources/View.php
@@ -96,7 +96,8 @@ class View
                 } elseif(!empty($tmp['stepTitle']) && $tmp['dependencyID'] < 0) {
                     $packet['description'] = $tmp['stepTitle'] . ': ' . $tmp['actionText'];
                 } else {
-                    $packet['description'] = $tmp['description'] . ': ' . $tmp['actionText'];
+                    $desc = empty($tmp['description']) ? 'Action' : $tmp['description'];
+                    $packet['description'] = $desc . ': ' . $tmp['actionText'];
                 }
 
                 $packet['comment'] = $tmp['comment'];

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -613,7 +613,8 @@ class Workflow
         $vars = array(
             ':nonWorkflowActions' => implode(",", $this->nonWorkflowActions)
         );
-        $qSQL = "SELECT * FROM actions WHERE NOT FIND_IN_SET(actionType, :nonWorkflowActions) AND deleted=0 ORDER BY actionText";
+        $qSQL = "SELECT `actionType`, `actionText`, `actionTextPasttense`, `actionIcon`, `actionAlignment`, `sort`, `fillDependency`, `deleted`
+            FROM actions WHERE NOT FIND_IN_SET(actionType, :nonWorkflowActions) AND deleted=0 ORDER BY actionText";
         $res = $this->db->prepared_query($qSQL, $vars);
 
         return $res;
@@ -1523,7 +1524,8 @@ class Workflow
         $vars = array(
             ':systemAction' => implode(",", $this->systemAction)
         );
-        $qSQL = "SELECT * FROM actions WHERE NOT FIND_IN_SET(actionType, :systemAction) AND NOT (deleted = 1)";
+        $qSQL = "SELECT `actionType`, `actionText`, `actionTextPasttense`, `actionIcon`, `actionAlignment`, `sort`, `fillDependency`, `deleted`
+            FROM actions WHERE NOT FIND_IN_SET(actionType, :systemAction) AND NOT (deleted = 1)";
         $res = $this->db->prepared_query($qSQL, $vars);
 
         return $res;

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -30,6 +30,25 @@ class Workflow
 
     private $dataActionLogger;
 
+    private $systemAction = array(
+        'approve',
+        'concur',
+        'defer',
+        'disapprove',
+        'sendback',
+        'submit',
+        'sign',
+        'deleted',
+        'changeInitiator',
+        'move',
+    );
+    //request cancel, change initiator, change step
+    private $nonWorkflowActions = array(
+        'deleted',
+        'changeInitiator',
+        'move',
+    );
+
     public function __construct($db, $login, $workflowID = 0)
     {
         $this->db = $db;
@@ -591,8 +610,11 @@ class Workflow
 
     public function getActions()
     {
-        $vars = array();
-        $res = $this->db->prepared_query('SELECT * FROM actions WHERE deleted=0 ORDER BY actionText', $vars);
+        $vars = array(
+            ':nonWorkflowActions' => implode(",", $this->nonWorkflowActions)
+        );
+        $qSQL = "SELECT * FROM actions WHERE NOT FIND_IN_SET(actionType, :nonWorkflowActions) AND deleted=0 ORDER BY actionText";
+        $res = $this->db->prepared_query($qSQL, $vars);
 
         return $res;
     }
@@ -1498,8 +1520,11 @@ class Workflow
     //returns user created actions
     public function getUserActions()
     {
-        $vars = array();
-        $res = $this->db->prepared_query("SELECT * FROM actions WHERE actionType NOT IN ('approve', 'concur', 'defer', 'disapprove', 'sendback', 'submit') AND NOT (deleted = 1)", $vars);
+        $vars = array(
+            ':systemAction' => implode(",", $this->systemAction)
+        );
+        $qSQL = "SELECT * FROM actions WHERE NOT FIND_IN_SET(actionType, :systemAction) AND NOT (deleted = 1)";
+        $res = $this->db->prepared_query($qSQL, $vars);
 
         return $res;
     }
@@ -1526,9 +1551,7 @@ class Workflow
             return 'Admin access required';
         }
 
-        $systemAction = array('approve', 'concur', 'defer', 'disapprove', 'sendback', 'submit', 'sign');
-
-        if (in_array($actionType, $systemAction))
+        if (in_array($actionType, $this->systemAction))
         {
             return 'System Actions cannot be edited.';
         }
@@ -1577,9 +1600,8 @@ class Workflow
         {
             return 'Admin access required';
         }
-        $systemAction = array('approve', 'concur', 'defer', 'disapprove', 'sendback', 'submit', 'sign');
 
-        if (in_array($actionType, $systemAction))
+        if (in_array($actionType, $this->systemAction))
         {
             return 'System Actions cannot be removed.';
         }

--- a/LEAF_Request_Portal/sources/WorkflowRoute.php
+++ b/LEAF_Request_Portal/sources/WorkflowRoute.php
@@ -42,7 +42,7 @@ class WorkflowRoute
     public function getUsedAction(string $action): array
     {
         $vars = array(':actionType' => $action);
-        $sql = 'SELECT `description`, `stepID`
+        $sql = 'SELECT `description`
                 FROM `workflow_routes`
                 LEFT JOIN `workflows` USING (`workflowID`)
                 WHERE `actionType` = :actionType';

--- a/LEAF_Request_Portal/sources/WorkflowRoute.php
+++ b/LEAF_Request_Portal/sources/WorkflowRoute.php
@@ -42,7 +42,7 @@ class WorkflowRoute
     public function getUsedAction(string $action): array
     {
         $vars = array(':actionType' => $action);
-        $sql = 'SELECT `description`
+        $sql = 'SELECT `description`, `stepID`
                 FROM `workflow_routes`
                 LEFT JOIN `workflows` USING (`workflowID`)
                 WHERE `actionType` = :actionType';

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024112500-2025020100.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2024112500-2025020100.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+INSERT INTO `actions` (`actionType`, `actionText`, `actionTextPasttense`) VALUES
+('deleted', 'Cancel', 'Cancelled'),
+('move', 'Change Step', 'Changed Step'),
+('changeInitiator', 'Change Initiator', 'Changed Initiator');
+
+UPDATE `settings` SET `data` = '2025020100' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;


### PR DESCRIPTION
**Description**

If a request initiator is changed, a request step is changed, or a request is cancelled, the Request History modal displays
'Action by username'.  Step change and initiator change include additional comments to clarify the action.  Cancel does not, which makes what has occurred unclear.  In the report builder, the approval history displays as 'null' for these changes.

This update adds 'move', 'changeInitiator', and 'deleted' actionTypes and associated text to the actions table.
These actionType names correspond to the entries that are already added to the actions_history table.
Prod was queried for existing custom workflow actions.  One active 'Move' actiontype was found and updated to MoveRequest.

-----
**Impact / Testing**

**Request History modal** should show the below information on initiator change, step move and cancel

Action: Change Initiator by username
Action: Change Step by username
Action: Cancel by username


**Report Builder (approval history)** should show below information instead of 'null'

Changed Initiator
Changed Step
Cancelled


**Workflow Editor -> Edit Actions**

The Built-In actions below should not show in the _Actions Editor_
'approve', 'concur', 'defer', 'disapprove', 'sendback', 'submit', 'sign', 'deleted', 'changeInitiator', 'move'

**Workflow Editor -> Connect two steps**

The _Create New Workflow Action modal_ should not include the actions with **actionTypes** 'move', 'deleted', 'changeInitiator'.

