### PR TITLE
Leaf 4647 - Fix subsequent JS getWorkflow() calls

### DIFF
--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -464,6 +464,10 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         },
                     });
                 }
+                else {
+                    workflowStepModule[step.stepID][step.stepModules[x].moduleName].init(step, rootURL);
+                    $(`#form_dep_container${step.dependencyID} .button`).attr("disabled", false);
+                }
             }
         }
 


### PR DESCRIPTION
This resolves an issue in workflow.js where subsequent calls to workflow.getWorkflow() don't render inlined form fields correctly.

Automated test added: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/38/files#diff-fec443a7fb26885985db23970be7c5dc8cade8533e013fc6948fb080fd4f53d7

## Potential Impact
Minimal because this resolves an incomplete if-else clause.

## Testing
- [ ] Automated tests pass