### PR TITLE
LEAF 4634 - email editor wyswyg

### DIFF
--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -426,6 +426,13 @@ label[for="template_file_select"] {
     font-size: .9rem;
 }
 
+
+#btn_useTrumbowyg, #btn_useCodeMirror {
+    display: none;
+}
+#btn_useTrumbowyg.show_button, #btn_useCodeMirror.show_button {
+    display: block;
+}
 #controls {
     width: 100%;
     padding: 0.5rem;

--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -34,6 +34,15 @@
 #emailBodyCode .CodeMirror-merge {
     height: 400px !important;
 }
+#emailBodyCode + div .trumbowyg-editor {
+    background-color: #fff;
+}
+#editor_trumbowyg_saving {
+    background-color: #fff;
+    padding: 0.5rem;
+    height:360px;
+    display:none;
+}
 .CodeMirror-code {
     font-size: .7rem;
 }

--- a/LEAF_Request_Portal/admin/index.php
+++ b/LEAF_Request_Portal/admin/index.php
@@ -289,7 +289,8 @@ switch ($action) {
             $t_form->right_delimiter = '}-->';
 
             $main->assign('useUI', true);
-            $main->assign('javascripts', array(APP_JS_PATH . '/codemirror/lib/codemirror.js',
+            $main->assign('javascripts', array(APP_JS_PATH . '/jquery/trumbowyg/plugins/colors/trumbowyg.colors.min.js',
+                                                APP_JS_PATH . '/codemirror/lib/codemirror.js',
                                                 APP_JS_PATH . '/codemirror/mode/xml/xml.js',
                                                 APP_JS_PATH . '/codemirror/mode/javascript/javascript.js',
                                                 APP_JS_PATH . '/codemirror/mode/css/css.js',
@@ -301,7 +302,8 @@ switch ($action) {
                                                 APP_JS_PATH . '/codemirror/addon/search/matchesonscrollbar.js',
                                                 APP_JS_PATH . '/codemirror/addon/display/fullscreen.js',
             ));
-            $main->assign('stylesheets', array(APP_JS_PATH . '/codemirror/lib/codemirror.css',
+            $main->assign('stylesheets', array(APP_JS_PATH . '/jquery/trumbowyg/plugins/colors/ui/trumbowyg.colors.min.css',
+                                                APP_JS_PATH . '/codemirror/lib/codemirror.css',
                                                 APP_JS_PATH . '/codemirror/addon/dialog/dialog.css',
                                                 APP_JS_PATH . '/codemirror/addon/scroll/simplescrollbars.css',
                                                 APP_JS_PATH . '/codemirror/addon/search/matchesonscrollbar.css',

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -64,7 +64,7 @@
                     <div id="codeCompare"></div>
                 </div>
                 <div>
-                    <textarea id="editor_code" aria-hidden="true" style="display:none;"></textarea>
+                    <textarea id="editor_trumbowyg" aria-hidden="true" style="display:none;"></textarea>
                 </div>
                 <div class="email-template-variables">
                     <fieldset>
@@ -204,11 +204,11 @@
 
                     <button type="button" id="btn_useTrumbowyg"
                         class="usa-button usa-button--outline edit_only show_button"
-                        onclick="emailEditorWYSWYG()">Use Preview Editor
+                        onclick="useTrumbowygEmailEditor()">Use Preview Editor
                     </button>
                     <button type="button" id="btn_useCodeMirror"
                         class="usa-button usa-button--outline edit_only"
-                        onclick="rawEmailEditorClick()">Use Code Editor
+                        onclick="useCodeEmailEditor(true)">Use Code Editor
                     </button>
 
                     <button type="button"
@@ -661,7 +661,7 @@
 
     // compares the current file to the default file content
     function compare() {
-        rawEmailEditorClick();
+        useCodeEmailEditor();
         const bodyData = getCodeEditorValue(codeEditor);
         const subjectData = getCodeEditorValue(subjectEditor);
         $('.CodeMirror').remove();
@@ -794,6 +794,7 @@
     * @param {string} emailCcFile - eg LEAF_send_back_emailCc.tpl
     */
     function loadContent(name, file, subjectFile, emailToFile, emailCcFile) {
+        useCodeEmailEditor();
         if (!file) {
             if(file === null && currentFile && codeEditor) { //from compare view
                 const mergeViewBodyValue = getCodeEditorValue(codeEditor);
@@ -1068,6 +1069,7 @@
      * Purpose: Initiate the CodeMirror editor functions for the body and subject fields
      */
     function initEditor() {
+        console.log("init")
         codeEditor = CodeMirror.fromTextArea(document.getElementById("code"), {
             mode: "htmlmixed",
             lineNumbers: true,
@@ -1208,13 +1210,11 @@
     }
 
     //jQuery plugins for WYSWYG.
-    function emailEditorWYSWYG() {
-        toggleEditorButtons(true);
-        let elCodeMirror = document.getElementById('emailBodyCode');
-        if (elCodeMirror !== null) {
-            elCodeMirror.style.display = 'none';
-        }
-        $('#editor_code').trumbowyg({
+    function useTrumbowygEmailEditor() {
+        toggleEditorElements(true);
+        const data = getCodeEditorValue(codeEditor);
+        $('#editor_trumbowyg').val(data);
+        $('#editor_trumbowyg').trumbowyg({
             resetCss: true,
             btns: ['formatting', 'bold', 'italic', 'underline', '|',
                 'unorderedList', 'orderedList', '|',
@@ -1227,8 +1227,8 @@
             'margin': '0.5rem 0'
         });
         $('.trumbowyg-editor, .trumbowyg-texteditor').css({
-            'min-height': '100px',
-            'height': '100px',
+            'min-height': '360px',
+            'height': '360px',
             'padding': '1rem',
             'resize': 'vertical',
         });
@@ -1304,25 +1304,36 @@
         document.getElementById('btn_useCodeMirror').focus();
     }
 
-    function rawEmailEditorClick() {
-        toggleEditorButtons(false);
-        $('#editor_code').trumbowyg('destroy');
-        $('#editor_code').hide();
-        let elCodeMirror = document.getElementById('emailBodyCode');
-        if (elCodeMirror !== null) {
-            elCodeMirror.style.display = 'block';
+    function useCodeEmailEditor(refreshCodeMirror = false) {
+        //TODO: this removes html and some other tags.
+        //if element associated with Trumbowyg exists, update codemirror element before proceeding.
+        const elTrumbow = document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea');
+        if(elTrumbow !== null) {
+            console.log("set trumbow value to cm content", elTrumbow.value);
+            codeEditor.setValue(elTrumbow.value);
+            toggleEditorElements(false);
+            $('#editor_trumbowyg').trumbowyg('destroy');
         }
-        //document.getElementById('btn_useTrumbowyg').focus();
+        if(refreshCodeMirror === true) {
+            $('.CodeMirror').each(function(i, el) {
+                el.CodeMirror.refresh();
+            });
+        }
     }
 
-    function toggleEditorButtons(showTrumbow = true) {
+    //show or hide elements associated with Trumbowyg(true) and CodeMirror for email body editing
+    function toggleEditorElements(showTrumbow = true) {
         let btnUseTrumbow = document.getElementById('btn_useTrumbowyg');
         let btnUseCodeMirror = document.getElementById('btn_useCodeMirror');
         if(btnUseTrumbow !== null && btnUseCodeMirror !== null) {
             if (showTrumbow === true) {
+                $('#editor_trumbowyg').show();
+                $('#emailLists, #subject, #divSubject, #emailBodyCode').hide();
                 btnUseCodeMirror.classList.add('show_button');
                 btnUseTrumbow.classList.remove('show_button');
             } else {
+                $('#editor_trumbowyg').hide();
+                $('#emailLists, #subject, #divSubject, #emailBodyCode').show();
                 btnUseCodeMirror.classList.remove('show_button');
                 btnUseTrumbow.classList.add('show_button');
             }

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -353,6 +353,13 @@
     * Displays last save time, updates current*Content values, and calls saveFileHistory at success.
     */
     function save() {
+        let reloadTrumbow = false;
+        const elTrumbow = document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea');
+        if(elTrumbow !== null) {
+            useCodeEmailEditor(true);
+            reloadTrumbow = true;
+        }
+
         const emailToData = document.getElementById('emailToCode').value;
         const emailCcData = document.getElementById('emailCcCode').value;
         const subject = getCodeEditorValue(subjectEditor);
@@ -361,6 +368,9 @@
         const hasAnyChanges = hasContentChanged(emailToData, emailCcData, subject, data);
         if (!hasAnyChanges) {
             alert('There are no changes to save.');
+            if(reloadTrumbow === true) {
+                useTrumbowygEmailEditor();
+            }
         } else {
             $.ajax({
                 type: 'POST',
@@ -388,6 +398,9 @@
                         saveFileHistory();
                         $('#restore_original, #btn_compare').addClass('modifiedTemplate');
                         $(`.template_files a[data-file="${currentFile}"] + span`).addClass('custom_file');
+                        if(reloadTrumbow === true) {
+                            useTrumbowygEmailEditor();
+                        }
                     }
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
@@ -1305,6 +1318,7 @@
     }
 
     function useCodeEmailEditor(refreshCodeMirror = false) {
+        console.log("swapping to codemirror");
         //TODO: this removes html and some other tags.
         //if element associated with Trumbowyg exists, update codemirror element before proceeding.
         const elTrumbow = document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea');
@@ -1313,6 +1327,7 @@
             codeEditor.setValue(elTrumbow.value);
             toggleEditorElements(false);
             $('#editor_trumbowyg').trumbowyg('destroy');
+            $('#editor_trumbowyg').hide();
         }
         if(refreshCodeMirror === true) {
             $('.CodeMirror').each(function(i, el) {
@@ -1327,12 +1342,10 @@
         let btnUseCodeMirror = document.getElementById('btn_useCodeMirror');
         if(btnUseTrumbow !== null && btnUseCodeMirror !== null) {
             if (showTrumbow === true) {
-                $('#editor_trumbowyg').show();
                 $('#emailLists, #subject, #divSubject, #emailBodyCode').hide();
                 btnUseCodeMirror.classList.add('show_button');
                 btnUseTrumbow.classList.remove('show_button');
             } else {
-                $('#editor_trumbowyg').hide();
                 $('#emailLists, #subject, #divSubject, #emailBodyCode').show();
                 btnUseCodeMirror.classList.remove('show_button');
                 btnUseTrumbow.classList.add('show_button');

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -354,8 +354,7 @@
     */
     function save() {
         let reloadTrumbow = false;
-        const elTrumbow = document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea');
-        if(elTrumbow !== null) {
+        if(trumbowygIsActive()) {
             useCodeEmailEditor(true);
             reloadTrumbow = true;
         }
@@ -523,6 +522,7 @@
     * @param {bool} updateURL - whether to update URL params and add to URL history
     */
     function compareHistoryFile(fileName = '', parentFile = '', updateURL = false) {
+        useCodeEmailEditor(true);
         const initialBodyData = getCodeEditorValue(codeEditor);
         $('#bodyarea').off('keydown');
         $('#file_replace_file_btn').off('click');
@@ -807,7 +807,11 @@
     * @param {string} emailCcFile - eg LEAF_send_back_emailCc.tpl
     */
     function loadContent(name, file, subjectFile, emailToFile, emailCcFile) {
-        useCodeEmailEditor();
+        let reloadTrumbow = false;
+        if(trumbowygIsActive()) {
+            useCodeEmailEditor(true);
+            reloadTrumbow = true;
+        }
         if (!file) {
             if(file === null && currentFile && codeEditor) { //from compare view
                 const mergeViewBodyValue = getCodeEditorValue(codeEditor);
@@ -884,6 +888,9 @@
                     currentEmailCcContent = res.emailCcFile;
                     $("#emailToCode").val(currentEmailToContent);
                     $("#emailCcCode").val(currentEmailCcContent);
+                    if(reloadTrumbow === true) {
+                        useTrumbowygEmailEditor();
+                    }
                 } else {
                     res?.file === undefined ?
                         console.error('file not found') :
@@ -1317,9 +1324,11 @@
         document.getElementById('btn_useCodeMirror').focus();
     }
 
+    function trumbowygIsActive() {
+        return document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea') !== null;
+    }
+
     function useCodeEmailEditor(refreshCodeMirror = false) {
-        console.log("swapping to codemirror");
-        //TODO: this removes html and some other tags.
         //if element associated with Trumbowyg exists, update codemirror element before proceeding.
         const elTrumbow = document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea');
         if(elTrumbow !== null) {

--- a/LEAF_Request_Portal/sources/EmailTemplate.php
+++ b/LEAF_Request_Portal/sources/EmailTemplate.php
@@ -116,7 +116,7 @@ class EmailTemplate
         }
         $out = array();
         $emailList = $this->db->query(
-            'SELECT label, emailTo, emailCc, subject, body from email_templates ORDER BY emailTemplateID DESC'
+            'SELECT label, emailTo, emailCc, subject, body from email_templates WHERE emailTemplateID != 1 ORDER BY emailTemplateID DESC'
         );
         foreach ($emailList as $listItem) {
             $data = array(

--- a/LEAF_Request_Portal/templates/email/LEAF_automated_reminder_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_automated_reminder_body.tpl
@@ -1,9 +1,9 @@
-Please review this request at your earliest convenience.<br /><br />
+Please review this request at your earliest convenience.<br><br>
 
-Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$fullTitle}}</a><br />
-Request status: {{$lastStatus}}<br /><br />
-Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
+Request title: <a href="{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}" target="_blank">
+    {{$fullTitle}}</a><br>
+Request status: {{$lastStatus}}<br><br>
+Request Link: <a href="{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}" target="_blank">
+    {{$siteRoot}}?a=printview&amp;recordID={{$recordID}}</a><br><br>
     {{$reminderBodyText}}
-<br />
+<br>

--- a/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_cancel_notification_body.tpl
@@ -1,12 +1,12 @@
-A request that you were a part of has been cancelled.<br />
-Request #{{$recordID}} - {{$fullTitle}}.<br /><br />
-This is a notification only and no action is required on your part.<br /><br />
+A request that you were a part of has been cancelled.<br>
+Request #{{$recordID}} - {{$fullTitle}}.<br><br>
+This is a notification only and no action is required on your part.<br><br>
 
 {{$comment}}
 
-Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$fullTitle}}</a><br />
-Request status: {{$lastStatus}}<br /><br />
-Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
-<br />
+Request title: <a href="{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}" target="_blank">
+    {{$fullTitle}}</a><br>
+Request status: {{$lastStatus}}<br><br>
+Request Link: <a href="{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}" target="_blank">
+    {{$siteRoot}}?a=printview&amp;recordID={{$recordID}}</a><br><br>
+<br>

--- a/LEAF_Request_Portal/templates/email/LEAF_mass_action_remind_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_mass_action_remind_body.tpl
@@ -1,9 +1,9 @@
 The last action on Request #{{$recordID}} is older than {{$daysSince}} days.
-Please review this request at your earliest convenience.<br /><br />
+Please review this request at your earliest convenience.<br><br>
 
-Request title: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$fullTitle}}</a><br />
-Request status: {{$lastStatus}}<br /><br />
-Request Link: <a href="{{$siteRoot}}?a=printview&recordID={{$recordID}}" target="_blank">
-    {{$siteRoot}}?a=printview&recordID={{$recordID}}</a><br /><br />
-<br />
+Request title: <a href="{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}" target="_blank">
+    {{$fullTitle}}</a><br>
+Request status: {{$lastStatus}}<br><br>
+Request Link: <a href="{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}" target="_blank">
+    {{$siteRoot}}?a=printview&amp;recordID={{$recordID}}</a><br><br>
+<br>

--- a/LEAF_Request_Portal/templates/email/LEAF_notify_complete_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_notify_complete_body.tpl
@@ -1,9 +1,9 @@
-Request ID#: {{$recordID}}<br />
-Request title: {{$fullTitle}}<br />
-Request status: {{$lastStatus}}<br />
-<br />
-Comments: {{$comment}}<br />
-<br />
-------------------------<br />
-View Request: {{$siteRoot}}?a=printview&recordID={{$recordID}}<br />
-<br />
+Request ID#: {{$recordID}}<br>
+Request title: {{$fullTitle}}<br>
+Request status: {{$lastStatus}}<br>
+<br>
+Comments: {{$comment}}<br>
+<br>
+------------------------<br>
+View Request: {{$siteRoot}}?a=printview&amp;recordID={{$recordID}}<br>
+<br>

--- a/LEAF_Request_Portal/templates/email/LEAF_notify_next_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_notify_next_body.tpl
@@ -1,13 +1,13 @@
-The following request requires your review.<br />
-<br />
-Please review your inbox at: {{$siteRoot}}report.php?a=LEAF_Inbox<br />
-<br />
-Request ID#: {{$recordID}}<br />
-Request title: {{$fullTitle}}<br />
-Request status: {{$lastStatus}}<br />
-<br />
-Comments: {{$comment}}<br />
-<br />
-------------------------<br />
-View Request: {{$siteRoot}}?a=printview&recordID={{$recordID}}<br />
-<br />
+The following request requires your review.<br>
+<br>
+Please review your inbox at: {{$siteRoot}}report.php?a=LEAF_Inbox<br>
+<br>
+Request ID#: {{$recordID}}<br>
+Request title: {{$fullTitle}}<br>
+Request status: {{$lastStatus}}<br>
+<br>
+Comments: {{$comment}}<br>
+<br>
+------------------------<br>
+View Request: {{$siteRoot}}?a=printview&amp;recordID={{$recordID}}<br>
+<br>

--- a/LEAF_Request_Portal/templates/email/LEAF_send_back_body.tpl
+++ b/LEAF_Request_Portal/templates/email/LEAF_send_back_body.tpl
@@ -1,11 +1,11 @@
-Request ID#: {{$recordID}}<br />
-<br />
-Request status: Sent Back by {{$stepTitle}}<br />
-<br />
-Comments: {{$comment}}<br />
-<br />
-------------------------<br />
-{{$siteRoot}}?a=printview&recordID={{$recordID}}<br />
-<br />
-{{$fullTitle}}<br />
-<br />
+Request ID#: {{$recordID}}<br>
+<br>
+Request status: Sent Back by {{$stepTitle}}<br>
+<br>
+Comments: {{$comment}}<br>
+<br>
+------------------------<br>
+{{$siteRoot}}?a=printview&amp;recordID={{$recordID}}<br>
+<br>
+{{$fullTitle}}<br>
+<br>

--- a/LEAF_Request_Portal/templates/email/base_templates/LEAF_template_body.tpl
+++ b/LEAF_Request_Portal/templates/email/base_templates/LEAF_template_body.tpl
@@ -1,13 +1,13 @@
-The following request requires your review.<br />
-<br />
-Please review your inbox at: {{$siteRoot}}?a=inbox<br />
-<br />
-Request ID#: {{$recordID}}<br />
-Request title: {{$fullTitle}}<br />
-Request status: {{$lastStatus}}<br />
-<br />
-Comments: {{$comment}}<br />
-<br />
-------------------------<br />
-View Request: {{$siteRoot}}?a=printview&recordID={{$recordID}}<br />
-<br />
+The following request requires your review.<br>
+<br>
+Please review your inbox at: {{$siteRoot}}?a=inbox<br>
+<br>
+Request ID#: {{$recordID}}<br>
+Request title: {{$fullTitle}}<br>
+Request status: {{$lastStatus}}<br>
+<br>
+Comments: {{$comment}}<br>
+<br>
+------------------------<br>
+View Request: {{$siteRoot}}?a=printview&amp;recordID={{$recordID}}<br>
+<br>


### PR DESCRIPTION
This update adds the Trumbowyg text editor to the Email Template Editor.  Users will be able to toggle between the CodeMirror and WYSWYG inputs.

It was found that the 'Default Email Template' is not used through the email template editor.  This template is used from templates/email/LEAF_main_email_tamplate.tpl (not custom_override).
A query in EmailTemplate.php has been updated to exclude this template from the Email Template Editor.
The Email Template Editor has also been updated to display 'Notify Next Approver' as the default view.

**Impact / Testing**

Portal Admin - Email Template Editor
Email editing from either CodeMirror or WYSWYG Text Editor should function as expected.
Page navigation should function as expected.