### PR TITLE
LEAF-4658 - VA Favicon loading error

### DIFF
--- a/LEAF_Request_Portal/login/index.php
+++ b/LEAF_Request_Portal/login/index.php
@@ -38,7 +38,7 @@ $authCertURL = $protocol . AUTH_CERT_URL . '/auth_token/index.php?r=' . base64_e
     <style type="text/css" media="screen">
         @import "../css/style.css";
     </style>
-    <link rel="icon" href="vafavicon.ico" type="image/x-icon" />
+    <link rel="icon" href="../vafavicon.ico" type="image/x-icon" />
 </head>
 <body>
 <div id="header">


### PR DESCRIPTION
# Issue
On the login page the icon was not loading and resulted in errors in our error reporting system

# Fix
Adjust login page to load in the proper ico
