### PR TITLE
LEAF 4203 - dev initial snapshot on save

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -168,10 +168,30 @@
     * Displays last save time, updates currentFileContent value, and calls saveFileHistory at success.
     */
     function save() {
+        let elSaveBtn = document.getElementById('save_button');
         const data = getCodeEditorValue(codeEditor);
         if (data === currentFileContent) {
             alert('There are no changes to save.');
         } else {
+            elSaveBtn.setAttribute("disabled", "disabled");
+            //if no history exists yet, synchronously snapshot the original first
+            const numRecords = Array.from(document.querySelectorAll('.file_history_options_container button')).length;
+            if(numRecords === 0) {
+                $.ajax({
+                    type: 'POST',
+                    data: {
+                        CSRFToken: '<!--{$CSRFToken}-->',
+                        file: currentFileContent
+                    },
+                    url: '../api/templateFileHistory/_' + currentFile,
+                    success: function(res) {},
+                    error: function(err) {
+                        console.log(err);
+                    },
+                    async: false
+                });
+            }
+
             $.ajax({
                 type: 'POST',
                 data: {
@@ -190,9 +210,11 @@
                         $('#restore_original, #btn_compare').addClass('modifiedTemplate');
                         $(`.template_files a[data-file="${currentFile}"] + span`).addClass('custom_file');
                     }
+                    elSaveBtn.removeAttribute("disabled");
                 },
                 error: function(err) {
                     console.log(err);
+                    elSaveBtn.removeAttribute("disabled");
                 }
             });
         }

--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -174,7 +174,7 @@
             alert('There are no changes to save.');
         } else {
             elSaveBtn.setAttribute("disabled", "disabled");
-            //if no history exists yet, synchronously snapshot the original first
+            //if no history exists yet, snapshot the original first
             const numRecords = Array.from(document.querySelectorAll('.file_history_options_container button')).length;
             if(numRecords === 0) {
                 $.ajax({
@@ -188,7 +188,6 @@
                     error: function(err) {
                         console.log(err);
                     },
-                    async: false
                 });
             }
 

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -355,6 +355,7 @@
     * Displays last save time, updates current*Content values, and calls saveFileHistory at success.
     */
     function save() {
+        let elSaveBtn = document.getElementById('save_button');
         const trumbowValue = document.querySelector(
             '#emailBodyCode + div textarea.trumbowyg-textarea'
         )?.value || null;
@@ -378,6 +379,31 @@
                 $('#editor_trumbowyg_saving').hide();
             }
         } else {
+            elSaveBtn.setAttribute("disabled", "disabled");
+            //if no history exists yet, synchronously snapshot the original first
+            const numRecords = Array.from(document.querySelectorAll('.file_history_options_container button')).length;
+            if(numRecords === 0) {
+                $.ajax({
+                    type: 'POST',
+                    data: {
+                        CSRFToken: '<!--{$CSRFToken}-->',
+                        file: currentFileContent,
+                        subjectFile: currentSubjectContent,
+                        subjectFileName: currentSubjectFile,
+                        emailToFile: currentEmailToContent,
+                        emailToFileName: currentEmailToFile,
+                        emailCcFile: currentEmailCcContent,
+                        emailCcFileName: currentEmailCcFile
+                    },
+                    url: '../api/emailTemplateFileHistory/_' + currentFile,
+                    success: function(res) {},
+                    error: function(err) {
+                        console.log(err);
+                    },
+                    async: false
+                });
+            }
+
             $.ajax({
                 type: 'POST',
                 data: {
@@ -414,12 +440,14 @@
                             currentTrumbowygFileContent = data;
                         }
                     }
+                    elSaveBtn.removeAttribute("disabled");
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     if(trumbowValue !== null) {
                         $('#editor_trumbowyg_saving').hide();
                         useTrumbowygEmailEditor();
                     }
+                    elSaveBtn.removeAttribute("disabled");
                     console.log('Error occurred during the save operation:', errorThrown);
                 }
             });

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -380,7 +380,7 @@
             }
         } else {
             elSaveBtn.setAttribute("disabled", "disabled");
-            //if no history exists yet, synchronously snapshot the original first
+            //if no history exists yet, snapshot the original first
             const numRecords = Array.from(document.querySelectorAll('.file_history_options_container button')).length;
             if(numRecords === 0) {
                 $.ajax({
@@ -400,7 +400,6 @@
                     error: function(err) {
                         console.log(err);
                     },
-                    async: false
                 });
             }
 

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -174,7 +174,7 @@
             alert('There are no changes to save.');
         } else {
             elSaveBtn.setAttribute("disabled", "disabled");
-            //if no history exists yet, synchronously snapshot the original first
+            //if no history exists yet, snapshot the original first
             const numRecords = Array.from(document.querySelectorAll('.file_history_options_container button')).length;
             if(numRecords === 0) {
                 $.ajax({
@@ -188,7 +188,6 @@
                     error: function(err) {
                         console.log(err);
                     },
-                    async: false
                 });
             }
 

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -704,7 +704,7 @@
                     
                     if (!isExcludedFile(file)) {
                         buffer += '<li><a href="#" role="button" data-file="' + file + '">' + file + '</a></li>';
-                        filesMobile += '<option value="' + file + '"><div class="template_files">' + file + '</div></option>';
+                        filesMobile += '<option value="' + file + '">' + file + '</option>';
                     } else {
                         bufferExamples += '<li><a href="#" role="button" data-file="' + file + '">' + file + '</a></li>';
                     }

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -168,10 +168,30 @@
     * Displays last save time, updates currentFileContent value, and calls saveFileHistory at success.
     */
     function save() {
+        let elSaveBtn = document.getElementById('save_button');
         const data = getCodeEditorValue(codeEditor);
         if (data === currentFileContent) {
             alert('There are no changes to save.');
         } else {
+            elSaveBtn.setAttribute("disabled", "disabled");
+            //if no history exists yet, synchronously snapshot the original first
+            const numRecords = Array.from(document.querySelectorAll('.file_history_options_container button')).length;
+            if(numRecords === 0) {
+                $.ajax({
+                    type: 'POST',
+                    data: {
+                        CSRFToken: '<!--{$CSRFToken}-->',
+                        file: currentFileContent
+                    },
+                    url: '../api/applet/fileHistory/_' + currentFile,
+                    success: function(res) {},
+                    error: function(err) {
+                        console.log(err);
+                    },
+                    async: false
+                });
+            }
+
             $.ajax({
                 type: 'POST',
                 data: {
@@ -188,9 +208,11 @@
                         currentFileContent = data;
                         saveFileHistory();
                     }
+                    elSaveBtn.removeAttribute("disabled");
                 },
-                error: function() {
-                    alert('An error occurred while saving the file.');
+                error: function(err) {
+                    alert('An error occurred while saving the file.', err);
+                    elSaveBtn.removeAttribute("disabled");
                 }
             });
         }

--- a/LEAF_Request_Portal/sources/Applet.php
+++ b/LEAF_Request_Portal/sources/Applet.php
@@ -286,7 +286,7 @@ class Applet
         $list = $this->getReportTemplateList();
         $time = date("Y-m-d h:i:s");
 
-        $templateID = time();
+        $templateID = uniqid();
 
         if (array_search($template, $list) !== false) {
             $fileData = $_POST['file'];

--- a/LEAF_Request_Portal/sources/TemplateFileHistory.php
+++ b/LEAF_Request_Portal/sources/TemplateFileHistory.php
@@ -175,7 +175,7 @@ class TemplateFileHistory
 
         $list = $this->getTemplateList();
         $time = date("Y-m-d h:i:s");
-        $templateID = time();
+        $templateID = uniqid();
 
 
         if (array_search($templateFileHistory, $list) !== false) {

--- a/LEAF_Request_Portal/sources/TemplateFileHistory.php
+++ b/LEAF_Request_Portal/sources/TemplateFileHistory.php
@@ -157,7 +157,7 @@ class TemplateFileHistory
         $sql = 'SELECT file_id, file_parent_name, file_name, file_path, file_size, file_modify_by, file_created
                   FROM `template_history_files`
                   WHERE file_parent_name = :template_file
-                  ORDER BY `file_created` DESC';
+                  ORDER BY `file_id` DESC';
 
         return $this->db->prepared_query($sql, $vars);
     }


### PR DESCRIPTION
Updates template editor areas to take an initial snapshot of current content if a template is saved and there are no history snapshots yet to ensure original state also has a recorded snapshot. 

Server side
Template file history and applet history have a template prefix added with uniqid instead of with time.
The addition precision is needed to potentially take two snapshots in rapid succession.
Email template editor already used uniqid.

Updates a query to sort by file_id DESC instead of by the file_created text field to ensure file history list appears in the expected order.

Front:
Adds a check for file history and performs ajax call to snapshot history of the current content if necessary.
Disables save button during the save process to prevent multiple clicks.
Removed a div nested in a select element option.

**Testing / Impact**
Portal admin Template Editor, Email Template Editor, Programmer
Files load and save as expected.
If no history files exist for a template, a snapshot of the current content is taken prior to a snapshot of the newest change.
File history list is in expected order, which the newest files at the top (For example, confirm that a save at 12:00 does not appear before a save at 1:00).  The behavior on master and test branch can be tested by editing template_history_files table.