### PR TITLE
Leaf 4663 - refactor ad to leaf updates

### DIFF
--- a/LEAF_Nexus/scripts/updateNationalOrgchart.php
+++ b/LEAF_Nexus/scripts/updateNationalOrgchart.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ * As a work of the United States government, this project is in the public domain within the United States.
+ */
+
+/*
+    Refreshes employee data into local orgchart
+*/
+
+passthru('php /var/www/scripts/scheduled-task-commands/updateNationalOrgchartEmployees.php');
+passthru('php /var/www/scripts/scheduled-task-commands/disableNationalOrgchartEmployees.php');

--- a/LEAF_Nexus/sources/Employee.php
+++ b/LEAF_Nexus/sources/Employee.php
@@ -245,34 +245,9 @@ class Employee extends Data
             if (!empty($local_data_array)) {
                 $results[] = $this->batchEmployeeDataUpdate($local_data_array);
             }
-
-            $users = $this->updateNationalDisabledEmployees();
-
-            if (!empty($users)) {
-                $results[] = $this->disableEmployees($users);
-            }
         }
 
         return $results;
-    }
-
-    private function updateNationalDisabledEmployees(): array
-    {
-        $vars = array();
-        $sql = 'SELECT `userName`
-                FROM `employee`
-                WHERE `deleted` > 0
-                AND LEFT(`userName`, 9) <> "disabled_"';
-
-        $res = $this->db->prepared_query($sql, $vars);
-
-        $userNames = array();
-
-        foreach ($res as $user) {
-            $userNames[] = $user['userName'];
-        }
-
-        return $userNames;
     }
 
     /**

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -19,6 +19,8 @@ class VAMCActiveDirectory
 
     private $users = array();
 
+    private $disable_time = time();
+
     private $headers = array('sn' => 'lname',
                 'givenName' => 'fname',
                 'initials' => 'midIni',
@@ -282,7 +284,7 @@ class VAMCActiveDirectory
 
     private function preventRecycledUserName(array $userNames): void
     {
-        $deleteTime = time();
+        $deleteTime = $this->disable_time;
 
         $vars = array(':deleteTime' => $deleteTime);
         $sql = 'UPDATE `employee`

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -102,6 +102,8 @@ class VAMCActiveDirectory
                 //echo "Grabbing data for $employee['lname'], $employee['fname']\n";
                 $count++;
             } else if (isset($employee['service']) && strpos($employee['service'], 'ervice account')) {
+                $id = md5('ACCOUNT' . 'SERVICE' . $count);
+
                 $this->users[$id]['lname'] = 'Account';
                 $this->users[$id]['fname'] = 'Service';
                 $this->users[$id]['midIni'] = '';

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -19,7 +19,7 @@ class VAMCActiveDirectory
 
     private $users = array();
 
-    private $disable_time = time();
+    private $disable_time;
 
     private $headers = array('sn' => 'lname',
                 'givenName' => 'fname',

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -101,6 +101,23 @@ class VAMCActiveDirectory
                 $this->users[$id]['source'] = 'ad';
                 //echo "Grabbing data for $employee['lname'], $employee['fname']\n";
                 $count++;
+            } else if (strpos($employee['service'], 'ervice account')) {
+                $this->users[$id]['lname'] = 'Account';
+                $this->users[$id]['fname'] = 'Service';
+                $this->users[$id]['midIni'] = '';
+                $this->users[$id]['email'] = isset($employee['email']) ? $employee['email'] : null;
+                $this->users[$id]['phone'] = $employee['phone'];
+                $this->users[$id]['pager'] = isset($employee['pager']) ? $employee['pager'] : null;
+                $this->users[$id]['roomNum'] = $employee['roomNum'];
+                $this->users[$id]['title'] = $employee['title'];
+                $this->users[$id]['service'] = $employee['service'];
+                $this->users[$id]['mailcode'] = isset($employee['mailcode']) ? $employee['mailcode'] : null;
+                $this->users[$id]['loginName'] = $employee['loginName'];
+                $this->users[$id]['objectGUID'] = null;
+                $this->users[$id]['mobile'] = $employee['mobile'];
+                $this->users[$id]['domain'] = $this->parseVAdomain($employee['domain']);
+                $this->users[$id]['source'] = 'ad';
+                $count++;
             } else {
                 $ln = isset($employee['loginName']) ? $employee['loginName'] : 'no login name';
                 $lan = isset($employee['lname']) ? $employee['lname'] : 'no last name';

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -101,7 +101,7 @@ class VAMCActiveDirectory
                 $this->users[$id]['source'] = 'ad';
                 //echo "Grabbing data for $employee['lname'], $employee['fname']\n";
                 $count++;
-            } else if (strpos($employee['service'], 'ervice account')) {
+            } else if (isset($employee['service']) && strpos($employee['service'], 'ervice account')) {
                 $this->users[$id]['lname'] = 'Account';
                 $this->users[$id]['fname'] = 'Service';
                 $this->users[$id]['midIni'] = '';

--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -320,7 +320,8 @@ class VAMCActiveDirectory
         $sql = 'SELECT `userName`
                 FROM `employee`
                 WHERE `deleted` = 0
-                AND `lastUpdated` < (UNIX_TIMESTAMP(NOW()) - 108000)';
+                AND `lastUpdated` < (UNIX_TIMESTAMP(NOW()) - 108000)
+                AND `lastUpdated` > 0';
 
         $return_value = $this->db->prepared_query($sql, array());
 

--- a/docker/php/leaf_monlith.dockerfile
+++ b/docker/php/leaf_monlith.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm 
+FROM php:8.2-fpm
 COPY docker/php/php-dev.ini "$PHP_INI_DIR/php.ini"
 RUN docker-php-ext-install pdo pdo_mysql
 
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
 		libjpeg62-turbo-dev \
 		libpng-dev \
 		ssmtp \
+		parallel \
 	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
 	&& docker-php-ext-install -j$(nproc) gd
 
@@ -34,4 +35,5 @@ COPY ./health_checks /var/www/html/health_checks
 RUN chmod +x /var/www/html/
 RUN chown -R www-data:www-data /var/www
 RUN chmod -R g+rwX /var/www
+RUN mkdir /var/www/tmp/ && chown www-data:www-data /var/www/tmp/
 # USER www-data

--- a/scripts/scheduled-task-commands/disableNationalOrgchartEmployees.php
+++ b/scripts/scheduled-task-commands/disableNationalOrgchartEmployees.php
@@ -5,7 +5,6 @@ require_once APP_PATH . '/Leaf/VAMCActiveDirectory.php';
 
 $startTime = microtime(true);
 
-
 $national_db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_orgchart');
 $dir = new App\Leaf\VAMCActiveDirectory($national_db);
 
@@ -14,4 +13,4 @@ $dir->disableNationalOrgchartEmployees();
 $endTime = microtime(true);
 $totalTime = round(($endTime - $startTime)/60, 2);
 
-error_log(print_r($file . " took " . $totalTime . " minutes to complete.", true), 3 , '/var/www/php-logs/ad_processing.log');
+error_log(print_r("Disable took " . $totalTime . " minutes to complete.", true), 3 , '/var/www/php-logs/ad_processing.log');

--- a/scripts/scheduled-task-commands/refreshOrgchartEmps.php
+++ b/scripts/scheduled-task-commands/refreshOrgchartEmps.php
@@ -1,0 +1,39 @@
+<?php
+require_once 'globals.php';
+require_once APP_PATH . '/Leaf/Db.php';
+
+$dir = '/var/www/html';
+
+$startTime = microtime(true);
+
+$db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_leaf_launchpad');
+
+$vars = array();
+
+$sql = 'SELECT `site_path`
+        FROM `sites`
+        WHERE `site_type` = "orgchart"
+        ORDER BY `site_path`';
+
+$paths = $db->prepared_query($sql, $vars);
+
+passthru("cat /dev/null > /var/www/tmp/refreshOrgcharts.txt");
+
+echo "Refresh Orgcharts Started ...\r\n";
+
+$forgcharts = fopen('/var/www/tmp/refreshOrgcharts.txt', 'w');
+
+foreach ($paths as $path) {
+    $site = rtrim($path['site_path'], '/');
+    fwrite($forgcharts, "{$dir}{$site}/\r\n");
+}
+
+fclose($forgcharts);
+
+echo "Refreshing Orgcharts\r\n";
+passthru("cat /var/www/tmp/refreshOrgcharts.txt | parallel -j 10 -d '\r\n' php {}scripts/refreshOrgchartEmployees.php");
+
+$endTime = microtime(true);
+$timeInMinutes = round(($endTime - $startTime) / 60, 2);
+echo "Refresh took {$timeInMinutes} minutes and ended at ";
+echo date('Y-m-d g:i:s a'). "\r\n";

--- a/scripts/scheduled-task-commands/updateNationalOrgchartEmployees.php
+++ b/scripts/scheduled-task-commands/updateNationalOrgchartEmployees.php
@@ -2,6 +2,8 @@
 require_once 'globals.php';
 require_once APP_PATH . '/Leaf/Db.php';
 
+$startTime = microtime(true);
+
 $db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_orgchart');
 
 $sql = 'SELECT `cacheID`, LEFT(`data`, 5) AS `data`
@@ -10,13 +12,24 @@ $sql = 'SELECT `cacheID`, LEFT(`data`, 5) AS `data`
 
 $VISNS = $db->query($sql);
 
-function updateEmps($VISNS) {
-    foreach ($VISNS as $visn) {
-        if (str_starts_with($visn['data'], 'DN,')) {
-            exec("php /var/www/scripts/updateNationalOrgchart.php {$visn['cacheID']} > /dev/null 2>/dev/null &");
-            echo "Deploying to: {$visn['cacheID']}\r\n";
-        }
+passthru("cat /dev/null > /var/www/tmp/nationalUpdate.txt");
+
+echo "Beginning National Update ...\r\n";
+
+$national = fopen('/var/www/tmp/nationalUpdate.txt', 'w');
+
+foreach ($VISNS as $visn) {
+    if (str_starts_with($visn['data'], 'DN,')) {
+        fwrite($national, "{$visn['cacheID']}\r\n");
     }
 }
 
-updateEmps($VISNS);
+fclose($national);
+
+echo "Updating National Orgcharts\r\n";
+passthru("cat /var/www/tmp/nationalUpdate.txt | parallel -j 100 -d '\r\n' php /var/www/scripts/updateNationalOrgchart.php {}");
+
+$endTime = microtime(true);
+$timeInMinutes = round(($endTime - $startTime) / 60, 2);
+echo "National Update took {$timeInMinutes} minutes and ended at ";
+echo date('Y-m-d g:i:s a'). "\r\n";


### PR DESCRIPTION
Summary:
The old script, which resides on the Auth server processed all Active Directory updates to Leaf. Now the Auth Server will get the data from AD and save it to a table (cache) in the National Orgchart. Then a cron job on Leaf servers runs to update Employee and Employee data in the national orgchart. After this update is complete another script runs to disable Employees that have not been updated within the last 30 hours. 

For the purposes of this PR an Employee is considered disabled if their record in the National Orgchart hasn't been updated within the last 30 hours. Every Employee has a lastUpdated field and this gets updated whenever the first script runs to update Employees whether or not they had data to be updated, if it hasn't been updated they were not pulled from AD which means that userName is no longer being used and needs to be disabled.

There is also a fail safe when updating disabled Employees, the script looks to make sure that at least 200k Employee's have been updated within the last 2 hours before attempting to disable anyone. 

```mermaid
graph TB
    subgraph Active_Directory_Namespace
        AD_agent(Active Directory Server)
    end

    subgraph Auth_Server
        auth_server(import script)
    end

    subgraph Leaf_Server
        national_update(update National<br />Orgchart)
        national_disable(disable National Orgchart<br />Employees)
        local_updates(refresh local<br />orgchart and portals)
    end

    subgraph leaf.va.gov
        disable_button(Disable)
        enable_button(Enable)
    end

    national_orgchart[(National Orgchart)]
    local_orgcharts_portals[(Local Orgcharts<br /> and Portals)]

    auth_server o-- Get data<br /> from AD --o AD_agent
    auth_server -- Save data to<br />cache table --> national_orgchart
    national_update <-- Update Employee table from AD data in cache table --> national_orgchart
    national_disable <-- Disable Employees who have not been updated within the last 30 hours --> national_orgchart
    local_updates o-- Refresh local orgcharts and portals --o local_orgcharts_portals
    disable_button o-- Disables selected Employee in orgchart and 4 tables in all portals --o local_orgcharts_portals
    enable_button o--Enables selected Employee in orgchart and 4 tables in all portals --o local_orgcharts_portals
```

Some statistics comparing current process to this new process (this is all on staging, expect this to be better on prod)

Getting data from Active Directory and updating National Orgchart including disabling users. current - 7.5 hours, new - 45 mins

Potential Impact:
The biggest impact will be the fact that we should be able to run this script multiple time a day without any adverse consequences. With the time being reduced significantly there won't be the situation where it was possible that data wasn't being updated for nearly 48 hours in some cases before. One change with this script is the 30 hours limit. Previously it was 12 days before a person was disabled. Need to keep an eye on this, if it becomes a problem may need to increase the time to allow for extended leave and things like that.

Testing:
Currently the only way to test this is to put it on staging and let it run. Monitor the staging db for any discrepancies.
We will be putting together an automated test also.