### PR TITLE
LEAF 4664 workflow module loading issue

### DIFF
--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -203,6 +203,8 @@ var LeafWorkflow = function (containerID, CSRFToken) {
 
     /**
      * @memberOf LeafWorkflow
+     * Called for each requirement with access. Initializes the step module if one exists for the step ID.
+     * @param {object} step includes both step and depencency information for a specific requirement
      */
     var modulesLoaded = {};
     function drawWorkflow(step) {
@@ -417,7 +419,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         rootURL
                     );
                 },
-                fail: function (err) {
+                error: function (err) {
                     console.log("Error: " + err);
                 },
             });
@@ -431,7 +433,8 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                 ) {
                     modulesLoaded[
                         step.stepModules[x].moduleName + "_" + step.stepID
-                    ] = 1;
+                    ] = step.dependencyID;
+
                     $(`#form_dep_extension${step.dependencyID}`)
                         .html(`<div style="padding: 8px 24px 8px">
                         <div style="background-color: white; border: 1px solid black; padding: 16px">
@@ -459,10 +462,17 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                                 `#form_dep_container${step.dependencyID} .button`
                             ).attr("disabled", false);
                         },
-                        fail: function (err) {
+                        error: function (err) {
                             console.log("Error: " + err);
                         },
                     });
+                } else {
+                    //the module is already flagged as loaded
+                    const shouldReinit = modulesLoaded?.[step.stepModules[x].moduleName + "_" + step.stepID] === step.dependencyID;
+                    if(shouldReinit && typeof workflowStepModule?.[step.stepID] !== "undefined") {
+                        //if the initial dependencyID is here, getworkflow has been called again - re-initialize for this depID only
+                        workflowStepModule[step.stepID][step.stepModules[x].moduleName].init(step, rootURL);
+                    }
                 }
             }
         }
@@ -479,7 +489,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         rootURL
                     );
                 },
-                fail: function (err) {
+                error: function (err) {
                     console.log("Error: " + err);
                 },
             });
@@ -541,7 +551,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         color: step.stepFontColor,
                     });
                 },
-                fail: function (err) {
+                error: function (err) {
                     console.log("Error: " + err);
                 },
             });
@@ -574,7 +584,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                         color: step.stepFontColor,
                     });
                 },
-                fail: function (err) {
+                error: function (err) {
                     console.log("Error: " + err);
                 },
             });
@@ -789,7 +799,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                     $("#workflowcontent").append('<br style="clear: both" />');
                 }
             },
-            fail: function (err) {
+            error: function (err) {
                 console.log("Error: " + err);
             },
             cache: false,
@@ -830,7 +840,7 @@ var LeafWorkflow = function (containerID, CSRFToken) {
                 getLastAction(recordID, res);
                 $("#" + containerID).show("blind", 250);
             },
-            fail: function (err) {
+            error: function (err) {
                 console.log("Error: " + err);
             },
             cache: false,


### PR DESCRIPTION
Adds some comments to drawWorkflow to clarify that it is potentially called multiple times and that its step param also includes dependency information.
Adds a param to drawWorkflow to identify the requirement that the form fields are loaded to.

Fields are only loaded on the first requirement - running init on more than one was associated with breaking things.
The else clause has been updated so that it should reinit the module if
 -it is already flagged as loaded and
 -the depID/requirement currently being drawn is also the first one.

Updates ajax config object callback name to 'error'

**Testing / Impact**

This item impacts request workflow fields.  If these fields do not load or otherwise function correctly, the workflow process could be stopped and/or data could not correctly save.
-confirm fields load as expected, for both single and multi-requirement steps
-confirm that edited data and comments are consistently saved regardless of which requirement takes action