### PR TITLE
INC37536110 LEAF 4665 update currency regex to test potential leading -

### DIFF
--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -558,7 +558,7 @@
                         isValidValue = true;
                     } else {
                         value = value.replace(/,/ig, '');
-                        if (/^(\d*)(\.\d+)?$/.test(value)) {
+                        if (/^-?(\d*)(\.\d+)?$/.test(value)) {
                             let floatValue = parseFloat(value);
                             let strRoundTwoDecimals = (Math.round(100 * floatValue) / 100).toFixed(2);
                             $('#<!--{$indicator.indicatorID|strip_tags}-->').val(strRoundTwoDecimals);


### PR DESCRIPTION
Updates currency format validator to accept a potential leading negative sign.

Testing /Impact

Currency format questions.
Leading negative sign should be allowed.
Currency validator should otherwise continue to work as expected.