### PR TITLE
INC37469608 LEAF 4661 catch nexus side export error

### DIFF
--- a/LEAF_Request_Portal/js/formGrid.js
+++ b/LEAF_Request_Portal/js/formGrid.js
@@ -930,13 +930,6 @@ var LeafFormGrid = function (containerID, options) {
     );
 
     $("#" + prefixID + "getExcel").on("click", async function () {
-      // get indicator formats in case they need special handling (e.g. dates)
-      let iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format").then(res => res.json());
-      let indicatorFormats = {};
-      iFormatData.forEach(i => {
-        indicatorFormats[i.indicatorID] = i.format;
-      });
-
       if (currentRenderIndex != currentData.length) {
         renderBody(0, Infinity);
       }
@@ -946,10 +939,33 @@ var LeafFormGrid = function (containerID, options) {
       $("#" + prefixID + "thead>tr>th>span").each(function (idx, val) {
         $(val).html("");
       });
+      let hasPossibleIndicator = false;
       $("#" + prefixID + "thead>tr>th").each(function (idx, val) {
+        if(/header_\d+$/.test(val?.id)) {
+          hasPossibleIndicator = true;
+        }
         headers.push($(val).text().trim());
       });
       output.push(headers); //first row will be headers
+
+      let indicatorFormats = {};
+      if(hasPossibleIndicator === true) {
+        let iFormatData = [];
+        //try to get indicator formats in case they need special handling (e.g. dates)
+        try {
+          iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format")
+          .then(res => res.json())
+          .catch(err => {
+            console.log(err)
+            return new Promise((resolve, reject) => resolve([]));
+          });
+        } catch (e) {
+          console.log(e);
+        }
+        iFormatData.forEach(i => {
+          indicatorFormats[i.indicatorID] = i.format;
+        });
+      }
 
       let line = [];
       let i = 0;

--- a/app/libs/js/LEAF/formGrid.js
+++ b/app/libs/js/LEAF/formGrid.js
@@ -931,7 +931,20 @@ var LeafFormGrid = function (containerID, options) {
 
     $("#" + prefixID + "getExcel").on("click", async function () {
       // get indicator formats in case they need special handling (e.g. dates)
-      let iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format").then(res => res.json());
+      let iFormatData = [];
+      const isOrgchartPath = /\/orgchart\//i.test(window.location.href);
+      if(!isOrgchartPath) {
+        try {
+          iFormatData = await fetch(rootURL + "api/form/indicator/list?x-filterData=indicatorID,format")
+          .then(res => res.json())
+          .catch(err => {
+            console.log(err)
+            return new Promise((resolve, reject) => resolve([]));
+          });
+        } catch (e) {
+          console.log(e);
+        }
+      }
       let indicatorFormats = {};
       iFormatData.forEach(i => {
         indicatorFormats[i.indicatorID] = i.format;
@@ -966,7 +979,7 @@ var LeafFormGrid = function (containerID, options) {
           let trimmedText = val.innerText.trim();
           line[i] = trimmedText;
           //prevent some values from being interpreted as dates by excel
-          const dataFormat = indicatorFormats[val.getAttribute("data-indicator-id")];
+          const dataFormat = indicatorFormats?.[val.getAttribute("data-indicator-id")];
           const testExcelDateFormat = /^\d{1,2}[\/-]\d{1,2}([\/-]\d{2,4})?$/; // Excel thinks these are dates
           const isNumber = /^\d+$/;
 


### PR DESCRIPTION
On export, there is an endpoint call to pull indicator format information to avoid some issues with excel exports.

The orgchart does not have this endpoint, which results in a breaking error when attempting to export vacancy summary.

This update adds a try catch block so that potential errors will not affect the export.
It also adds pattern checking of the exported header ids to avoid trying to get format information if indicator patterns are not present.

Impact/Testing
formGrid export should work wherever it is used (Nexus Vacancy Summary page, Report Builder, Account Updater, Custom Reports)