### PR TITLE
LEAF 4669 required validator reset logic correction

### DIFF
--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -285,7 +285,8 @@ var LeafForm = function (containerID) {
             //If required validator and dialog exist, reset validator if there is not a hidden ancestor (exclude the one in the process of being assessed)
             const closestHidden = element.closest(`.response-hidden:not(.blockIndicator_${childID})`);
             const shouldSetRequired = closestHidden === null;
-            if ((formRequired[`id${id}`]?.setRequired || false) && dialog !== null && shouldSetRequired) {
+            const isRequired = typeof formRequired[`id${id}`]?.setRequired === "function";
+            if (isRequired && dialog !== null && shouldSetRequired) {
               dialog.requirements[id] = formRequired[`id${id}`].setRequired;
             }
           }

--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -285,7 +285,7 @@ var LeafForm = function (containerID) {
             //If required validator and dialog exist, reset validator if there is not a hidden ancestor (exclude the one in the process of being assessed)
             const closestHidden = element.closest(`.response-hidden:not(.blockIndicator_${childID})`);
             const shouldSetRequired = closestHidden === null;
-            if (formRequired[`id${id}`]?.setRequired || false && dialog !== null && shouldSetRequired) {
+            if ((formRequired[`id${id}`]?.setRequired || false) && dialog !== null && shouldSetRequired) {
               dialog.requirements[id] = formRequired[`id${id}`].setRequired;
             }
           }


### PR DESCRIPTION
Fixes a logic check associated with front end validator reset.

Testing / Impact
See Jira-4669 for an example form.
Impact should be minimal since this is a correction to intended logic

Issue occurs when
-A controller question triggers a branch check.
-Another controller question is in a separate branch than the question(s) it controls
-The questions it controls are required, and in the branch initially checked
-The controller is in a hidden state (so it cannot be interacted with to re-trigger a validator swap)
