### PR TITLE
LEAF 4667 add cancel button template logic

### DIFF
--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -46,7 +46,7 @@
     <div id="tools" class="tools">
         <h1>Tools</h1>
         <!--{if $submitted == 0}-->
-            <button class="tools" onclick="window.location='?a=view&amp;recordID=<!--{$recordID|strip_tags}-->'"><img
+            <button type="button" class="tools" onclick="window.location='?a=view&amp;recordID=<!--{$recordID|strip_tags}-->'"><img
                     src="dynicons/?img=edit-find-replace.svg&amp;w=32" alt="" title="Guided editor" aria-hidden="true"
                     style="vertical-align: middle" /> Edit this form</button>
             <br />
@@ -78,9 +78,11 @@
             Copy Request</button>
         <br />
         <br />
+        <!--{if $submitted == 0 || $is_admin}-->
         <button type="button" class="tools" id="btn_cancelRequest" title="Cancel Request" onclick="cancelRequest()"><img
                 src="dynicons/?img=process-stop.svg&amp;w=16" alt="" style="vertical-align: middle" />
             Cancel Request</button>
+        <!--{/if}-->
     </div>
 
 

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -229,6 +229,10 @@ function doSubmit(recordID) {
                 $('#submitContent').hide('blind', 500);
                 $('#comments').css({'display': "block"});
                 $('#notes').css({'display': "block"});
+                const isAdmin = '<!--{$is_admin}-->';
+                if (isAdmin !== "1") {
+                    $('#btn_cancelRequest').hide();
+                }
                 workflow.setExtraParams('masquerade=nonAdmin');
                 workflow.getWorkflow(recordID);
             } else {


### PR DESCRIPTION
Adds template logic and submit success logic to print_form so that the Cancel Request button does not display unless the form is not submitted, or the user is an admin.

**Impact / Testing**

Cancel button should be visible if a request is not submitted.
Cancel button should not be visible if a request is submitted unless the user is an admin.
Cancel button should become hidden after being submitted unless the user in an admin.
