### PR TITLE
LEAF 4615 add textarea for comments when mass action is cancel

### DIFF
--- a/LEAF_Request_Portal/js/pages/mass_action.js
+++ b/LEAF_Request_Portal/js/pages/mass_action.js
@@ -77,10 +77,15 @@ $(document).ready(function () {
 function chooseAction() {
     // If nothing selected and action selected is not 'Email Reminder'
     let actionValue = $("#action").val();
+    $("#comment_cancel").val("");
+    $("#comment_cancel_container").hide();
     if (actionValue !== "" && actionValue !== "email") {
         // Hide the email reminder and reset then show other options search and perform
         $("#emailSection").hide();
         $("#searchRequestsContainer").show();
+        if(actionValue === "cancel") {
+            $("#comment_cancel_container").show();
+        }
         leafSearch.init();
         doSearch();
     }
@@ -225,7 +230,7 @@ function listRequests(queryObj, thisSearchID, getReminder = 0) {
     $("#errorMessage").hide();
     $("table#requests tr.requestRow").remove();
     $("#iconBusy").show();
-    console.log(queryObj);
+
     $.ajax({
         type: "GET",
         url: "./api/form/query",
@@ -321,6 +326,7 @@ function listRequests(queryObj, thisSearchID, getReminder = 0) {
 function executeMassAction() {
     let selectedRequests = $("input.massActionRequest:checked");
     let reminderDaysSince = Number($("#lastAction").val());
+    const commentValue = ($("#comment_cancel").val() || "").trim();
     // Update global variables for execution - used in updateProgress function
     // Setting them to default at beginning of mass execution run
     processedRequests = 0;
@@ -341,6 +347,7 @@ function executeMassAction() {
                 break;
             case "cancel":
                 ajaxPath = "./api/form/" + recordID + "/cancel";
+                ajaxData["comment"] = commentValue;
                 break;
             case "restore":
                 ajaxPath = "./ajaxIndex.php?a=restore";

--- a/LEAF_Request_Portal/js/pages/mass_action.js
+++ b/LEAF_Request_Portal/js/pages/mass_action.js
@@ -39,15 +39,20 @@ $(document).ready(function () {
 
     // Confirm submission for mass action and perform action if accepted
     $("button.takeAction").click(function () {
-        dialog_confirm.setContent(
-            '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to perform this action?'
-        );
+        const commentValue = ($("#comment_cancel").val() || "").trim();
+        if (actionValue === "cancel" && commentValue === "") {
+            noteRequired();
+        } else {
+            dialog_confirm.setContent(
+                '<img src="dynicons/?img=process-stop.svg&amp;w=48" alt="" style="float: left; padding-right: 24px" /> Are you sure you want to perform this action?'
+            );
 
-        dialog_confirm.setSaveHandler(function () {
-            executeMassAction();
-            dialog_confirm.hide();
-        });
-        dialog_confirm.show();
+            dialog_confirm.setSaveHandler(function () {
+                executeMassAction();
+                dialog_confirm.hide();
+            });
+            dialog_confirm.show();
+        }
     });
 
     // When "Select All" selected/de-selected, set all of the request checkboxes to match
@@ -70,6 +75,16 @@ $(document).ready(function () {
         doSearch();
     });
 });
+
+function noteRequired() {
+    let elRequired = document.getElementById('comment_required');
+    if(elRequired !== null) {
+        elRequired.classList.add('attention');
+        setTimeout(() => {
+            elRequired.classList.remove('attention');
+        }, 2500);
+    }
+}
 
 /**
  * Purpose: Setup of choosing which action to take overall
@@ -324,9 +339,15 @@ function listRequests(queryObj, thisSearchID, getReminder = 0) {
  * Executes the selected action on each request selected in the table
  */
 function executeMassAction() {
+    const commentValue = ($("#comment_cancel").val() || "").trim();
+    if (actionValue === "cancel" && commentValue === "") {
+        noteRequired();
+        return
+    }
+
     let selectedRequests = $("input.massActionRequest:checked");
     let reminderDaysSince = Number($("#lastAction").val());
-    const commentValue = ($("#comment_cancel").val() || "").trim();
+
     // Update global variables for execution - used in updateProgress function
     // Setting them to default at beginning of mass execution run
     processedRequests = 0;
@@ -425,6 +446,7 @@ function updateProgress(recordID, success) {
         );
 
         $("button.takeAction").removeAttr("disabled");
+        $("#comment_cancel").val("");
     }
 }
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -51,6 +51,10 @@
             <option value="submit">Submit</option>
             <option value="email">Email Reminder</option>
         </select>
+        <div id="comment_cancel_container" style="display:none;margin:0.75rem 0;">
+            <label for="comment_cancel">Comment for cancel (optional)</label>
+            <textarea id="comment_cancel" rows="4" style="display:block;resize:vertical;width:530px;margin-top:2px"></textarea>
+        </div>
     </div>
 
     <div id="searchRequestsContainer"></div>

--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -32,6 +32,15 @@
         font-weight: bold;
         white-space: normal
     }
+    #comment_required {
+        transition: all 0.5s ease;
+        color: #c00;
+        font-weight: bolder;
+    }
+    #comment_required.attention {
+        color: #fff;
+        background-color: #c00;
+    }
 </style>
 <!--{include file="site_elements/generic_confirm_xhrDialog.tpl"}-->
 <script id="mass-action-js" src="./js/pages/mass_action.js"
@@ -52,7 +61,7 @@
             <option value="email">Email Reminder</option>
         </select>
         <div id="comment_cancel_container" style="display:none;margin:0.75rem 0;">
-            <label for="comment_cancel">Comment for cancel (optional)</label>
+            <label for="comment_cancel">Comment for cancel <span id="comment_required">* required</span></label>
             <textarea id="comment_cancel" rows="4" style="display:block;resize:vertical;width:530px;margin-top:2px"></textarea>
         </div>
     </div>


### PR DESCRIPTION
Adds a textarea where comments can be added for a cancel mass-action event.
This is the only mass-action event associated with comments
Per feedback, this section is now required when mass-cancelling requests.

Testing / Impact
Portal admin -> Toolbox -> Mass Actions Report

The new textarea should show if cancel is chosen.
A comment must be provided in order to perform this action.
The 'required' notice near the comments section will be highlighted if comments are not entered.
Comments should show in the respective request histories.