### PR TITLE
LEAF-4653 - Power BI/Power Query/Gateway Authentication Issues

### DIFF
--- a/LEAF_Request_Portal/auth_cookie/index.php
+++ b/LEAF_Request_Portal/auth_cookie/index.php
@@ -51,7 +51,7 @@ if (isset($_COOKIE['REMOTE_USER']))
         $res = $globalDB->prepared_query('SELECT * FROM employee
                                           LEFT JOIN employee_data USING (empUID)
                                           WHERE userName=:userName
-                                          AND indicatorID = 6
+                                          AND (indicatorID = 6 or indicatorID IS NULL)
                                                   AND deleted=0', $vars);
         // add user to local DB
         if (count($res) > 0)
@@ -78,15 +78,19 @@ if (isset($_COOKIE['REMOTE_USER']))
                                                           WHERE userName=:userName', $vars)[0]['empUID'];
             }
 
-            $vars = array(':empUID' => $empUID,
+            // this is to get around if the data is not found in instances like service accounts
+            if (!empty($res[0]['data']))
+            {
+                $vars = array(':empUID' => $empUID,
                     ':indicatorID' => 6,
                     ':data' => $res[0]['data'],
                     ':author' => 'viaLogin',
                     ':timestamp' => time(),
-            );
-            $oc_db->prepared_query('INSERT INTO employee_data (empUID, indicatorID, data, author, timestamp)
-                                            VALUES (:empUID, :indicatorID, :data, :author, :timestamp)
-                                            ON DUPLICATE KEY UPDATE data=:data', $vars);
+                );
+                $oc_db->prepared_query('INSERT INTO employee_data (empUID, indicatorID, data, author, timestamp)
+                                        VALUES (:empUID, :indicatorID, :data, :author, :timestamp)
+                                        ON DUPLICATE KEY UPDATE data=:data', $vars);
+            }
 
             // redirect as usual
             $_SESSION['userID'] = $res[0]['userName'];


### PR DESCRIPTION
# Formerly Known as : LEAF-4653 - Power Bi Gateway

# Note on the branch name
I messed up the branch name, it should have been called Power Bi Gateway, this doesnt really have to do with large query besides none of this works even without the large query changes in place.

## Summary
Currently if the user is in the national orgchart and you try and request data through power bi, power query or through a power bi gateway it will never get the data. In power bi and the gateway it will return with "We reached the end of the buffer" which would lead you to believe data would have issues and not authentication, however it is failing the authentication and returning an empty data set.

### The fix
The issue is when the system is authenticating it is also requiring an email. A service account does not have an email address attached so the check for this causes it to fail. I have adjusted this to allow this user to log in even without  the email address and adjusted the insertion of the email address to not include it if there is none. This appears to not have any defect from what I can find. 

### Research
I was trying to find how the old system would have authenticated. It appears everything for authentication appears to go down this same path. We do not have a historical reference of the auth servers code so I cannot be sure if this authenticated in any way. The code change here was added 6 years ago. Other and older files all appear to have email as part of this check. Only thing I can think of is this data was set previously for old service accounts and maybe an empty email address was in place previously which would explain why this check was probably fine in the past and now it does not work.

## Impact
Do these service accounts get automatically pulled in or are we manually adding them? Some cases look manually added and others appear to be pulled in via the import scripts. There was some discussion between Jamie and I and this appears to be the case. There are some that are pulled in and some more that could possibly be pulled in. I would say this may be a separate discussion and could be expanded upon when we start getting people going on pulling data this way.

## Testing
This is setup to allow accounts without email to be setup on the site for processes. When you run a process using a service account on a site that does not have that service account on you should now be able to run processes against.
![image](https://github.com/user-attachments/assets/a8bc15b8-7a16-4d70-add4-70fbcea227f0)
We found that users that are not part of any of the User Access Rolls can result in some errors that are not apparent. We were able to get a working result.

### Working Result
![{64841156-72AA-4081-8126-313C42294BC5}](https://github.com/user-attachments/assets/dd38b65c-f61d-4b12-b0c4-853918da2132)

### Weird Error 
This was when the user was not able to pull any data.
![{D3D721DC-5F79-4031-9EA7-30D086937720}](https://github.com/user-attachments/assets/0a4f2840-89d7-47e1-bcf4-2b480c431515)
