### PR TITLE
PHP Docker Logs

### DIFF
--- a/docker/php/php-dev.ini
+++ b/docker/php/php-dev.ini
@@ -459,7 +459,7 @@ memory_limit = 1024M
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; http://php.net/error-reporting
-error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+error_reporting = E_ALL
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but


### PR DESCRIPTION
# Issue
Allow php to show error messages for docker log. 

Previously error_log and other messages would not be put out to `docker logs leaf-php-fpm-1` now it will output errors, see "moo" below.
![image](https://github.com/user-attachments/assets/c3e271dc-8f22-4fa3-ba3d-3c101b2a8486)

# Impact
This will only affect local development