### PR TITLE
LEAF 4666 form printview clickable links

### DIFF
--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -1,34 +1,36 @@
 <script>
     function setPrintViewUserLinkContent(elResBlock) {
-        const whitelist = {
-            "dvagov.sharepoint.com": 1,
-            "apps.gov.powerapps.us": 1
-        }
         let htmlContent = elResBlock?.innerHTML || "";
-        //links must have https, they could have tags. only grab the url content here and filter based on whitelist
-        let matchLinks = htmlContent.match(/(?<=https:\/\/).*?(?=\s|$|"|'|&gt;|<)/gi);
-        matchLinks = Array.from(new Set(matchLinks));
-        matchLinks = matchLinks.filter(url => {
-            const baseurl = (url.split("/")[0] || "").toLowerCase();
-            return baseurl.endsWith(".gov") || whitelist[baseurl] === 1;
-        });
-
-        matchLinks.forEach(match => {
-            const linkText = match.length <= 50 ? match : match.slice(0,50) + '...';
-            const oldText = `https://${match}`;
-            const newText =   `<a href="https://${match}" target="_blank">https://${linkText}</a>`;
-            //initial replacement
-            htmlContent = htmlContent.replace(oldText, newText);
-
-            //if user tried to add anchor tags this will replace them. link text was will be replaced by the new link text.
-            const textEscaped = newText.replaceAll(".", "\\.").replaceAll("?", "\\?");
-            const regStr = `(&lt;|<)a\\s+href=['"]${textEscaped}['"](>|&gt;)(.*)?(&lt;|<)/a(>|&gt;)`;
-            const tagReg = new RegExp(regStr, "gi");
-            if(tagReg.test(htmlContent)) {
-                htmlContent = htmlContent.replace(tagReg, newText);
+        if (htmlContent !== "") {
+            const whitelist = {
+                "dvagov.sharepoint.com": 1,
+                "apps.gov.powerapps.us": 1
             }
-        });
-        elResBlock.innerHTML = htmlContent;
+            //links must have https, they could have tags. only grab the url content here and filter based on whitelist
+            let matchLinks = htmlContent.match(/(?<=https:\/\/).*?(?=\s|$|"|'|&gt;|<)/gi);
+            matchLinks = Array.from(new Set(matchLinks));
+            matchLinks = matchLinks.filter(url => {
+                const baseurl = (url.split("/")[0] || "").toLowerCase();
+                return baseurl.endsWith(".gov") || whitelist[baseurl] === 1;
+            });
+
+            matchLinks.forEach(match => {
+                const linkText = match.length <= 50 ? match : match.slice(0,50) + '...';
+                const oldText = `https://${match}`;
+                const newText =   `<a href="https://${match}" target="_blank">https://${linkText}</a>`;
+                //initial replacement
+                htmlContent = htmlContent.replace(oldText, newText);
+
+                //if user tried to add anchor tags this will replace them. link text was will be replaced by the new link text.
+                const textEscaped = newText.replaceAll(".", "\\.").replaceAll("?", "\\?");
+                const regStr = `(&lt;|<)a\\s+href=['"]${textEscaped}['"](>|&gt;)(.*)?(&lt;|<)/a(>|&gt;)`;
+                const tagReg = new RegExp(regStr, "gi");
+                if(tagReg.test(htmlContent)) {
+                    htmlContent = htmlContent.replace(tagReg, newText);
+                }
+            });
+            elResBlock.innerHTML = htmlContent;
+        }
     }
 </script>
 <!--{strip}-->

--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -1,3 +1,33 @@
+<script>
+    function setPrintViewUserContent(elResBlock) {
+        let htmlContent = elResBlock?.innerHTML || "";
+        //links must have https, they could have tags
+        let matchLinks = htmlContent.match(/(?<=https:\/\/).*?(?=\s|$|"|'|&gt;|<)/gi);
+        matchLinks = Array.from(new Set(matchLinks));
+        matchLinks.forEach(match => {
+            const linkText = match.length <= 50 ? match : match.slice(50) + '...';
+            const oldText = `https://${match}`;
+            const newText =   `<a href="https://${match}">${linkText}</a>`;
+
+            htmlContent = htmlContent.replaceAll(oldText, newText);
+            console.log(htmlContent);
+            const textEscaped = newText.replaceAll(".", "\\.").replaceAll("/", "\\/");
+            //<a\s+[^>]*href=['"]([^'"]*)['"][^>]*>(.*?)<\/a>
+            const regStr = `(&lt;|<)a\s+href=['"]${textEscaped}['"](>|&gt;)(.*?)(&lt;|<)/a(>|&gt;)`;
+            const tagReg = new RegExp(regStr, "gi");
+            const tagMatch = htmlContent.match(tagReg);
+            if(tagMatch?.length > 0) {
+                console.log("if", tagReg, tagMatch)
+                console.log(htmlContent);
+                htmlContent = htmlContent.replaceAll(tagMatch[0], newText);
+                console.log(htmlContent);
+            } else {
+                console.log("else", tagReg, tagMatch)
+            }
+        });
+        elResBlock.innerHTML = htmlContent;
+    }
+</script>
 <!--{strip}-->
     <!--{if !isset($depth)}-->
     <!--{assign var='depth' value=0}-->

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -43,7 +43,7 @@
             <script>
                 $(function() {
                     const elResBlock = document.getElementById("data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->");
-                    setPrintViewUserContent(elResBlock);
+                    setPrintViewUserLinkContent(elResBlock);
                 });
             </script>
         <!--{/if}-->

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -40,6 +40,12 @@
                 <!--{$indicator.value|replace:'  ':'&nbsp;&nbsp;'|sanitize}-->
             </span>
             <!--{$indicator.htmlPrint}-->
+            <script>
+                $(function() {
+                    const elResBlock = document.getElementById("data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->");
+                    setPrintViewUserContent(elResBlock);
+                });
+            </script>
         <!--{/if}-->
         <!--{if $indicator.format == 'radio'}-->
                 <span class="printResponse" id="data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->">


### PR DESCRIPTION
Adds a method to find and replace text  for multiselect format questions on the form print view.

Links with the following patterns should be clickable from the print view and open in a new window.
Links must use https

*.gov
dvagov.sharepoint.com
apps.gov.powerapps.us


**Impact / Testing**
 
This update finds and replaces displayed text on the form print view (?a=printview).  It could affect display but does not alter saved data.
Links, such as https://leaf.va.gov, entered into a multiselect format question should be clickable from the print view