### PR TITLE
Leaf 4571 - nexus cant delete tag unless removed from portal first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ libs/css/leaf.js
 
 x-test/API-tests/result_cache/*
 test/Test-Automation/ExtentReports/*
+mermaid.md

--- a/LEAF_Nexus/api/controllers/PlatformController.php
+++ b/LEAF_Nexus/api/controllers/PlatformController.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * As a work of the United States government, this project is in the public domain within the United States.
+ */
+
+namespace Orgchart;
+
+use App\Leaf\XSSHelpers;
+
+class PlatformController extends RESTfulResponse
+{
+    public $index = array();
+
+    private $API_VERSION = 1;    // Integer
+
+    private $db;
+
+    private $login;
+
+    private $platform;
+
+    public function __construct($db, $login, Platform $platform)
+    {
+        $this->db = $db;
+        $this->login = $login;
+        $this->platform = $platform;
+    }
+
+    public function get($act)
+    {
+        $verified = $this->login->getMembership();
+
+        $this->index['GET'] = new ControllerMap();
+
+        $this->index['GET']->register('platform/version', function () {
+            return $this->API_VERSION;
+        });
+
+        $this->index['GET']->register('platform/portal/[text]', function ($args) use ($verified) {
+            if (!isset($verified['groupID'][1])) {
+                $return_value = 'You do not have access to this resource, only Admin\'s can delete Tags.';
+            } else {
+                $portals = $this->platform->getLaunchpadSites($args[0]);
+                $return_value = array();
+
+                foreach ($portals as $portal) {
+                    $sql = 'USE ' . $portal['portal_database'];
+                    $this->db->query($sql);
+
+                    $return_value[] = array(
+                        'launchpadID' => $portal['launchpadID'],
+                        'site_path' => $portal['site_path'],
+                        'tags' => $this->platform->getTags($this->db)
+                    );
+                }
+            }
+
+            return $return_value;
+        });
+
+
+
+        return $this->index['GET']->runControl($act['key'], $act['args']);
+    }
+
+    public function post($act)
+    {
+        $this->index['POST'] = new ControllerMap();
+
+
+        return $this->index['POST']->runControl($act['key'], $act['args']);
+    }
+
+    public function delete($act)
+    {
+        // Not used in this file
+    }
+}

--- a/LEAF_Nexus/api/index.php
+++ b/LEAF_Nexus/api/index.php
@@ -8,7 +8,8 @@ error_reporting(E_ERROR);
 
 require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 
-$oc_db = $oc_db;
+$orgchart_db = $oc_db;
+$launchpad_db = $file_paths_db;
 $oc_login->setBaseDir('../');
 
 if (strtolower($oc_config->dbName) == strtolower(DIRECTORY_DB)) {
@@ -40,61 +41,69 @@ $controllerMap = new Orgchart\ControllerMap();
 
 switch ($key) {
     case 'group':
-        $controllerMap->register('group', function () use ($oc_db, $oc_login, $action) {
-            $groupController = new Orgchart\GroupController($oc_db, $oc_login);
+        $controllerMap->register('group', function () use ($orgchart_db, $oc_login, $action) {
+            $groupController = new Orgchart\GroupController($orgchart_db, $oc_login);
             $groupController->handler($action);
         });
 
         break;
     case 'position':
-        $controllerMap->register('position', function () use ($oc_db, $oc_login, $action) {
-            $positionController = new Orgchart\PositionController($oc_db, $oc_login);
+        $controllerMap->register('position', function () use ($orgchart_db, $oc_login, $action) {
+            $positionController = new Orgchart\PositionController($orgchart_db, $oc_login);
             $positionController->handler($action);
         });
 
         break;
     case 'employee':
-        $controllerMap->register('employee', function () use ($oc_db, $oc_login, $national_db, $action) {
-            $employeeController = new Orgchart\EmployeeController($oc_db, $oc_login, $national_db);
+        $controllerMap->register('employee', function () use ($orgchart_db, $oc_login, $national_db, $action) {
+            $employeeController = new Orgchart\EmployeeController($orgchart_db, $oc_login, $national_db);
             $employeeController->handler($action);
         });
 
         break;
     case 'indicator':
-        $controllerMap->register('indicator', function () use ($oc_db, $oc_login, $action) {
-            $indicatorController = new Orgchart\IndicatorController($oc_db, $oc_login);
+        $controllerMap->register('indicator', function () use ($orgchart_db, $oc_login, $action) {
+            $indicatorController = new Orgchart\IndicatorController($orgchart_db, $oc_login);
             $indicatorController->handler($action);
         });
 
         break;
     case 'tag':
-         $controllerMap->register('tag', function () use ($oc_db, $oc_login, $action) {
-            $tagController = new Orgchart\TagController($oc_db, $oc_login);
+         $controllerMap->register('tag', function () use ($orgchart_db, $oc_login, $action) {
+            $tagController = new Orgchart\TagController($orgchart_db, $oc_login);
             $tagController->handler($action);
          });
 
            break;
     case 'system':
-        $controllerMap->register('system', function () use ($oc_db, $oc_login, $action) {
-            $systemController = new Orgchart\SystemController($oc_db, $oc_login);
+        $controllerMap->register('system', function () use ($orgchart_db, $oc_login, $action) {
+            $systemController = new Orgchart\SystemController($orgchart_db, $oc_login);
             $systemController->handler($action);
+        });
+
+        break;
+    case 'platform':
+        $controllerMap->register('platform', function () use ($orgchart_db, $oc_login, $launchpad_db, $action) {
+            $platform = new Orgchart\Platform($orgchart_db, $oc_login, $launchpad_db);
+            $platformController = new Orgchart\PlatformController($orgchart_db, $oc_login, $platform);
+            $platformController->handler($action);
         });
 
         break;
     case 'national':
         $controllerMap->register('national', function () use ($action) {
-            $oc_db_nat = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
-            $oc_login_nat = new Orgchart\Login($oc_db_nat, $oc_db_nat);
+            $orgchart_db_nat = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
+            $oc_login_nat = new Orgchart\Login($orgchart_db_nat, $orgchart_db_nat);
 
-            $nationalEmployeeController = new Orgchart\NationalEmployeeController($oc_db_nat, $oc_login_nat);
+            $nationalEmployeeController = new Orgchart\NationalEmployeeController($orgchart_db_nat, $oc_login_nat);
             $nationalEmployeeController->handler($action);
         });
 
         break;
 
     case 'x':
-        $controllerMap->register('x', function () use ($oc_db, $oc_login, $action) {
-            $experimentalController = new Orgchart\ExperimentalController($oc_db, $oc_login);
+        $controllerMap->register('x', function () use ($orgchart_db, $oc_login, $action) {
+            $experimentalController = new Orgchart\ExperimentalController($orgchart_db, $oc_login);
             $experimentalController->handler($action);
         });
 

--- a/LEAF_Nexus/index.php
+++ b/LEAF_Nexus/index.php
@@ -255,7 +255,7 @@ switch ($action) {
             $t_form->assign('tag_hierarchy', $tag->getAll());
             $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
             $t_form->assign('userDomain', $oc_login->getDomain());
-            $t_form->assign('leaf_domain', trim(PORTAL_PATH, '/'));
+            $t_form->assign('orgchart_path', trim(PORTAL_PATH, '/'));
             $t_form->assign('timeZone', $tz);
 
             if (count($resGroup) > 0)

--- a/LEAF_Nexus/index.php
+++ b/LEAF_Nexus/index.php
@@ -9,7 +9,7 @@
 
 */
 /*
- * test comment for 4583 
+ * test comment for 4583
  */
 
 use App\Leaf\XSSHelpers;
@@ -255,6 +255,7 @@ switch ($action) {
             $t_form->assign('tag_hierarchy', $tag->getAll());
             $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
             $t_form->assign('userDomain', $oc_login->getDomain());
+            $t_form->assign('leaf_domain', trim(PORTAL_PATH, '/'));
             $t_form->assign('timeZone', $tz);
 
             if (count($resGroup) > 0)
@@ -394,7 +395,7 @@ switch ($action) {
         break;
     case 'view_group_permissions':
         $group = new Orgchart\Group($oc_db, $oc_login);
-    
+
         $t_form = new \Smarty;
         $t_form->left_delimiter = '<!--{';
         $t_form->right_delimiter = '}-->';

--- a/LEAF_Nexus/sources/Platform.php
+++ b/LEAF_Nexus/sources/Platform.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * As a work of the United States government, this project is in the public domain within the United States.
+ */
+
+/*
+    System controls
+    Date: September 17, 2015
+
+*/
+
+namespace Orgchart;
+
+use \App\Leaf\Db;
+
+class Platform
+{
+    public $siteRoot = '';
+
+    private $db;
+
+    private $login;
+
+    private $launchpad_db;
+
+    public function __construct(Db $db, Login $login, Db $launchpad_db)
+    {
+        $this->db = $db;
+        $this->login = $login;
+        $this->launchpad_db = $launchpad_db;
+
+        $protocol = 'https';
+        $this->siteRoot = "{$protocol}://" . HTTP_HOST . dirname($_SERVER['REQUEST_URI']) . '/';
+    }
+
+    public function getLaunchpadSites(string $orgchart_path): array
+    {
+        $vars = array(':orgchart_path' => '/' . $orgchart_path);
+        $sql = 'SELECT `launchpadID`, `site_path`, `portal_database`
+                FROM `sites`
+                WHERE `orgchart_path` = :orgchart_path
+                AND `site_type` = "portal"';
+
+        $sites = $this->launchpad_db->prepared_query($sql, $vars);
+
+        return $sites;
+    }
+
+    public function getTags(Db $portal_db): array
+    {
+        $vars = array(':tag' => 'orgchartImportTags');
+        $sql = 'SELECT `data`
+                FROM `settings`
+                WHERE `setting` = :tag';
+
+        $tags = $portal_db->prepared_query($sql, $vars);
+
+        return json_decode($tags[0]['data'], true);
+    }
+}

--- a/LEAF_Nexus/templates/view_group.tpl
+++ b/LEAF_Nexus/templates/view_group.tpl
@@ -347,7 +347,7 @@ function confirmDeleteTag(inTag) {
     let validate = {'groupID': '<!--{$groupID}-->'};
     $.ajax({
         type: 'GET',
-        url: './api/platform/portal/_<!--{$leaf_domain}-->',
+        url: './api/platform/portal/_<!--{$orgchart_path}-->',
         success: function(response) {
             if (response.constructor === Array) {
                 response.forEach(function (item, index) {
@@ -370,7 +370,7 @@ function confirmDeleteTag(inTag) {
                                     if (found) {
                                         // need to display a message that this can't be done
                                         dialog_ok.setTitle('Warning');
-                                        dialog_ok.setContent('Tags cannot be removed here until all references to them are removed from the cooresponding portal.');
+                                        dialog_ok.setContent('Corresponding portal tags must be removed prior to taking this action.');
                                         dialog_ok.setSaveHandler(function() {
                                             dialog_ok.clearDialog();
                                             dialog_ok.hide();

--- a/LEAF_Nexus/templates/view_group.tpl
+++ b/LEAF_Nexus/templates/view_group.tpl
@@ -91,6 +91,7 @@
 <!--{include file="site_elements/generic_xhrDialog.tpl"}-->
 <!--{include file="site_elements/generic_confirm_xhrDialog.tpl"}-->
 <!--{include file="site_elements/generic_dialog.tpl"}-->
+<!--{include file="site_elements/generic_OkDialog.tpl"}-->
 
 <div id="orgchartForm"></div>
 
@@ -343,24 +344,88 @@ function confirmUnlinkEmployee(empUID) {
 }
 
 function confirmDeleteTag(inTag) {
-    var warning = '';
-    warning = '<br /><br /><span style="color: red">WARNING!! removal of service would potentially impact your org chart structure, if you are trying to grant service chief access go to Request Portal->Admin panel-> Service Chief</span>';
+    let validate = {'groupID': '<!--{$groupID}-->'};
+    $.ajax({
+        type: 'GET',
+        url: './api/platform/portal/_<!--{$leaf_domain}-->',
+        success: function(response) {
+            if (response.constructor === Array) {
+                response.forEach(function (item, index) {
+                    item.tags.forEach(function (tag) {
+                        if (tag === inTag) {
+                            // need to check the portal for this tag in this group
+                            $.ajax({
+                                type: 'GET',
+                                url: '..' + item.site_path + '/api/group/list',
+                                success: function (response) {
+                                    console.log(response);
+                                    let found = false;
 
-    confirm_dialog.setContent('<img src="dynicons/?img=help-browser.svg&amp;w=48" alt="" style="float: left; padding-right: 16px" /> <span style="font-size: 150%">Are you sure you want to delete this tag?</span>'+ warning);
-    confirm_dialog.setTitle('Confirmation');
-    confirm_dialog.setSaveHandler(function() {
-        $.ajax({
-        	type: 'DELETE',
-            url: './api/group/<!--{$groupID}-->/tag?' +
-                $.param({tag: inTag,
-                         CSRFToken: '<!--{$CSRFToken}-->'}),
-            success: function(response) {
-                window.location.reload();
-            },
-            cache: false
-        });
+                                    response.forEach(function (group) {
+                                        if (group.groupID === Number(validate.groupID)) {
+                                            found = true;
+                                        }
+                                    });
+
+                                    if (found) {
+                                        // need to display a message that this can't be done
+                                        dialog_ok.setTitle('Warning');
+                                        dialog_ok.setContent('Tags cannot be removed here until all references to them are removed from the cooresponding portal.');
+                                        dialog_ok.setSaveHandler(function() {
+                                            dialog_ok.clearDialog();
+                                            dialog_ok.hide();
+                                            dialog.hide();
+                                        });
+                                        dialog_ok.show();
+
+                                    } else {
+                                        // proceed with the delete
+                                        let warning = '';
+                                        warning = '<br /><br /><span style="color: red">WARNING!! removal of service would potentially impact your org chart structure, if you are trying to grant service chief access go to Request Portal->Admin panel-> Service Chief</span>';
+
+                                        confirm_dialog.setContent('<img src="dynicons/?img=help-browser.svg&amp;w=48" alt="" style="float: left; padding-right: 16px" /> <span style="font-size: 150%">Are you sure you want to delete this tag?</span>'+ warning);
+                                        confirm_dialog.setTitle('Confirmation');
+                                        confirm_dialog.setSaveHandler(function() {
+                                            $.ajax({
+                                                type: 'DELETE',
+                                                url: './api/group/<!--{$groupID}-->/tag?' +
+                                                    $.param({tag: inTag,
+                                                            CSRFToken: '<!--{$CSRFToken}-->'}),
+                                                success: function(response) {
+                                                    window.location.reload();
+                                                },
+                                                cache: false
+                                            });
+                                        });
+                                        confirm_dialog.show();
+                                    }
+                                },
+                                error: function(err) {
+                                    console.log(err);
+                                }
+                            });
+                        }
+                    })
+                })
+            } else {
+                dialog_ok.setTitle('Warning');
+                dialog_ok.setContent(response);
+                dialog_ok.setSaveHandler(function() {
+                    dialog_ok.clearDialog();
+                    dialog_ok.hide();
+                    dialog.hide();
+                });
+                dialog_ok.show();
+            }
+        },
+        error: function(err) {
+            console.log(err);
+        },
+        cache: false
     });
-    confirm_dialog.show();
+
+
+
 }
 
 function writeTag(input, groupID) {
@@ -511,6 +576,7 @@ $(function() {
     dialog = new dialogController('xhrDialog', 'xhr', 'loadIndicator', 'button_save', 'button_cancelchange');
     confirm_dialog = new dialogController('confirm_xhrDialog', 'confirm_xhr', 'confirm_loadIndicator', 'confirm_button_save', 'confirm_button_cancelchange');
     dialog_message = new dialogController('genericDialog', 'genericDialogxhr', 'genericDialogloadIndicator', 'genericDialogbutton_save', 'genericDialogbutton_cancelchange');
+    dialog_ok = new dialogController('ok_xhrDialog', 'ok_xhr', 'ok_loadIndicator', 'confirm_button_ok', 'confirm_button_cancelchange');
 });
 
 </script>


### PR DESCRIPTION
Summary:
Currently, If you go to the nexus and search for a group and view the group. When you click on a tag name a popup will ask if you are sure you want to remove the tag. It doesn't matter if the group is still in the portal or not, the tag will be removed.
With this PR, when you click on the tag name the system checks that the group is no longer in the portal that was clicked. If it does exist in the portal a message will appear telling the user that the tag cannot be removed until the group is removed from the portal. If it does not exist in the portal the user will be asked if they are sure they want to remove the tag.

```mermaid
graph TB
    subgraph Nexus
        group(Group)
    end

    subgraph Platform API
        platform_api(return all portals<br>for orgchart)
    end

    subgraph Frontend
        script(process returned call)
    end

    subgraph Warning Message
        warning_message(Corresponding portal tags must be removed prior to taking this action.)
    end

    subgraph Delete Confirmation
        delete_confirm(<span style="color: red">WARNING!! removal of service would potentially impact your org chart structure, if you are trying to grant service chief access go to Request Portal->Admin panel-> Service Chief</span>)
    end

    

    group -- click tag name --> platform_api
    platform_api --> script
    script -- group still exists<br>on portal --> warning_message
    script -- group does not exist<br>on portal--> delete_confirm
    delete_confirm -- Yes --> Tag_deleted
    delete_confirm -- No --> Tag_remains
```

Potential Impact:
This change should make it so that group tags cannot be removed when they are still active portal side, keeping data integrity intact. 

Acceptance Criteria:
A tag in the nexus can only be removed once the group is removed from the User Access Groups on that portal. Also, having a message appear when the reference is still present portal side telling user to remove portal side first.

Testing:
Go to nexus and search for a group that is known to still be in the portal. Click on the portals tag to remove it. A message should appear informing user that this action is not permitted until the reference on the portal side is removed.
Go to nexus and search for a group that is know NOT to exist portal side. Click on the portals tag to remove it. A message should appear asking user if they are sure they want to remove tag. Clicking Yes should remove it, clicking cancel should leave it where it is.

Updating DB Schema: Request Portal... OK
Updating DB Schema: Local Nexus (Orgchart)... OK
Updating DB Schema: National Nexus (Orgchart)... OK
PASS
ok  	LEAF/API-tester	9.024s