### PR TITLE
LEAF 4683 variable fix for requests pending person-designated inactive accounts 

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -204,11 +204,10 @@ class FormWorkflow
                 // Only amend approverName for person designated records
                 if($v['dependencyID'] == -1) {
                     $approver = $dir->lookupEmpUID($dRecords[$v['recordID']]['data']);
-                    
                     if (empty($approver[0]['Fname']) && empty($approver[0]['Lname'])) {
                         $srcRecords[$i]['description'] = $srcRecords[$i]['stepTitle'] . ' ( *NEEDS REASSIGNMENT* ' . $dRecords[$v['recordID']]['name'] . ')';
                         $srcRecords[$i]['approverName'] = '*NEEDS REASSIGNMENT* ' . $dRecords[$v['recordID']]['name'];
-                        $srcRecords[$i]['approverUID'] = 'indicatorID:' . $res[$i]['indicatorID_for_assigned_empUID'];
+                        $srcRecords[$i]['approverUID'] = 'indicatorID:' . $srcRecords[$i]['indicatorID_for_assigned_empUID'];
                     }
                     else {
                         $srcRecords[$i]['description'] = $srcRecords[$i]['stepTitle'] . ' (' . $approver[0]['Fname'] . ' ' . $approver[0]['Lname'] . ')';


### PR DESCRIPTION
Updates a variable used for an alternate approver UID value when the person-designated account is disabled.
This alternate value had not been correctly set.  This led to non-unique DOM element ids and associated listeners would not function correctly.


**Impact/Testing**

This issue affects the LEAF Inbox when there are multiple requests pending action for different person-designated requirements (different orgchart_employee indicator IDs) and the associated accounts are disabled.

To test locally:

Submit 2 requests for a 'multiple person designated' form.

Move one of them along to 'reviewer 1', and the other to 'reviewer 2'.

Go to the inbox.  Select view as admin.  Organize by role.

At this point, both requests should be pending the user that was entered for respective steps.

In adminer, change the associated portal table data.data values for the requests that were entered to an empUID that does not exist (eg 99999).

Refresh the inbox.  New 'needs reassignment' headers should contain the pending requests.  These headers should open when clicked, and/or by tab-enter.
