### PR TITLE
LEAF 4687 move url method to parent template

### DIFF
--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -1,38 +1,3 @@
-<script>
-    function setPrintViewUserLinkContent(elResBlock) {
-        let htmlContent = elResBlock?.innerHTML || "";
-        if (htmlContent !== "") {
-            const whitelist = {
-                "dvagov.sharepoint.com": 1,
-                "apps.gov.powerapps.us": 1
-            }
-            //links must have https, they could have tags. only grab the url content here and filter based on whitelist
-            let matchLinks = htmlContent.match(/(?<=https:\/\/).*?(?=\s|$|"|'|&gt;|<)/gi);
-            matchLinks = Array.from(new Set(matchLinks));
-            matchLinks = matchLinks.filter(url => {
-                const baseurl = (url.split("/")[0] || "").toLowerCase();
-                return baseurl.endsWith(".gov") || whitelist[baseurl] === 1;
-            });
-
-            matchLinks.forEach(match => {
-                const linkText = match.length <= 50 ? match : match.slice(0,50) + '...';
-                const oldText = `https://${match}`;
-                const newText =   `<a href="https://${match}" target="_blank">https://${linkText}</a>`;
-                //initial replacement
-                htmlContent = htmlContent.replace(oldText, newText);
-
-                //if user tried to add anchor tags this will replace them. link text was will be replaced by the new link text.
-                const textEscaped = newText.replaceAll(".", "\\.").replaceAll("?", "\\?");
-                const regStr = `(&lt;|<)a\\s+href=['"]${textEscaped}['"](>|&gt;)(.*)?(&lt;|<)/a(>|&gt;)`;
-                const tagReg = new RegExp(regStr, "gi");
-                if(tagReg.test(htmlContent)) {
-                    htmlContent = htmlContent.replace(tagReg, newText);
-                }
-            });
-            elResBlock.innerHTML = htmlContent;
-        }
-    }
-</script>
 <!--{strip}-->
     <!--{if !isset($depth)}-->
     <!--{assign var='depth' value=0}-->

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -41,10 +41,12 @@
             </span>
             <!--{$indicator.htmlPrint}-->
             <script>
-                $(function() {
-                    const elResBlock = document.getElementById("data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->");
-                    setPrintViewUserLinkContent(elResBlock);
-                });
+                (function() {
+                    if(typeof setPrintViewUserLinkContent === 'function') {
+                        const elResBlock = document.getElementById("data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->");
+                        setPrintViewUserLinkContent(elResBlock);
+                    }
+                })();
             </script>
         <!--{/if}-->
         <!--{if $indicator.format == 'radio'}-->


### PR DESCRIPTION
This moves the method used to find-replace URLs to parent template print form to prevent the code from being associated with more template sections than intended.

This was noticed because it modified code behavior for a user getting jquery element text() through selector #xhrIndicator_id.
This is not a consistent selector regardless, so I am not sure what test modifications specific to this feature should be made.

A wrapper check has also been added prior to the function call, since portals with custom print-form templates will not have this method.  
