### PR TITLE
LEAF 4685 - limit data importer requests with interval queue

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
@@ -548,7 +548,7 @@
 
         function importNew() {
             let requestQueue = new intervalQueue();
-
+            let hasSensitiveField = false; //updated to true in makeIndicator if a question is marked as sensitive
             $('#status').html('Processing...'); /* UI hint */
             var newFormIndicators = $('#new_form_indicators');
             var workflowID = $('#workflowID > option:selected').val();
@@ -587,6 +587,9 @@
                     function makeIndicator() {
                         /* Creates indicators synchronously, then moves on to next step of filling out requests */
                         if (formCreationIndex < indicatorTableRows.length) {
+                            if ($("td:eq(4) > input", indicatorTableRows[formCreationIndex]).is(":checked") === true) {
+                                hasSensitiveField = true;
+                            }
                             $.ajax({
                                 method: 'POST',
                                 url: './api/formEditor/newIndicator',
@@ -614,6 +617,19 @@
                             });
 
                         } else {
+                            if (hasSensitiveField === true) {
+                                $.ajax({
+                                    type: 'POST',
+                                    url: `./api/formEditor/formNeedToKnow`,
+                                    data: {
+                                        needToKnow: 1,
+                                        categoryID: newCategoryID,
+                                        CSRFToken: CSRFToken
+                                    },
+                                    success: () => {},
+                                    error: err => console.log('set form need to know post err', err)
+                                });
+                            }
                             requestStatus.html(indicators.length.toString() + ' out of ' + indicatorTableRows.length + ' questions added.');
                             requestStatus.html('Filling out form...');
 

--- a/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_import_data.tpl
@@ -423,7 +423,6 @@
                     async: !preserveOrder,
                     success(recordID) {
                         if(recordID > 0) {
-                            //console.log("req create success", recordID)
                             delete requestData.title;
                             requestData['CSRFToken'] = CSRFToken;
 
@@ -436,7 +435,6 @@
                                     if (result > 0) {
                                         createdRequests++;
                                         updateReportStatus(title);
-                                        //console.log("req update success")
                                         resolve();
                                     } else {
                                         logFailure(title, `error adding data for request ${recordID}`)
@@ -781,7 +779,7 @@
                                     });
                                 });
                             });
-                            const concurrency = preserveOrder ? 1 : 2;
+                            const concurrency = preserveOrder ? 0 : 1;
                             requestQueue.setConcurrency(concurrency);
                             requestQueue.start().then(res => {
                                 progressbar.progressbar("value", 100);
@@ -974,7 +972,7 @@
                     });
                 });
             });
-            const concurrency = preserveOrder ? 1 : 2;
+            const concurrency = preserveOrder ? 0 : 1;
             console.log("set con", concurrency)
             requestQueue.setConcurrency(concurrency);
             requestQueue.start().then(res => {


### PR DESCRIPTION
## Summary

The initial scope of this update was to add the interval queue to the Toolbox - Import Spreadsheet (LEAF_import_data ) utility report.  Unlimited rates would cause imports with a large number of rows (~1000+) to fail on production.

The scope was expanded to resolve column order issues, fix an unresolved promise that would stop the import process, and add a needtoknow update if a question on a new form is marked as sensitive.
Minor template logic was also added to restrict display of the 'new form' choice to admins.

All changes are to the front end LEAF_import_data template file.

## Impact

This update affects the portal admin Import Spreadsheet utility.
Users with a moderate-large number of updates (~1000) will find that the process is slower.
This should correct breaking issues for imports with a large number of requests


## Testing

This report can be navigated to from
Portal Admin -> Toolbox -> Import spreadsheet

See attachments to Jira-4685 for a file with
a ~1200 row import
a file for testing orgchart errors
a local file for testing orgchart errors

The report import process is guided once a file is chosen.

Select 'new form' for the initial tests of the 1200 import and orgchart import (the import will create the associated form).
For the orgchart file, specify that 'Org Emp' is an orgchart employee format.  The other formats can be left as single line text.
Once a form exists, followup testing can use the existing form option.

- New Form option: indicators/questions should reflect the column order on the spreadsheets used to create them.
Go to the Form Editor to see the resulting form

- New Form option: If any question is marked as sensitive, form need to know will be turned on after questions have been added. 

- The unordered import of 1200 rows should succeed.  Use the resulting report button/link (it will open a Report Builder view) to get a list of the imported requests.  Modify the search and include the form's questions to confirm that data saved for the requests.  This should be re-tested on Academy/Demo1 (production) when the update is made live.

- Check the 'preserve row order' checkbox) to test importing requests in order (this process will be slower).
When an import is completed, a button will appear at the bottom of the report. Navigation will go to a Report Builder report. Choose 'Modify Search' and on step 2 select the letter and number columns for the associated form. Sort by UID - the number and letter columns can be used to judge whether the requests imported in order.

- The import of _orgchart_error file should finish.
A request will not be made for the row that errored, but the process itself should complete.  Previously, failure to locate an employee email would result in an unresolved promise and the import to stop at that row.

- Non-admins should not see the 'new form' option.
Go to adminer, leaf_portal_API_testing.users and change the row with tester tester groupID 1 to another number so they are not in admin. Change it back to 1 after testing.

