### PR TITLE
Leaf 4571 - nexus tags only delete when not used

### DIFF
--- a/LEAF_Nexus/api/controllers/PlatformController.php
+++ b/LEAF_Nexus/api/controllers/PlatformController.php
@@ -36,11 +36,11 @@ class PlatformController extends RESTfulResponse
             return $this->API_VERSION;
         });
 
-        $this->index['GET']->register('platform/portal/[text]', function ($args) use ($verified) {
+        $this->index['GET']->register('platform/portal', function ($args) use ($verified) {
             if (!isset($verified['groupID'][1])) {
                 $return_value = 'You do not have access to this resource, only Admin\'s can delete Tags.';
             } else {
-                $portals = $this->platform->getLaunchpadSites($args[0]);
+                $portals = $this->platform->getLaunchpadSites();
                 $return_value = array();
 
                 foreach ($portals as $portal) {
@@ -50,7 +50,7 @@ class PlatformController extends RESTfulResponse
                     $return_value[] = array(
                         'launchpadID' => $portal['launchpadID'],
                         'site_path' => $portal['site_path'],
-                        'tags' => $this->platform->getTags($this->db)
+                        'orgchartImportTags' => $this->platform->getTags($this->db)
                     );
                 }
             }

--- a/LEAF_Nexus/index.php
+++ b/LEAF_Nexus/index.php
@@ -255,7 +255,6 @@ switch ($action) {
             $t_form->assign('tag_hierarchy', $tag->getAll());
             $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
             $t_form->assign('userDomain', $oc_login->getDomain());
-            $t_form->assign('orgchart_path', trim(PORTAL_PATH, '/'));
             $t_form->assign('domain', trim(LEAF_DOMAIN, '/'));
             $t_form->assign('timeZone', $tz);
 

--- a/LEAF_Nexus/sources/Platform.php
+++ b/LEAF_Nexus/sources/Platform.php
@@ -33,10 +33,10 @@ class Platform
         $this->siteRoot = "{$protocol}://" . HTTP_HOST . dirname($_SERVER['REQUEST_URI']) . '/';
     }
 
-    public function getLaunchpadSites(string $orgchart_path): array
+    public function getLaunchpadSites(): array
     {
-        $path = strpos(LEAF_NEXUS_URL, 'host.docker.internal') ? '' : '/orgchart';
-        $vars = array(':orgchart_path' => '/' . $orgchart_path . $path);
+        $orgchart_path = strpos(LEAF_NEXUS_URL, 'host.docker.internal') ? str_replace('/orgchart', '', trim(PORTAL_PATH, '/')) : trim(PORTAL_PATH, '/');
+        $vars = array(':orgchart_path' => '/' . $orgchart_path);
         $sql = 'SELECT `launchpadID`, `site_path`, `portal_database`
                 FROM `sites`
                 WHERE `orgchart_path` = :orgchart_path

--- a/LEAF_Nexus/templates/view_group.tpl
+++ b/LEAF_Nexus/templates/view_group.tpl
@@ -347,9 +347,7 @@ function confirmDeleteTag(inTag) {
     let validate = {'groupID': '<!--{$groupID}-->'};
     let warning = '';
     let domain = '<!--{$domain}-->' + '/';
-    let orgchart_path = '<!--{$orgchart_path}-->' + '/';
     let tag_found = false;
-    orgchart_path = orgchart_path.replace('/orgchart', '');
 
     warning = '<br /><br /><span style="color: red">WARNING!! removal of service would potentially impact your org chart structure, if you are trying to grant service chief access go to Request Portal->Admin panel-> Service Chief</span>';
 
@@ -358,11 +356,11 @@ function confirmDeleteTag(inTag) {
 
     $.ajax({
         type: 'GET',
-        url: './api/platform/portal/_' + orgchart_path,
+        url: './api/platform/portal',
         success: function(response) {
             if (response.constructor === Array) {
                 response.forEach(function (item, index) {
-                    item.tags.forEach(function (tag) {
+                    item.orgchartImportTags.forEach(function (tag) {
                         if (tag === inTag) {
                             // need to check the portal for this tag in this group
                             $.ajax({

--- a/LEAF_Nexus/templates/view_group.tpl
+++ b/LEAF_Nexus/templates/view_group.tpl
@@ -348,6 +348,7 @@ function confirmDeleteTag(inTag) {
     let warning = '';
     let domain = '<!--{$domain}-->' + '/';
     let orgchart_path = '<!--{$orgchart_path}-->' + '/';
+    let tag_found = false;
     orgchart_path = orgchart_path.replace('/orgchart', '');
 
     warning = '<br /><br /><span style="color: red">WARNING!! removal of service would potentially impact your org chart structure, if you are trying to grant service chief access go to Request Portal->Admin panel-> Service Chief</span>';
@@ -370,6 +371,7 @@ function confirmDeleteTag(inTag) {
                                 success: function (response) {
                                     if (response.some(group => group.groupID === Number(validate.groupID))) {
                                         // need to display a message that this can't be done
+                                        tag_found = true;
                                         dialog_ok.setTitle('Warning');
                                         dialog_ok.setContent('Corresponding portal tags must be removed prior to taking this action.');
                                         dialog_ok.setSaveHandler(function() {
@@ -378,52 +380,36 @@ function confirmDeleteTag(inTag) {
                                             dialog.hide();
                                         });
                                         dialog_ok.show();
-
-                                    } else {
-                                        // proceed with the delete
-                                        confirm_dialog.setSaveHandler(function() {
-                                            $.ajax({
-                                                type: 'DELETE',
-                                                url: './api/group/<!--{$groupID}-->/tag?' +
-                                                    $.param({tag: inTag,
-                                                            CSRFToken: '<!--{$CSRFToken}-->'}),
-                                                success: function(response) {
-                                                    window.location.reload();
-                                                },
-                                                error: function (err) {
-                                                    console.log(err);
-                                                },
-                                                cache: false
-                                            });
-                                        });
-                                        confirm_dialog.show();
                                     }
                                 },
                                 error: function(err) {
                                     console.log(err);
-                                }
+                                },
+                                async: false
                             });
-                        } else if (inTag == 'service' || inTag == 'ELT' || inTag == 'Quadrad') {
-                            // tag was not found in any portal need to ask to delete
-                            confirm_dialog.setSaveHandler(function() {
-                                $.ajax({
-                                    type: 'DELETE',
-                                    url: './api/group/<!--{$groupID}-->/tag?' +
-                                        $.param({tag: inTag,
-                                                CSRFToken: '<!--{$CSRFToken}-->'}),
-                                    success: function(response) {
-                                        window.location.reload();
-                                    },
-                                    error: function (err) {
-                                        console.log(err);
-                                    },
-                                    cache: false
-                                });
-                            });
-                            confirm_dialog.show();
                         }
                     })
-                })
+                });
+
+                if (!tag_found) {
+                    // tag was not found in any portal need to ask to delete
+                    confirm_dialog.setSaveHandler(function() {
+                        $.ajax({
+                            type: 'DELETE',
+                            url: './api/group/<!--{$groupID}-->/tag?' +
+                                $.param({tag: inTag,
+                                        CSRFToken: '<!--{$CSRFToken}-->'}),
+                            success: function(response) {
+                                window.location.reload();
+                            },
+                            error: function (err) {
+                                console.log(err);
+                            },
+                            cache: false
+                        });
+                    });
+                    confirm_dialog.show();
+                }
             } else {
                 dialog_ok.setTitle('Warning');
                 dialog_ok.setContent(response);
@@ -440,9 +426,6 @@ function confirmDeleteTag(inTag) {
         },
         cache: false
     });
-
-
-
 }
 
 function writeTag(input, groupID) {

--- a/LEAF_Nexus/templates/view_group.tpl
+++ b/LEAF_Nexus/templates/view_group.tpl
@@ -346,7 +346,7 @@ function confirmUnlinkEmployee(empUID) {
 function confirmDeleteTag(inTag) {
     let validate = {'groupID': '<!--{$groupID}-->'};
     let warning = '';
-    let domain = '<!--{$domain}-->' + '/';
+    let domain = '<!--{$domain}-->';
     let tag_found = false;
 
     warning = '<br /><br /><span style="color: red">WARNING!! removal of service would potentially impact your org chart structure, if you are trying to grant service chief access go to Request Portal->Admin panel-> Service Chief</span>';


### PR DESCRIPTION
This PR is in lieu of #2682 - nexus can't be delete tag unless removed from portal first and makes adjustments to the script to allow orphaned tags to be removed.

#2682 - nexus can't be delete tag unless removed from portal first, added a new Nexus API endpoint 'api/platform/portal' see this PR for further details.

