### PR TITLE
Allow disabling employees

### DIFF
--- a/scripts/scheduled-task-commands/disableNationalOrgchartEmployees.php
+++ b/scripts/scheduled-task-commands/disableNationalOrgchartEmployees.php
@@ -2,7 +2,7 @@
 require_once 'globals.php';
 require_once APP_PATH . '/Leaf/Db.php';
 require_once APP_PATH . '/Leaf/VAMCActiveDirectory.php';
-exit();
+
 $startTime = microtime(true);
 
 $national_db = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, 'national_orgchart');


### PR DESCRIPTION
## Summary
Need to re-open disabling employees by removing the exit in the file.

## Impact
Employees that need to be disabled will be

## Testing
Run the disable script and employees with a lastUpdated timestamp older than 30 hours will get a deleted timestamp