### PR TITLE
Leaf 4702 - update AD importer

### DIFF
--- a/app/Leaf/VAMCActiveDirectory.php
+++ b/app/Leaf/VAMCActiveDirectory.php
@@ -264,14 +264,14 @@ class VAMCActiveDirectory
 
                 $this->db->prepared_query($sql, $vars);
             } else {
-                $vars = array(':loginName', $this->users[$key]['loginName'],
-                            ':lname', $this->users[$key]['lname'],
-                            ':fname', $this->users[$key]['fname'],
-                            ':midIni', $this->users[$key]['midIni'],
-                            ':phoneticFname', $phoneticFname,
-                            ':phoneticLname', $phoneticLname,
-                            ':domain', $this->users[$key]['domain'],
-                            ':lastUpdated', $time);
+                $vars = array(':loginName' => $this->users[$key]['loginName'],
+                            ':lname' => $this->users[$key]['lname'],
+                            ':fname' => $this->users[$key]['fname'],
+                            ':midIni' => $this->users[$key]['midIni'],
+                            ':phoneticFname' => $phoneticFname,
+                            ':phoneticLname' => $phoneticLname,
+                            ':domain' => $this->users[$key]['domain'],
+                            ':lastUpdated' => $time);
 
                 $this->db->prepared_query($sql1, $vars);
 


### PR DESCRIPTION
## Summary
This change helps Help Desk in that new users will get imported into Leaf from AD where previously they were not.

## Impact
Help Desk should see a decrease in the number of requests to manually import users from AD

## Testing
Run the nightly script to import users from AD
Any new users should be in the National Orgchart