### PR TITLE
Leaf 4704 - hotfix use db

### DIFF
--- a/LEAF_Nexus/api/controllers/PlatformController.php
+++ b/LEAF_Nexus/api/controllers/PlatformController.php
@@ -44,7 +44,7 @@ class PlatformController extends RESTfulResponse
                 $return_value = array();
 
                 foreach ($portals as $portal) {
-                    $sql = 'USE ' . $portal['portal_database'];
+                    $sql = 'USE `' . $portal['portal_database'] . '`';
                     $this->db->query($sql);
 
                     $return_value[] = array(


### PR DESCRIPTION
## Summary
This change addresses a use db_name command that doesn't work when a db_name has a dash in it. 

## Impact
This allows portals with dashes in the db name to use the delete tag api endpoint.

## Testing
Once released go to a portal with a dash in the name (more specifically in the db name) attempt to delete it's tag from the nexus group area.