### PR TITLE
LEAF-4707 Avoid playwright warning

### DIFF
--- a/docker/playwright/playwright.dockerfile
+++ b/docker/playwright/playwright.dockerfile
@@ -6,4 +6,4 @@ RUN npm install -D mysql2
 
 WORKDIR /usr/app/leaf
 RUN npx playwright install --with-deps
-CMD node main.js
+CMD npx playwright install && node main.js

--- a/docker/playwright/playwright.dockerfile
+++ b/docker/playwright/playwright.dockerfile
@@ -6,4 +6,5 @@ RUN npm install -D mysql2
 
 WORKDIR /usr/app/leaf
 RUN npx playwright install --with-deps
+# Second "playwright install" needed to workaround issue on first run: "Playwright was just installed or updated"
 CMD npx playwright install && node main.js


### PR DESCRIPTION
## Summary
This avoids an issue in the development environment, where on first run, the end2end test suite would error with "Looks like Playwright Test or Playwright was just installed or updated...".

## Impact
The changes are limited to the development environment.

## Testing
After deleting all development docker volumes, containers, and images, following the instructions in https://github.com/department-of-veterans-affairs/LEAF/blob/master/docs/InstallationConfiguration.md results in a working environment. Then, following prompts to run the end2end test suite should not result in any errors or failures.