### PR TITLE
Leaf 4701 - fix organize by form view

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -528,8 +528,9 @@
         formGrid.setHeaders(headers);
         let tGridData = [];
         let hasServices = false;
+
         recordIDs.forEach(recordID => {
-            if (res[recordID].stepTitle === noSpaceCurrentStatus.replace(/_/g, ' ')) {
+            if (noSpaceCurrentStatus === '' || res[recordID].stepTitle === noSpaceCurrentStatus.replace(/_/g, ' ')) {
                 if (res[recordID].service != null) {
                     hasServices = true;
                 }


### PR DESCRIPTION
## Summary
Initial work here caused the Organize by form view to not display anything. This is the fix for that

## Impact
Organize by form will now work

## Testing
Go to inbox organize by form and open one of the forms requests should be there