### PR TITLE
LEAF-4714 Redirect "inactive" users through authentication path automatically

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -24,9 +24,6 @@ function customTemplate($tpl)
 $dataActionLogger = new DataActionLogger($db, $login);
 
 $login->loginUser();
-if ($login)
-{
-}
 
 $action = isset($_GET['a']) ? $_GET['a'] : '';
 

--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -16,12 +16,6 @@ header('X-UA-Compatible: IE=edge');
 
 $login->loginUser();
 
-if (!$login->isLogin() || !$login->isInDB()) {
-    $login->logout(); // destroy current session tokens
-    header("Location: session_expire.php");
-    exit;
-}
-
 $main = new Smarty;
 $t_login = new Smarty;
 $t_menu = new Smarty;

--- a/LEAF_Request_Portal/report.php
+++ b/LEAF_Request_Portal/report.php
@@ -18,14 +18,6 @@ require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 header('X-UA-Compatible: IE=edge');
 
 $login->loginUser();
-if (!$login->isLogin() || !$login->isInDB())
-{
-    echo 'Session expired, please refresh the page.<br /><br />If this message persists, please contact your administrator.';
-    echo '<br />' . $login->getName();
-    echo '<br />' . $login->getUserID();
-    $login->logout(); // destroy current session tokens
-    exit;
-}
 
 $main = new Smarty;
 $t_login = new Smarty;


### PR DESCRIPTION
## Summary
This resolves an issue where new users who visit a site see a "session expired" message. 

This refactors some logic out of `loginUser()` into a new `requestAuthentication()`. The old logic shows the error message because the local Nexus doesn't contain an active reference to the user.

The new logic transparently routes them through the authentication process, which creates an active reference in the local Nexus, and avoids the error message.

## Impact
This potentially has high impact for user logins and automated scripts. Pre-prod testing is required to help mitigate potential issues.

## Testing
- [ ] Pre-prod testing required:
  1. Navigate to a Site's homepage, and click "Logout"
  2. Manually edit the site's Nexus database's employee table, and change your account's `deleted` field to 1
  3. Navigate to the same homepage again
  4. You should see the normal homepage, and not any "Session Expired" message

- [ ] Pre-prod testing:
  1. Navigate to a Site's homepage, and click "Logout"
  2. Manually edit the site's Nexus database's employee table, and change your account's `deleted` field to 1
  3. Manually edit the National Nexus database's employee table, and change your account's `deleted` field to 1
  4. Navigate to the same homepage again
  5. You should see the manual login page `./login/index.php`
  6. You should not be able to log in
  7. Manually edit the National Nexus database's employee table, and change your account's `deleted` field to 0
  8. You should be able to log in

- [ ] Pre-prod: test automated scripts to ensure they work correctly

- Automated test: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/70

