### PR TITLE
LEAF-4700 - if need to know is enabled, replace request titles in emails with the type of form.

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -77,11 +77,11 @@
                             </tr>
                             <tr>
                                 <td><b>{{$fullTitle}}</b></td>
-                                <td>The full title of the request</td>
+                                <td>The full title of the request. <span style="color:#c00000;">If Need to Know is on: The type of form.</span></td>
                             </tr>
                             <tr>
                                 <td><b>{{$truncatedTitle}}</b></td>
-                                <td>A truncated version of the request title</td>
+                                <td>A truncated version of the request title. <span style="color:#c00000;">If Need to Know is on: The type of form.</span></td>
                             </tr>
                             <tr>
                                 <td><b>{{$formType}}</b></td>

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -84,6 +84,10 @@
                                 <td>A truncated version of the request title</td>
                             </tr>
                             <tr>
+                                <td><b>{{$formType}}</b></td>
+                                <td>The type of form</td>
+                            </tr>
+                            <tr>
                                 <td><b>{{$lastStatus}}</b></td>
                                 <td>The last action taken for the request</td>
                             </tr>

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -77,11 +77,11 @@
                             </tr>
                             <tr>
                                 <td><b>{{$fullTitle}}</b></td>
-                                <td>The full title of the request. <span style="color:#c00000;">If Need to Know is on: The type of form.</span></td>
+                                <td>The full title of the request. <span style="color:#c00000;">If need to know is on: The type of form.</span></td>
                             </tr>
                             <tr>
                                 <td><b>{{$truncatedTitle}}</b></td>
-                                <td>A truncated version of the request title. <span style="color:#c00000;">If Need to Know is on: The type of form.</span></td>
+                                <td>A truncated version of the request title. <span style="color:#c00000;">If need to know is on: The type of form.</span></td>
                             </tr>
                             <tr>
                                 <td><b>{{$formType}}</b></td>

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -615,16 +615,17 @@ class Email
 
         // Start adding users to email if we have them
         if (count($approvers) > 0) {
-            $fullTitle = $approvers[0]['title'];
-            $formType = $approvers[0]['categoryName'];
+            $formType = trim(strip_tags(
+                htmlspecialchars_decode($approvers[0]['categoryName'], ENT_QUOTES | ENT_HTML5)
+            ));
 
+            $fullTitle = trim(strip_tags(
+                htmlspecialchars_decode($approvers[0]['title'], ENT_QUOTES | ENT_HTML5)
+            ));
             if($approvers[0]['needToKnow'] === 1) {
-                $title = $formType;
                 $fullTitle = $formType;
-            } else {
-                $title = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
             }
-            $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+            $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
@@ -765,16 +766,17 @@ class Email
         } elseif ($emailTemplateID === -4) {
             // Record has no approver so if it is sent from Mass Action Email Reminder, notify user
             $recordInfo = $this->getRecord($recordID);
-            $fullTitle = $recordInfo[0]['title'];
-            $formType = $recordInfo[0]['categoryName'];
+            $formType = trim(strip_tags(
+                htmlspecialchars_decode($recordInfo[0]['categoryName'], ENT_QUOTES | ENT_HTML5)
+            ));
 
+            $fullTitle = trim(strip_tags(
+                htmlspecialchars_decode($recordInfo[0]['title'], ENT_QUOTES | ENT_HTML5)
+            ));
             if($recordInfo[0]['needToKnow'] === 1) {
-                $title = $formType;
                 $fullTitle = $formType;
-            } else {
-                $title = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
             }
-            $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+            $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
@@ -803,16 +805,17 @@ class Email
 
             $comment = $comments[0]['comment'] === '' ? '' : 'Reason for cancelling: ' . $comments[0]['comment'] . '<br /><br />';
 
-            $fullTitle = $recordInfo[0]['title'];
-            $formType = $recordInfo[0]['categoryName'];
+            $formType = trim(strip_tags(
+                htmlspecialchars_decode($recordInfo[0]['categoryName'], ENT_QUOTES | ENT_HTML5)
+            ));
 
+            $fullTitle = trim(strip_tags(
+                htmlspecialchars_decode($recordInfo[0]['title'], ENT_QUOTES | ENT_HTML5)
+            ));
             if($recordInfo[0]['needToKnow'] === 1) {
-                $title = $formType;
                 $fullTitle = $formType;
-            } else {
-                $title = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
             }
-            $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+            $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
 
 
             $this->addSmartyVariables(array(

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -622,7 +622,7 @@ class Email
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($approvers[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
-            if($approvers[0]['needToKnow'] === 1) {
+            if((int)$approvers[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
@@ -773,7 +773,7 @@ class Email
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($recordInfo[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
-            if($recordInfo[0]['needToKnow'] === 1) {
+            if((int)$recordInfo[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
@@ -812,7 +812,7 @@ class Email
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($recordInfo[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
-            if($recordInfo[0]['needToKnow'] === 1) {
+            if((int)$recordInfo[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -622,7 +622,7 @@ class Email
                 $title = $formType;
                 $fullTitle = $formType;
             } else {
-                $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
+                $title = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
             }
             $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
 
@@ -765,13 +765,21 @@ class Email
         } elseif ($emailTemplateID === -4) {
             // Record has no approver so if it is sent from Mass Action Email Reminder, notify user
             $recordInfo = $this->getRecord($recordID);
+            $fullTitle = $recordInfo[0]['title'];
+            $formType = $recordInfo[0]['categoryName'];
 
-            $title = strlen($recordInfo[0]['title']) > 45 ? substr($recordInfo[0]['title'], 0, 42) . '...' : $recordInfo[0]['title'];
+            if($recordInfo[0]['needToKnow'] === 1) {
+                $title = $formType;
+                $fullTitle = $formType;
+            } else {
+                $title = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+            }
             $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
-                "fullTitle" => $recordInfo[0]['title'],
+                "fullTitle" => $fullTitle,
+                "formType" => $formType,
                 "recordID" => $recordID,
                 "service" => $recordInfo[0]['service'],
                 "lastStatus" => $recordInfo[0]['lastStatus'],
@@ -795,12 +803,22 @@ class Email
 
             $comment = $comments[0]['comment'] === '' ? '' : 'Reason for cancelling: ' . $comments[0]['comment'] . '<br /><br />';
 
-            $title = strlen($recordInfo[0]['title']) > 45 ? substr($recordInfo[0]['title'], 0, 42) . '...' : $recordInfo[0]['title'];
+            $fullTitle = $recordInfo[0]['title'];
+            $formType = $recordInfo[0]['categoryName'];
+
+            if($recordInfo[0]['needToKnow'] === 1) {
+                $title = $formType;
+                $fullTitle = $formType;
+            } else {
+                $title = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+            }
             $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
-                "fullTitle" => $recordInfo[0]['title'],
+                "fullTitle" => $fullTitle,
+                "formType" => $formType,
                 "recordID" => $recordID,
                 "service" => $recordInfo[0]['service'],
                 "lastStatus" => $comments[0]['actionType'],
@@ -823,8 +841,10 @@ class Email
     {
         $vars = array(':recordID' => $recordID);
         $strSQL =  "SELECT `rec`.`userID`, `rec`.`serviceID`, `ser`.`service`, `rec`.`title`,
-                        `rec`.`lastStatus`
+                        `rec`.`lastStatus`,`needToKnow`,`categoryName`
                     FROM `records` AS `rec`
+                    LEFT JOIN category_count USING (recordID)
+                    LEFT JOIN categories USING (categoryID)
                     LEFT JOIN `services` AS `ser` USING (`serviceID`)
                     WHERE `recordID` = :recordID";
 

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1344,16 +1344,17 @@ class FormWorkflow
             $strSQL = 'SELECT stepTitle FROM workflow_steps WHERE stepID = :stepID';
             $groupName = $this->db->prepared_query($strSQL, $vars);
 
-            $fullTitle = $record[0]['title'];
-            $formType = $record[0]['categoryName'];
+            $formType = trim(strip_tags(
+                htmlspecialchars_decode($record[0]['categoryName'], ENT_QUOTES | ENT_HTML5)
+            ));
 
+            $fullTitle = trim(strip_tags(
+                htmlspecialchars_decode($record[0]['title'], ENT_QUOTES | ENT_HTML5)
+            ));
             if($record[0]['needToKnow'] === 1) {
-                $title = $formType;
                 $fullTitle = $formType;
-            } else {
-                $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
             }
-            $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+            $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
 
             $email->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
@@ -1454,16 +1455,17 @@ class FormWorkflow
 
                         $email = new Email();
 
-                        $fullTitle = $requestRecords[0]['title'];
-                        $formType = $requestRecords[0]['categoryName'];
+                        $formType = trim(strip_tags(
+                            htmlspecialchars_decode($requestRecords[0]['categoryName'], ENT_QUOTES | ENT_HTML5)
+                        ));
 
+                        $fullTitle = trim(strip_tags(
+                            htmlspecialchars_decode($requestRecords[0]['title'], ENT_QUOTES | ENT_HTML5)
+                        ));
                         if($requestRecords[0]['needToKnow'] === 1) {
-                            $title = $formType;
                             $fullTitle = $formType;
-                        } else {
-                            $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
                         }
-                        $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+                        $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $truncatedTitle,
@@ -1534,16 +1536,17 @@ class FormWorkflow
 
                         $email = new Email();
 
-                        $fullTitle = $requestRecords[0]['title'];
-                        $formType = $requestRecords[0]['categoryName'];
+                        $formType = trim(strip_tags(
+                            htmlspecialchars_decode($requestRecords[0]['categoryName'], ENT_QUOTES | ENT_HTML5)
+                        ));
 
+                        $fullTitle = trim(strip_tags(
+                            htmlspecialchars_decode($requestRecords[0]['title'], ENT_QUOTES | ENT_HTML5)
+                        ));
                         if($requestRecords[0]['needToKnow'] === 1) {
-                            $title = $formType;
                             $fullTitle = $formType;
-                        } else {
-                            $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
                         }
-                        $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
+                        $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $truncatedTitle,

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1351,7 +1351,7 @@ class FormWorkflow
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($record[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
-            if($record[0]['needToKnow'] === 1) {
+            if((int)$record[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
@@ -1462,7 +1462,7 @@ class FormWorkflow
                         $fullTitle = trim(strip_tags(
                             htmlspecialchars_decode($requestRecords[0]['title'], ENT_QUOTES | ENT_HTML5)
                         ));
-                        if($requestRecords[0]['needToKnow'] === 1) {
+                        if((int)$requestRecords[0]['needToKnow'] === 1) {
                             $fullTitle = $formType;
                         }
                         $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
@@ -1543,7 +1543,7 @@ class FormWorkflow
                         $fullTitle = trim(strip_tags(
                             htmlspecialchars_decode($requestRecords[0]['title'], ENT_QUOTES | ENT_HTML5)
                         ));
-                        if($requestRecords[0]['needToKnow'] === 1) {
+                        if((int)$requestRecords[0]['needToKnow'] === 1) {
                             $fullTitle = $formType;
                         }
                         $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1333,23 +1333,32 @@ class FormWorkflow
             $email = new Email();
 
             $vars = array(':recordID' => $this->recordID);
-            $strSQL = 'SELECT rec.title, rec.userID, ser.service FROM records AS rec
+            $strSQL = 'SELECT rec.title, rec.userID, ser.service, needToKnow, categoryName FROM records AS rec
+                LEFT JOIN category_count USING (recordID)
+                LEFT JOIN categories USING (categoryID)
                 LEFT JOIN services AS ser USING (serviceID)
                 WHERE recordID = :recordID';
             $record = $this->db->prepared_query($strSQL, $vars);
-
 
             $vars = array(':stepID' => $stepID);
             $strSQL = 'SELECT stepTitle FROM workflow_steps WHERE stepID = :stepID';
             $groupName = $this->db->prepared_query($strSQL, $vars);
 
+            $fullTitle = $record[0]['title'];
+            $formType = $record[0]['categoryName'];
 
-            $title = strlen($record[0]['title']) > 45 ? substr($record[0]['title'], 0, 42) . '...' : $record[0]['title'];
+            if($record[0]['needToKnow'] === 1) {
+                $title = $formType;
+                $fullTitle = $formType;
+            } else {
+                $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
+            }
             $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
 
             $email->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
-                "fullTitle" => $record[0]['title'],
+                "fullTitle" => $fullTitle,
+                "formType" => $formType,
                 "recordID" => $this->recordID,
                 "service" => $record[0]['service'],
                 "stepTitle" => $groupName[0]['stepTitle'],
@@ -1424,8 +1433,10 @@ class FormWorkflow
                     $vars = array(':recordID' => $this->recordID);
 
                     // get the record and requestor
-                    $strSQL = 'SELECT rec.title, rec.lastStatus, rec.userID, ser.service
+                    $strSQL = 'SELECT rec.title, rec.lastStatus, rec.userID, ser.service,needToKnow,categoryName
                         FROM records AS rec
+                        LEFT JOIN category_count USING (recordID)
+                        LEFT JOIN categories USING (categoryID)
                         LEFT JOIN services AS ser USING (serviceID)
                         WHERE recordID = :recordID';
                     $requestRecords = $this->db->prepared_query($strSQL, $vars);
@@ -1443,12 +1454,21 @@ class FormWorkflow
 
                         $email = new Email();
 
-                        $title = strlen($requestRecords[0]['title']) > 45 ? substr($requestRecords[0]['title'], 0, 42) . '...' : $requestRecords[0]['title'];
+                        $fullTitle = $requestRecords[0]['title'];
+                        $formType = $requestRecords[0]['categoryName'];
+
+                        if($requestRecords[0]['needToKnow'] === 1) {
+                            $title = $formType;
+                            $fullTitle = $formType;
+                        } else {
+                            $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
+                        }
                         $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $truncatedTitle,
-                            "fullTitle" => $requestRecords[0]['title'],
+                            "fullTitle" => $fullTitle,
+                            "formType" => $formType,
                             "recordID" => $this->recordID,
                             "service" => $requestRecords[0]['service'],
                             "lastStatus" => $requestRecords[0]['lastStatus'],
@@ -1493,8 +1513,10 @@ class FormWorkflow
                     $vars = array(':recordID' => $this->recordID);
 
                     // get the record and requestor
-                    $strSQL = 'SELECT rec.title, rec.lastStatus, rec.userID, ser.service
+                    $strSQL = 'SELECT rec.title, rec.lastStatus, rec.userID, ser.service,needToKnow,categoryName
                         FROM records AS rec
+                        LEFT JOIN category_count USING (recordID)
+                        LEFT JOIN categories USING (categoryID)
                         LEFT JOIN services AS ser USING (serviceID)
                         WHERE recordID = :recordID';
                     $requestRecords = $this->db->prepared_query($strSQL, $vars);
@@ -1512,12 +1534,21 @@ class FormWorkflow
 
                         $email = new Email();
 
-                        $title = strlen($requestRecords[0]['title']) > 45 ? substr($requestRecords[0]['title'], 0, 42) . '...' : $requestRecords[0]['title'];
+                        $fullTitle = $requestRecords[0]['title'];
+                        $formType = $requestRecords[0]['categoryName'];
+
+                        if($requestRecords[0]['needToKnow'] === 1) {
+                            $title = $formType;
+                            $fullTitle = $formType;
+                        } else {
+                            $title = strlen($fullTitle) > 45 ? substr($rfullTitle, 0, 42) . '...' : $fullTitle;
+                        }
                         $truncatedTitle = trim(strip_tags(htmlspecialchars_decode($title, ENT_QUOTES | ENT_HTML5 )));
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $truncatedTitle,
-                            "fullTitle" => $requestRecords[0]['title'],
+                            "fullTitle" => $fullTitle,
+                            "formType" => $formType,
                             "recordID" => $this->recordID,
                             "service" => $requestRecords[0]['service'],
                             "lastStatus" => $requestRecords[0]['lastStatus'],


### PR DESCRIPTION
## Summary
This update helps ensure sensitive data is not potentially displayed in emails.  The values of the 'fullTitle' and 'truncatedTitle' variables in the email template normally refer to the user-entered request title.  These values are replaced with the type of form if the form's need to know setting is turned on.

Since it has been requested by users in the past, formType has also been added to available smarty variables.

## Impact
Users should be notified of this update.  Template variables 'fullTitle' and 'truncatedTitle' will have unexpected values if the form's need to know setting is on.

## Testing
Within emails:
- If need to know is off, fullTitle and truncatedTitle should contain the title of the specific request.
- If need to know is on, fullTitle and truncatedTitle should contain the type of form (categoryName).
- Confirm current automated tests pass


See portal admin **Email Template Editor** for different types of email events:
_notify next approver, notify requestor of completion, custom email events, cancel notification, send back, automated email reminder, mass-action email reminders._

These are processed separately so each should be tested.
The original email templates contain truncatedTitle and fullTitle references.  Confirm these are still there if the templates have been customized.
Add a formType reference to the email content.

Update or add workflow events as needed and step a request through a workflow.
Cancel the request to trigger a cancel notification email.
Mass-action Email Reminders can be sent from portal admin -> **Mass Actions**.

Use the **SMTP Server** to confirm that emails send as expected and that they contain expected values.
