### PR TITLE
LEAF-4725 Optimize query used in Inbox: Organize by Roles

### DIFF
--- a/LEAF_Request_Portal/index.php
+++ b/LEAF_Request_Portal/index.php
@@ -265,6 +265,11 @@ switch ($action) {
 
         break;
     case 'inbox':
+        header('Refresh: 2;URL=report.php?a=LEAF_Inbox&organizeByRole&adminView');
+
+        echo 'Redirecting to the Inbox. Please update your bookmarks.';
+        exit();
+    case 'inbox_old':
         $main->assign('useUI', true);
         $main->assign('stylesheets', array(APP_JS_PATH . '/choicesjs/choices.min.css'));
         $main->assign('javascripts', array('js/form.js',

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -990,5 +990,4 @@
 
 <h2 style="text-align: center; padding-top: 5em">No more items in your inbox. Have a good day!</h2>
 
-<a href="index.php?a=inbox" style="margin-top: 3em">View Original Inbox</a>
 </div>


### PR DESCRIPTION
## Summary
This improves load performance for the Inbox's "Organize by Roles" mode by ~27% in testing, and up to ~80% in a site containing 2.5k pending requests:
```
                              │ before.txt  │              after.txt              │
                              │   sec/op    │   sec/op     vs base                │
Inbox_adminActionableRoles-24   138.8m ± 2%   101.3m ± 4%  -27.06% (p=0.000 n=10)
```

The improvement is achieved by leveraging the `data.metadata` column to retrieve information (first/last name, email), which avoids needing a query for each unique user in the set.

Since this closes the remaining advantage of the old Inbox, this PR also discourages use of the old Inbox. Visitors are redirected to the current one. In the event something is overlooked, the old inbox remains accessible at a new link: `PORTAL_URL/?a=inbox_old`

## Impact
This makes changes to queries for Actionable records, which are primarily used in the Inbox and Report Builder.

Since the system is unlikely to report "Needs Reassignment" in the Inbox for new records, a different approach should be taken to highlight records assigned to inactive accounts. In the meantime, process owners should use the "Unresolved Requests" feature to ensure timely completion.

## Testing
New Automated Tests: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/72
