### PR TITLE
LEAF-4727 Documentation: docker compose build on new docker desktop

### DIFF
--- a/docs/InstallationConfiguration.md
+++ b/docs/InstallationConfiguration.md
@@ -23,6 +23,26 @@ Open up a terminal and enter these commands:
     docker volume create leaf-lib
 ```
 
+## Installation Issues
+Newer versions of Docker Desktop may ask you to "Share your Files".
+
+You will see errors like the following during building.
+``` bash
+error during connect: Post "http://%2F%2F.%2Fpipe%2FdockerDesktopLinuxEngine/v1.48/containers/create?name=leaf-php-fpm-1": EOF
+PS C:\Users\******\LEAF\docker> docker compose up --build -d
+Compose now can delegate build to bake for better performances
+Just set COMPOSE_BAKE=true
+2025/03/26 06:56:41 http2: server: error reading preface from client //./pipe/dockerDesktopLinuxEngine: file has already been closed
+```
+
+ - Open Docker Desktop
+ - Settings (Gear Icon near the top) 
+ - Open Resources
+ - Open File Sharing in the sub menu
+ - Click on the browse button and find the root of your LEAF folder
+ - Once selected click on the "+" icon 
+
+
 ## Running
 
 1. Make sure you're in the LEAF/docker directory


### PR DESCRIPTION

## Summary
 update for installation, right now I think this may not be seen by 100% of people but could be something that is seen by users

How does this change help the customer or platform?
This is documentation updates to include notes on if you receive an error while building, depending how the system is setup you may receive this message.

## Impact
This is a help documentation that should help people get around possible errors

## Testing
N/A