### PR TITLE
LEAF-4726 - Followup to PR#2708: Fix variable assignment

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -2243,7 +2243,7 @@ class Form
                         AND approved=1';
         $backupIds = $nexusDB->prepared_query($strSQL, $vars);
 
-        $this->cache['checkIfBackup'] = [];
+        $this->cache['checkIfBackupUserName'] = [];
         foreach ($backupIds as $row)
         {
             $this->cache['checkIfBackupUserName'][strtolower($row['userName'])] = true;


### PR DESCRIPTION
## Summary
This resolves an issue in https://github.com/department-of-veterans-affairs/LEAF/pull/2708 identified during pre-production testing.

If the current user isn't serving as a backup for another, the local cache is never initialized which causes duplicate database calls.


## Impact
Same as PR#2708

## Testing
Same as PR#2708