### PR TITLE
HOTFIX: LEAF-4756 Improve feature parity with the old inbox pt2

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -139,6 +139,16 @@
                             status = waitText + listRecord.stepTitle;
                         }
 
+                        // Show individually assigned name, if present
+                        if(listRecord.assignedIndividual != undefined && listRecord.assignedIndividual == true) {
+                            if(listRecord.unfilledDependencyData[-1] != undefined) {
+                                status += ': ' + listRecord.unfilledDependencyData[-1].approverName;
+                            }
+                            if(listRecord.unfilledDependencyData[-2] != undefined) {
+                                status += ': ' + listRecord.unfilledDependencyData[-2].approverName;
+                            }
+                        }
+
                         cellContainer.html(status).attr('tabindex', '0').attr('aria-label', status);
                         if (listRecord.userID == '<!--{$userID}-->') {
                         cellContainer.css('background-color', '#feffd1');
@@ -563,6 +573,11 @@
             if (res[recordID].service != null) {
                 hasServices = true;
             }
+            res[recordID].assignedIndividual = false;
+            if(stepID == 'assignedIndividual') {
+                res[recordID].assignedIndividual = true;
+            }
+
             tGridData.push(res[recordID]);
         });
         // remove service column if there's no services

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -325,8 +325,15 @@
                 let roleID = Number(depID);
                 let description = uDD.description;
                 if(roleID < 0 && uDD.approverUID != undefined) { // handle "smart requirements"
-                    roleID = Sha1.hash(uDD.approverUID);
-                    description = scrubHTML(uDD.approverName);
+                    // For Admins in the "Organize by Roles" view:
+                    // Organize individually assigned records into a section (e.g. person designated, requestor followup)
+                    if(!nonAdmin && (roleID == -1 || roleID == -2)) {
+                        roleID = 'assignedIndividual';
+                        description = '* Assigned to an individual *';
+                    } else {
+                        roleID = Sha1.hash(uDD.approverUID);
+                        description = scrubHTML(uDD.approverName);
+                    }
                 }
 
                 let stepHash = `${description}:;ROLEID${roleID}`;


### PR DESCRIPTION
## Summary
This is Phase 2 of https://github.com/department-of-veterans-affairs/LEAF/pull/2714, which improves feature parity with the old Inbox, resolving:
- Collapse individually assigned records in admin view
  - The old inbox collapsed these requests (e.g. requestor followup, person designated) in a single collapsible section

The name of the assigned person will now show up in the Status column in the new collapsed group, as it would otherwise be hidden.


## Impact
No dependencies.

## Testing
- When viewing the Inbox (Organize by Roles, View as Admin), individually assigned records are consolidated into a section: "Assigned to an individual"

- When viewing the Inbox (Organize by Roles, View as Admin):
  1. Open the "Assigned to an individual" section
  2. Open the "Group A" sections
  3. For records that exist in both sections, observe the Status column. The names of individuals should only show up in the "Assigned to an individual" section
