### PR TITLE
LEAF-4770 - Optimization: Use userMetadata instead of individual lookups

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -494,18 +494,16 @@ class FormWorkflow
                         $personDesignatedIndicators[$res[$i]['indicatorID_for_assigned_empUID']] = 1;
                         break;
                     case -2: // dependencyID -2 is for requestor followup
-                        $dir = $this->getDirectory();
-                        $approver = $dir->lookupLogin($res[$i]['userID']);
-
-                        if (empty($approver[0]['Fname']) && empty($approver[0]['Lname'])) {
+                        $metaData = json_decode($record['userMetadata'], true);
+                        if ($metaData == null || $metaData['firstName'] == '') {
                             $res[$i]['description'] = $res[$i]['stepTitle'] . ' (Inactive User)';
                             $res[$i]['approverName'] = '(Inactive User)';
                             $res[$i]['approverUID'] = $res[$i]['userID'];
                         }
                         else {
-                            $res[$i]['description'] = $res[$i]['stepTitle'] . ' (' . $approver[0]['Fname'] . ' ' . $approver[0]['Lname'] . ')';
-                            $res[$i]['approverName'] = $approver[0]['Fname'] . ' ' . $approver[0]['Lname'];
-                            $res[$i]['approverUID'] = $approver[0]['Email'];
+                            $res[$i]['description'] = $res[$i]['stepTitle'] . ' (' . $metaData['firstName'] . ' ' . $metaData['lastName'] . ')';
+                            $res[$i]['approverName'] = $metaData['firstName'] . ' ' . $metaData['lastName'];
+                            $res[$i]['approverUID'] = $metaData['email'];
                         }
                         break;
                     case -3: // dependencyID -3 is for a group designated by the requestor


### PR DESCRIPTION
## Summary
This follows https://github.com/department-of-veterans-affairs/LEAF/pull/2706, which improves performance for the Inbox's "Organize by Roles" mode.

This provides an additional ~45% improvement, specifically when requests are pending "Requestor Followup" AND the user is an admin.

The test database has been updated to include more "Requestor Followup" conditions, which helps highlight this hotspot, and is a more realistic real-world scenario. Performance improvements across multiple builds are as follows:

```
                                │ build.20250407 │               this_PR               │
                                │     sec/op     │   sec/op     vs base                │
Homepage_defaultQuery-6              55.80m ± 1%   55.85m ± 2%        ~ (p=0.971 n=10)
Inbox_nonAdminActionable-6           82.00m ± 3%   81.97m ± 1%        ~ (p=0.853 n=10)
Inbox_nonAdminActionableRoles-6      172.0m ± 2%   172.6m ± 1%        ~ (p=0.353 n=10)
Inbox_adminActionableRoles-6        168.33m ± 2%   93.10m ± 1%  -44.69% (p=0.000 n=10)


                                │ build.20250325 │           build.20250407            │
                                │     sec/op     │   sec/op     vs base                │
Homepage_defaultQuery-6              57.15m ± 3%   55.80m ± 1%        ~ (p=0.089 n=10)
Inbox_nonAdminActionable-6          106.11m ± 2%   82.00m ± 3%  -22.72% (p=0.000 n=10)
Inbox_nonAdminActionableRoles-6      247.3m ± 2%   172.0m ± 2%  -30.43% (p=0.000 n=10)
Inbox_adminActionableRoles-6         207.4m ± 1%   168.3m ± 2%  -18.82% (p=0.000 n=10)
```


## Impact
This makes changes to queries for Actionable records, which are primarily used in the Inbox and Report Builder.

Since the system is now unlikely to report "(Inactive User)" for records where the initiator has a disabled account, a different approach should be taken to highlight records assigned to them. In the meantime, process owners should use the "Unresolved Requests" feature to ensure timely completion.

## Testing
New automated test: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/75
