### PR TITLE
LEAF 4716 - workflow editor UX improvements

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -1532,9 +1532,9 @@
             }
 
             output += '<br /><div>Triggers these events:<ul>';
-            // the sendback action always notifies the requestor
+            // the sendback action always notifies the requestor and uses the Send Back template
             if (params.action == 'sendback') {
-                output += '<li><b>Email - Notify the requestor</b></li>';
+                output += '<li><b>Email - Send Back Notification for Requestor</b></li>';
             }
             for (let i in res) {
                 output += `<li><b>${res[i].eventType} - ${res[i].eventDescription}</b>
@@ -2087,7 +2087,7 @@
 
     function drawRoutes(workflowID, stepID = null) {
         let loc = 0.5;
-        const locIncrement = 0.1;
+        const locIncrement = 0.15;
         $.ajax({
             type: 'GET',
             url: '../api/workflow/' + workflowID + '/route',
@@ -2127,8 +2127,8 @@
                             if(actionCounts?.[fromStepToStep] >= 0) {
                                 actionCounts[fromStepToStep] += 1;
                                 loc = Math.min(
-                                    +((0.20 + locIncrement * actionCounts[fromStepToStep]).toFixed(2)),
-                                    0.70
+                                    +((0.05 + locIncrement * actionCounts[fromStepToStep]).toFixed(2)),
+                                    0.65
                                 );
                                 if(loc >= 0.5) { //reserve 0.5 for 0 - keeps centered if only one route
                                     loc += locIncrement;

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2123,18 +2123,20 @@
                         default:
                             const from = String(res[i].stepID);
                             const to = String(res[i].nextStepID);
-                            const fromStepToStep = from + "_" + to;
-                            if(actionCounts?.[fromStepToStep] >= 0) {
-                                actionCounts[fromStepToStep] += 1;
-                                loc = Math.min(
-                                    +((0.05 + locIncrement * actionCounts[fromStepToStep]).toFixed(2)),
-                                    0.65
-                                );
-                                if(loc >= 0.5) { //reserve 0.5 for 0 - keeps centered if only one route
-                                    loc += locIncrement;
+                            if(from !== to) {
+                                const fromStepToStep = from + "_" + to;
+                                if(actionCounts?.[fromStepToStep] >= 0) {
+                                    actionCounts[fromStepToStep] += 1;
+                                    loc = Math.min(
+                                        +((0.05 + locIncrement * actionCounts[fromStepToStep]).toFixed(2)),
+                                        0.65
+                                    );
+                                    if(loc >= 0.5) { //reserve 0.5 for 0 - keeps centered if only one route
+                                        loc += locIncrement;
+                                    }
+                                } else {
+                                    actionCounts[fromStepToStep] = 0;
                                 }
-                            } else {
-                                actionCounts[fromStepToStep] = 0;
                             }
                             break;
                     }

--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -2087,6 +2087,7 @@
 
     function drawRoutes(workflowID, stepID = null) {
         let loc = 0.5;
+        const locIncrement = 0.1;
         $.ajax({
             type: 'GET',
             url: '../api/workflow/' + workflowID + '/route',
@@ -2104,6 +2105,7 @@
                 // draw connector
                 let actionCounts = {};
                 for (let i in res) {
+                    loc = 0.5;
                     switch (res[i].actionType.toLowerCase()) {
                         case 'sendback':
                             loc = 0.30;
@@ -2121,18 +2123,18 @@
                         default:
                             const from = String(res[i].stepID);
                             const to = String(res[i].nextStepID);
-                            if (from !== to) {
-                                const fromStepToStep = from + "_" + to;
-                                if(actionCounts?.[fromStepToStep] >= 0) {
-                                    actionCounts[fromStepToStep] += 1;
-                                    loc = Math.min(
-                                        +((0.20 + 0.08 * actionCounts[fromStepToStep]).toFixed(2)),
-                                        0.80
-                                    );
-                                } else {
-                                    actionCounts[fromStepToStep] = 0;
-                                    loc = 0.20;
+                            const fromStepToStep = from + "_" + to;
+                            if(actionCounts?.[fromStepToStep] >= 0) {
+                                actionCounts[fromStepToStep] += 1;
+                                loc = Math.min(
+                                    +((0.20 + locIncrement * actionCounts[fromStepToStep]).toFixed(2)),
+                                    0.70
+                                );
+                                if(loc >= 0.5) { //reserve 0.5 for 0 - keeps centered if only one route
+                                    loc += locIncrement;
                                 }
+                            } else {
+                                actionCounts[fromStepToStep] = 0;
                             }
                             break;
                     }


### PR DESCRIPTION
## Summary
Addresses pain points noted by the community.

**Action Bubbles** for custom routes are positioned 50% across the route line.  Multiple routes from-to the same steps can be difficult to read and interact with.  This update spreads up to 5 actions between 20-80%.  If there is only one route, it will be at 50%.  If there are more than 5 routes, they will max at 80% across the line.  Action positioning will get some further refinement in a future story, but this will address the main issues for most workflows.

**Step and Action Modals** can open off the right side of the screen.  This could cause scrolling issues on some browsers.
When opened, positioning will be assessed and updated if needed to keep the modals on the screen.

**Return to Requestor** action has an incorrect label for its associated event, making it unclear which email template it is associated with.  The label is updated to read 'Email - Send Back Notification for Requestor' to distinguish it from a different built-in event and make it clearer that its email template is 'Send Back'.  Email template labels and event descriptions are not being updated in the database at this time due to the potential for custom label/description naming collisions.  Additional UX improvements to the Email Template editor will also be addressed in a future story.

## Impact
All changes are front end to mod_workflow.tpl (Workflow Editor)

## Testing
Confirm workflow action bubbles/buttons display and can be interacted with as expected.  Create multiple actions using the 'Edit Actions' option in the side menu.  Add them from - to a pair of steps in the workflow using the workflow connector icons.

Confirm that step and action modals are adjusted to be onscreen if needed and that they otherwise display and can be interacted with as expected.  Clicking on a step opens the step info modal.  Clicking on an action bubble opens the action modal.

Routes going from any step back to the requestor have 'Email - Send Back Notification for Requestor' as the non-removable event

Confirm that automated tests pass.

