### PR TITLE
LEAF-4765 - Report Builder: Add undefined check

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -103,7 +103,9 @@ function addHeader(column) {
                 indicatorID: 'type',
                 editable: false,
                 callback: function(data, blob) {
-                     document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].categoryNames.join(' | ');
+                    if(blob[data.recordID].categoryNames != undefined) {
+                        document.querySelector(`#${data.cellContainerID}`).innerHTML = blob[data.recordID].categoryNames.join(' | ');
+                    }
             }});
             break;
         case 'status':


### PR DESCRIPTION
## Summary
This resolves a potential issue where a report would appear incomplete.

The issue is due to an undefined variable, and missing check. This issue is also highly unlikely to appear in normal operation, as it requires a form to be fully destroyed, which is not possible using the Admin interface.

## Impact
No dependencies outside of the report builder

## Testing
- This can be tested in the Demo1 site because its database has been manually modified.
    1. Navigate to Admin Panel -> Unresolved Requests
    2. All of the cells within the "Days since last action" column contain information
