### PR TITLE
formQuery.js: Resolve issue if "#" is part of the query

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -242,6 +242,7 @@ var LeafFormQuery = function () {
    */
   function encodeReadableURI(url) {
     url = url.replaceAll('+', '%2b');
+    url = url.replaceAll('#', '%23');
     return url;
   }
 


### PR DESCRIPTION
## Summary
This resolves an issue where queries that contain "#" return with "Invalid query".

The error happens because "#" is not URL encoded before sending it to the server.

## Impact
This impacts dependencies of formQuery.js, such as the Homepage and Report Builder

## Testing
New end2end test: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/77
