### PR TITLE
LEAF-4771 - Role-based Inbox: Enable custom columns in specific conditions

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -367,12 +367,6 @@
             // sort by workflow step
             let siteData = getSiteRoleData(sites, i);
             let depDesc = siteData.depDesc;
-            let categoryIDs = undefined;
-
-            // If there's only one category, prepare to render custom columns if they exist
-            if(Object.keys(siteData.categoryIDs).length == 1) {
-                categoryIDs = siteData.categoryIDs[Object.keys(siteData.categoryIDs)[0]];
-            }
 
             let sortedDepDesc = Object.keys(depDesc).sort();
 
@@ -381,7 +375,7 @@
                 let stepName = hash.substring(0, hash.indexOf(':;ROLEID'));
                 let stepID = hash.substring(hash.indexOf(':;ROLEID') + 8);
                 buildDepInboxByStep(dataInboxes[sites[i].url], stepID, stepName, recordIDs,
-                    sites[i], categoryIDs);
+                    sites[i], siteData.categoryIDs);
             });
         }
 
@@ -613,11 +607,29 @@
     // Build forms and grids for the inbox's requests based on the list of $recordIDs, organized by step
     function buildDepInboxByStep(res, stepID, stepName, recordIDs, site, categoryIDs = undefined) {
         let hash = Sha1.hash(site.url);
-		let categoryName = '';
-        let categoryID = '';
-        if(Object.keys(recordIDs).length > 0) {
-            categoryName = `${res[recordIDs[0]].categoryName} - ${res[recordIDs[0]].stepTitle}`;
-            categoryID = res[recordIDs[0]].categoryID;
+
+        // If all records within the step have the same form type (categoryID), then enable custom columns
+        let enabledCategoryIDs = undefined;
+        let firstMatch = null;
+        let allCategoriesMatch = true;
+        if(recordIDs.length > 0) {
+            recordIDs.forEach(recordID => {
+                if(firstMatch == null) {
+                    firstMatch = res[recordID].categoryIDs[0];
+                }
+                if(firstMatch != res[recordID].categoryIDs[0]) {
+                    allCategoriesMatch = false;
+                    return;
+                }
+            });
+
+            if(allCategoriesMatch) {
+                for(let i in categoryIDs) {
+                    if(categoryIDs[i][0] == firstMatch) {
+                        enabledCategoryIDs = categoryIDs[i];
+                    }
+                }
+            }
         }
 
         let icon = getIcon(site.icon, site.name);
@@ -642,7 +654,7 @@
             </button>
 			<div id="depList${hash}_${stepID}" style="width: 90%; margin: auto; display: none"></div></div>`);
         $('#depLabel' + hash + '_' + stepID).on('click', function() {
-            buildInboxGridView(res, stepID, stepName, recordIDs, site, hash, categoryIDs);
+            buildInboxGridView(res, stepID, stepName, recordIDs, site, hash, enabledCategoryIDs);
             if ($('#depList' + hash + '_' + stepID).css('display') == 'none') {
                 $('#depList' + hash + '_' + stepID).css('display', 'inline');
                 $('#depLabel' + hash + '_' + stepID).attr('aria-expanded', 'true');

--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -367,7 +367,12 @@
             // sort by workflow step
             let siteData = getSiteRoleData(sites, i);
             let depDesc = siteData.depDesc;
-            let categoryIDs = siteData.categoryIDs;
+            let categoryIDs = undefined;
+
+            // If there's only one category, prepare to render custom columns if they exist
+            if(Object.keys(siteData.categoryIDs).length == 1) {
+                categoryIDs = siteData.categoryIDs[Object.keys(siteData.categoryIDs)[0]];
+            }
 
             let sortedDepDesc = Object.keys(depDesc).sort();
 
@@ -376,7 +381,7 @@
                 let stepName = hash.substring(0, hash.indexOf(':;ROLEID'));
                 let stepID = hash.substring(hash.indexOf(':;ROLEID') + 8);
                 buildDepInboxByStep(dataInboxes[sites[i].url], stepID, stepName, recordIDs,
-                    sites[i]);
+                    sites[i], categoryIDs);
             });
         }
 
@@ -606,7 +611,7 @@
     }
 
     // Build forms and grids for the inbox's requests based on the list of $recordIDs, organized by step
-    function buildDepInboxByStep(res, stepID, stepName, recordIDs, site) {
+    function buildDepInboxByStep(res, stepID, stepName, recordIDs, site, categoryIDs = undefined) {
         let hash = Sha1.hash(site.url);
 		let categoryName = '';
         let categoryID = '';
@@ -637,7 +642,7 @@
             </button>
 			<div id="depList${hash}_${stepID}" style="width: 90%; margin: auto; display: none"></div></div>`);
         $('#depLabel' + hash + '_' + stepID).on('click', function() {
-            buildInboxGridView(res, stepID, stepName, recordIDs, site, hash);
+            buildInboxGridView(res, stepID, stepName, recordIDs, site, hash, categoryIDs);
             if ($('#depList' + hash + '_' + stepID).css('display') == 'none') {
                 $('#depList' + hash + '_' + stepID).css('display', 'inline');
                 $('#depLabel' + hash + '_' + stepID).attr('aria-expanded', 'true');


### PR DESCRIPTION
## Summary
This enables customizable columns in the "Organize by Role" view, for a specific condition within the Inbox.

Since the Role-based view can potentially include more than one type of form, custom columns are normally disabled. However if all records within the section contain the same type of form, then we can enable the columns.

## Impact
Changes are limited to the "Organize by Role" section in the Inbox.

## Testing
New automated test: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/79
