### PR TITLE
Leaf 4779 - email reminder last action

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -642,6 +642,7 @@ async function listRequests(thisSearchID) {
                 if (Number(lastAction.value) > 0) {
                     filterData = filterEmailData(result);
                 }
+
                 formGrid.setDataBlob(filterData);
                 formGrid.setHeaders([
                     {

--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -514,7 +514,6 @@ function getForms() {
  * Purpose do reminder search (used by click or change of lastAction text)
  */
 function reminderDaysSearch() {
-    console.log("reminderDaysSearch");
     let daysSince = document.getElementById("lastAction").valueOf();
     searchID = Math.floor(Math.random() * 1000000000);
     listRequests(searchID);
@@ -531,7 +530,6 @@ function addTerms(leafFormQuery) {
             let lastAction = document.getElementById("lastAction");
 
             if (Number(lastAction.value) > 0) {
-                console.log("adding unresolved term")
                 leafFormQuery.addTerm('stepID', '!=', 'resolved');
             }
             break;
@@ -761,7 +759,6 @@ function executeMassAction() {
             case "email":
                 ajaxPath =
                     "./api/form/" + recordID + "/reminder/" + reminderDaysSince;
-                console.log(ajaxPath);
                 break;
             case "take_action":
                 let dependencyID = $("select#requirements_select").val();


### PR DESCRIPTION
## Summary
This PR addresses a bug where the mass action - email reminder, days since last action does not filter the result set. 

## Impact
This will allow filtering of data based on days since last action

## Testing
Navigate to the mass action page.
In the drop down select Email Reminder
The result set should filter down to requests where there is an action history and the date is older than 7 days.
If there are multiple requests with different dates of last actions you should be able to change the days since last action the the result set should change based on those days.