### PR TITLE
Leaf 4779 - dropdown results fix

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -635,9 +635,10 @@ async function listRequests(thisSearchID) {
                 const formGrid = new LeafFormGrid('searchResults', {});
                 formGrid.setRootURL("./");
                 let lastAction = document.getElementById("lastAction");
+                let action = document.getElementById("action");
                 let filterData = result;
 
-                if (Number(lastAction.value) > 0) {
+                if (action.value === 'email' && Number(lastAction.value) > 0) {
                     filterData = filterEmailData(result);
                 }
 


### PR DESCRIPTION
## Summary
This fixes a bug created by the first fix of this ticket. When fixing the email last action days it broke the cancel, restore, and submit result sets. This fixes that and all are now working as expected.

## Impact
This will prevent a hot fix where the dropdown doesn't return anything but for email reminders

## Testing
Go to the mass action page and select each of the dropdown options and verify that the results are correct.