### PR TITLE
Optimization: Use userMetadata instead of individual lookups (non admin)

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -541,17 +541,16 @@ class FormWorkflow
 
                     $res[$i]['isActionable'] = $isActionable;
 
-                    $dir = $this->getDirectory();
-                    $approver = $dir->lookupLogin($res[$i]['userID']);
-                    if (empty($approver[0]['Fname']) && empty($approver[0]['Lname'])) {
+                    $metaData = json_decode($record['userMetadata'], true);
+                    if ($metaData == null || $metaData['firstName'] == '') {
                         $res[$i]['description'] = $res[$i]['stepTitle'] . ' (Inactive User)';
                         $res[$i]['approverName'] = '(Inactive User)';
                         $res[$i]['approverUID'] = $res[$i]['userID'];
                     }
                     else {
-                        $res[$i]['description'] = $res[$i]['stepTitle'] . ' (' . $approver[0]['Fname'] . ' ' . $approver[0]['Lname'] . ')';
-                        $res[$i]['approverName'] = $approver[0]['Fname'] . ' ' . $approver[0]['Lname'];
-                        $res[$i]['approverUID'] = $approver[0]['Email'];
+                        $res[$i]['description'] = $res[$i]['stepTitle'] . ' (' . $metaData['firstName'] . ' ' . $metaData['lastName'] . ')';
+                        $res[$i]['approverName'] = $metaData['firstName'] . ' ' . $metaData['lastName'];
+                        $res[$i]['approverUID'] = $metaData['email'];
                     }
                     break;
 


### PR DESCRIPTION
## Summary
This improves performance of the Inbox by using the same strategy as in https://github.com/department-of-veterans-affairs/LEAF/pull/2718

The optimization avoids database queries by utilizing metadata introduced in https://github.com/department-of-veterans-affairs/LEAF/pull/2400, https://github.com/department-of-veterans-affairs/LEAF/pull/2435, https://github.com/department-of-veterans-affairs/LEAF/pull/2466

Compared to the current build, this improves performance of the non-admin role-based view by ~43%:
```
                                │ build.20250422 │               this_PR               │
                                │     sec/op     │   sec/op     vs base                │
Homepage_defaultQuery-6              57.58m ± 4%   56.25m ± 2%   -2.32% (p=0.009 n=10)
Inbox_nonAdminActionable-6           86.47m ± 4%   84.80m ± 2%        ~ (p=0.075 n=10)
Inbox_nonAdminActionableRoles-6     174.03m ± 4%   98.75m ± 3%  -43.26% (p=0.000 n=10)
Inbox_adminActionableRoles-6         95.81m ± 2%   95.83m ± 2%        ~ (p=0.912 n=10)
geomean                              95.45m        81.96m       -14.13%
```


Compared to the pre-metadata schema on 6/14/2024, and other improvements along the way, we've improved response time by up to 62%:
```
                                │   20240614   │               this_PR               │
                                │    sec/op    │   sec/op     vs base                │
Homepage_defaultQuery-6            58.64m ± 2%   56.25m ± 2%   -4.09% (p=0.000 n=10)
Inbox_nonAdminActionable-6        110.44m ± 2%   84.80m ± 2%  -23.22% (p=0.000 n=10)
Inbox_nonAdminActionableRoles-6   259.85m ± 4%   98.75m ± 3%  -62.00% (p=0.000 n=10)
Inbox_adminActionableRoles-6      221.06m ± 5%   95.83m ± 2%  -56.65% (p=0.000 n=10)
geomean                            138.9m        81.96m       -40.98%
```


## Impact
Similar to https://github.com/department-of-veterans-affairs/LEAF/pull/2718, the system is now unlikely to report "(Inactive User)" for records where the initiator has a disabled account. However, this has lower impact as non-admins have a more limited view, and they will only see records if they have a "need-to-know".


## Testing
This Automated test was updated to account for the behavior described in the Impact section: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/86, and should be merged at the same time as this PR.
