### PR TITLE
LEAF 4801 call grid stop if Create Row is used, move style update

### DIFF
--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -991,16 +991,9 @@ function createRequest(catID) {
                     //Type number. Sent back on success (UID column of report builder)
                     if (recordID > 0) {
                         newRecordID = parseInt(recordID);  //global
+                        grid.stop();
                         $('#generateReport').click();
                         dialog.hide();
-                        //styling to hilite row for short / simple queries
-                        setTimeout(function () {
-                            let el_ID = grid.getPrefixID() + "tbody_tr" + recordID;
-                            let newRow = document.getElementById(el_ID);
-                            if (newRow !== null) { //null if query > .75s or if the query does not return the record created
-                                newRow.style.backgroundColor = 'rgb(254, 255, 209)';
-                            }
-                        }, 750);
                     }
                 },
                 function (error) {
@@ -1366,6 +1359,18 @@ $(function() {
             document.querySelector('#btn_abort').style.display = 'none';
             $('#reportStats').html(`${Object.keys(queryResult).length} records${partialLoad}`);
             renderGrid(queryResult);
+            if (+newRecordID > 0) {
+                //styling to hilite row for short / simple queries
+                let el_ID = grid.getPrefixID() + "tbody_tr" + newRecordID;
+                let newRow = document.getElementById(el_ID);
+                if (newRow !== null) { //null if the query does not return the record created or if the row is off page
+                    newRow.style.backgroundColor = 'rgb(254, 255, 209)';
+                }
+                let newRowBtn = document.getElementById('newRequestButton');
+                if(newRowBtn !== null) {
+                    newRowBtn.dataset.newestRowId = newRecordID;
+                }
+            }
             //update Checkpoint Date Step header text if still needed (should be rare)
             if(tStepHeader.some(ele => ele === 0)) {
                 $.ajax({


### PR DESCRIPTION
## Summary
Cached row locations could cause requests to sort incorrectly when the 'Create Row' button was used.
Adds a call to grid.stop to prevent use of render cache in this situation.

The code controlling the styling update of the newest row has been moved to occur after grid render rather than after request creation to improve consistent reactivity.  The prior 750 MS timeout has been removed.  The ID of the latest record created is also added to the button as a data property to facilitate testing.


## Impact
Addresses a sorting issue in the Report Builder / view_reports.tpl

## Testing
Use a Report Builder filter for a form type that has over 50 requests.
Use the 'Create Row' button several times after sorting by a header other than UID (eg title).

If present, only one row should have highlighting (if there are a large number of requests the newest row might be off screen)
Re-sorting by UID should have the expected outcomes
The ID of the newest request created with the Create Row button should be available on the button as a data property
