### PR TITLE
Leaf 4803 - mass action email reminders producing error

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -726,7 +726,7 @@ function executeMassAction() {
     }
 
     let selectedRequests = $("input.massActionRequest:checked");
-    let lastAction = document.getElementById("lastAction").valueOf()
+    let lastAction = document.getElementById("lastAction").value;
     let reminderDaysSince = Number(lastAction);
 
     // Update global variables for execution - used in updateProgress function


### PR DESCRIPTION
## Summary
When attempting to send email reminders from mass action page there is an alert box error being produced. This is the result of code that was getting the valueOf instead of value for the days since last action.

## Impact
Email reminders will now go out.

## Testing
navigate to mass actions
select email reminders from dropdown
select at least one request to send an email to
observe that the email got sent.