### PR TITLE
LEAF 4758 remove alternate bolded heading label and move html AO

### DIFF
--- a/LEAF_Request_Portal/templates/subindicators.tpl
+++ b/LEAF_Request_Portal/templates/subindicators.tpl
@@ -30,9 +30,6 @@
                 <b><!--{$indicator.name|sanitizeRichtext}--></b><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}--><br />
             </span>
             <!--{/if}-->
-            <!--{if $indicator.format == ''}-->
-                <!--{$indicator.html}-->
-            <!--{/if}-->
             </div>
         <!--{else}-->
         <div class="sublabel blockIndicator_<!--{$indicator.indicatorID|strip_tags}-->">
@@ -42,11 +39,7 @@
             </label>
             <!--{else}-->
             <span id="format_label_<!--{$indicator.indicatorID|strip_tags}-->" <!--{if $indicator.format|in_array:['','fileupload','image'] }-->tabindex="0"<!--{/if}-->>
-                    <!--{if $indicator.format === ''}-->
-                        <br /><b><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--></b><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
-                    <!--{else}-->
-                        <br /><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
-                    <!--{/if}-->
+                    <br><!--{$indicator.name|sanitizeRichtext|indent:$depth:""}--><!--{if $indicator.required == 1}--><span id="<!--{$indicator.indicatorID|strip_tags}-->_required" class="input-required">*&nbsp;Required</span><!--{/if}-->
             </span>
             <!--{/if}-->
         <!--{/if}-->
@@ -56,6 +49,10 @@
             <span class="text">
                 [protected data]
             </span>
+        <!--{/if}-->
+
+        <!--{if $indicator.format == ''}-->
+            <!--{$indicator.html}-->
         <!--{/if}-->
         <!--{if $indicator.format == 'grid' && ($indicator.isMasked == 0 || $indicator.value == '')}-->
             <span style="position: absolute; color: transparent" aria-atomic="true" aria-live="polite" id="tableStatus" role="status"></span>


### PR DESCRIPTION
## Summary
Removes logic that forced sub-questions that had no / empty formats to be bold.
Moves the logic that adds Advanced Options (html) for 'no format' questions so that it does not apply only to main headers.  htmlPrint does not have this issue.

Users will have intended control over indicator name formatting and can add advanced options for sub-questions that have a 'none' format.

## Impact
There might be users who have saved prior attempts at Advanced Options added to none-format questions.  Advanced Options will now run (as intended) but could potentially cause unexpected results.  This is likely a rare situation, but noted so we can be on the lookout for it.   Removing the html AO would resolve it. 

None-format sub-questions will not be bold unless they are set to be in the form editor.  This could cause minor appearance changes in forms with such questions.

This update does not address more complex issues that can arise due to the combination of WYSWYG Editor tags and the html sanitizer methods.

## Testing
Sub-questions with 'none' format are not forced to be bold.
Sub-questions with Advanced Options in the question's Programmer html section will run.
