### PR TITLE
LEAF-4755 Add "insecure" template variable

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -77,11 +77,19 @@
                             </tr>
                             <tr>
                                 <td><b>{{$fullTitle}}</b></td>
-                                <td>The full title of the request. <span style="color:#c00000;">If need to know is on: The type of form.</span></td>
+                                <td>The full title of the request<br /><span style="color:#c00000;">If need to know is on: The type of form</span></td>
+                            </tr>
+                            <tr>
+                                <td><b>{{$fullTitle_insecure}}</b></td>
+                                <td>The full title of the request<br /><span style="color:#c00000;">By using this variable, I certify that record titles related to these emails are not designed to contain PHI/PII.</span></td>
                             </tr>
                             <tr>
                                 <td><b>{{$truncatedTitle}}</b></td>
-                                <td>A truncated version of the request title. <span style="color:#c00000;">If need to know is on: The type of form.</span></td>
+                                <td>The request title, truncated to 45 characters in length<br /><span style="color:#c00000;">If need to know is on: The type of form</span></td>
+                            </tr>
+                            <tr>
+                                <td><b>{{$truncatedTitle_insecure}}</b></td>
+                                <td>The request title, truncated to 45 characters in length<br /><span style="color:#c00000;">By using this variable, I certify that record titles related to these emails are not designed to contain PHI/PII.</span></td>
                             </tr>
                             <tr>
                                 <td><b>{{$formType}}</b></td>
@@ -106,8 +114,7 @@
                             <tr>
                                 <td><b>{{$field.&lt;fieldID&gt;}}</fieldID>
                                 </td>
-                                <td>The value of the field by ID. <span style="color:#c00000;">Sensitive data fields may
-                                        not be included in email templates.</span></td>
+                                <td>The value of the field by ID<br /><span style="color:#c00000;">Sensitive data fields will not work in email templates.</span></td>
                             </tr>
                         </table>
                     </fieldset>

--- a/LEAF_Request_Portal/sources/Email.php
+++ b/LEAF_Request_Portal/sources/Email.php
@@ -622,14 +622,18 @@ class Email
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($approvers[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
+            $fullTitleInsecure = $fullTitle;
             if((int)$approvers[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+            $truncatedTitleInsecure = strlen($fullTitleInsecure) > 45 ? substr($fullTitleInsecure, 0, 42) . '...' : $fullTitleInsecure;
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
+                "truncatedTitle_insecure" => $truncatedTitleInsecure,
                 "fullTitle" => $fullTitle,
+                "fullTitle_insecure" => $fullTitleInsecure,
                 "formType" => $formType,
                 "recordID" => $recordID,
                 "service" => $approvers[0]['service'],
@@ -773,14 +777,18 @@ class Email
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($recordInfo[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
+            $fullTitleInsecure = $fullTitle;
             if((int)$recordInfo[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+            $truncatedTitleInsecure = strlen($fullTitleInsecure) > 45 ? substr($fullTitleInsecure, 0, 42) . '...' : $fullTitleInsecure;
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
+                "truncatedTitle_insecure" => $truncatedTitleInsecure,
                 "fullTitle" => $fullTitle,
+                "fullTitle_insecure" => $fullTitleInsecure,
                 "formType" => $formType,
                 "recordID" => $recordID,
                 "service" => $recordInfo[0]['service'],
@@ -812,15 +820,19 @@ class Email
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($recordInfo[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
+            $fullTitleInsecure = $fullTitle;
             if((int)$recordInfo[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+            $truncatedTitleInsecure = strlen($fullTitleInsecure) > 45 ? substr($fullTitleInsecure, 0, 42) . '...' : $fullTitleInsecure;
 
 
             $this->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
+                "truncatedTitle_insecure" => $truncatedTitleInsecure,
                 "fullTitle" => $fullTitle,
+                "fullTitle_insecure" => $fullTitleInsecure,
                 "formType" => $formType,
                 "recordID" => $recordID,
                 "service" => $recordInfo[0]['service'],

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1386,14 +1386,18 @@ class FormWorkflow
             $fullTitle = trim(strip_tags(
                 htmlspecialchars_decode($record[0]['title'], ENT_QUOTES | ENT_HTML5)
             ));
+            $fullTitleInsecure = $fullTitle;
             if((int)$record[0]['needToKnow'] === 1) {
                 $fullTitle = $formType;
             }
             $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+            $truncatedTitleInsecure = strlen($fullTitleInsecure) > 45 ? substr($fullTitleInsecure, 0, 42) . '...' : $fullTitleInsecure;
 
             $email->addSmartyVariables(array(
                 "truncatedTitle" => $truncatedTitle,
+                "truncatedTitle_insecure" => $truncatedTitleInsecure,
                 "fullTitle" => $fullTitle,
+                "fullTitle_insecure" => $fullTitleInsecure,
                 "formType" => $formType,
                 "recordID" => $this->recordID,
                 "service" => $record[0]['service'],
@@ -1497,14 +1501,18 @@ class FormWorkflow
                         $fullTitle = trim(strip_tags(
                             htmlspecialchars_decode($requestRecords[0]['title'], ENT_QUOTES | ENT_HTML5)
                         ));
+                        $fullTitleInsecure = $fullTitle;
                         if((int)$requestRecords[0]['needToKnow'] === 1) {
                             $fullTitle = $formType;
                         }
                         $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+                        $truncatedTitleInsecure = strlen($fullTitleInsecure) > 45 ? substr($fullTitleInsecure, 0, 42) . '...' : $fullTitleInsecure;
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $truncatedTitle,
+                            "truncatedTitle_insecure" => $truncatedTitleInsecure,
                             "fullTitle" => $fullTitle,
+                            "fullTitle_insecure" => $fullTitleInsecure,
                             "formType" => $formType,
                             "recordID" => $this->recordID,
                             "service" => $requestRecords[0]['service'],
@@ -1578,14 +1586,18 @@ class FormWorkflow
                         $fullTitle = trim(strip_tags(
                             htmlspecialchars_decode($requestRecords[0]['title'], ENT_QUOTES | ENT_HTML5)
                         ));
+                        $fullTitleInsecure = $fullTitle;
                         if((int)$requestRecords[0]['needToKnow'] === 1) {
                             $fullTitle = $formType;
                         }
                         $truncatedTitle = strlen($fullTitle) > 45 ? substr($fullTitle, 0, 42) . '...' : $fullTitle;
+                        $truncatedTitleInsecure = strlen($fullTitleInsecure) > 45 ? substr($fullTitleInsecure, 0, 42) . '...' : $fullTitleInsecure;
 
                         $email->addSmartyVariables(array(
                             "truncatedTitle" => $truncatedTitle,
+                            "truncatedTitle_insecure" => $truncatedTitleInsecure,
                             "fullTitle" => $fullTitle,
+                            "fullTitle_insecure" => $fullTitleInsecure,
                             "formType" => $formType,
                             "recordID" => $this->recordID,
                             "service" => $requestRecords[0]['service'],


### PR DESCRIPTION
## Summary
This provides flexibility in email templates related to forms marked as "Need to know", following https://github.com/department-of-veterans-affairs/LEAF/pull/2705.

This adds two new email template variables, `fullTitle_insecure` and `truncatedTitle_insecure`, which require explicit action by an administrator to enable.

This also includes some minor formatting and description changes in the Editor's Template Variable section.

## Impact
This solution has not been extended to the automated email system in order to minimize the scope of this PR. LEAF-4815 has been created to address this.

## Testing
- Prerequisites:
    1. A Workflow has been configured with an email notification event, associated with a Form
    2. The relevant email template has been updated to include the *_insecure variable
1. Create a record with a unique title based on the prerequisite Form
2. Trigger the email notification
3. You should see the unique title in the email subject