### PR TITLE
LEAF-4826 - FormWorkflow: Add optional stepID for action validation

### DIFF
--- a/LEAF_Request_Portal/api/controllers/FormWorkflowController.php
+++ b/LEAF_Request_Portal/api/controllers/FormWorkflowController.php
@@ -74,7 +74,7 @@ class FormWorkflowController extends RESTfulResponse
         $this->index['POST']->register('formWorkflow/[digit]/apply', function ($args) use ($formWorkflow) {
             $formWorkflow->initRecordID($args[0]);
             if(is_numeric($_POST['dependencyID'])) {
-                return $formWorkflow->handleAction($_POST['dependencyID'], XSSHelpers::xscrub($_POST['actionType']), $_POST['comment']);
+                return $formWorkflow->handleAction($_POST['dependencyID'], XSSHelpers::xscrub($_POST['actionType']), $_POST['comment'], $_POST['stepID']);
             } else {
                 http_response_code(400);
                 return 'The configuration for this workflow is incomplete. Please contact the administrator (missing requirement).';

--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -816,9 +816,10 @@ class FormWorkflow
      * @param int $dependencyID
      * @param string $actionType
      * @param string (optional) $comment
+     * @param int (optional) $stepID stepID must be kept optional in order to support multi-workflow records.
      * @return string|array {errors(array), comment(string)} Returns a string on client-side error, containing the error message
      */
-    public function handleAction(int $dependencyID, string $actionType, ?string $comment = ''): string|array
+    public function handleAction(int $dependencyID, string $actionType, ?string $comment = '', ?int $stepID = null): string|array
     {
         if (!is_numeric($dependencyID))
         {
@@ -952,16 +953,34 @@ class FormWorkflow
         }
 
         // get every step associated with dependencyID
-        $vars = array(':recordID' => $this->recordID,
-                      ':dependencyID' => $dependencyID, );
-        $strSQL = 'SELECT * FROM step_dependencies
-            RIGHT JOIN records_workflow_state USING (stepID)
-            LEFT JOIN workflow_steps USING (stepID)
-            LEFT JOIN dependencies USING (dependencyID)
-            WHERE recordID = :recordID
-            AND dependencyID = :dependencyID';
-        $res = $this->db->prepared_query($strSQL, $vars);
-
+        // use stepID if provided
+        $res = [];
+        if($stepID == null)
+        {
+            $vars = array(':recordID' => $this->recordID,
+                        ':dependencyID' => $dependencyID, );
+            $strSQL = 'SELECT * FROM step_dependencies
+                RIGHT JOIN records_workflow_state USING (stepID)
+                LEFT JOIN workflow_steps USING (stepID)
+                LEFT JOIN dependencies USING (dependencyID)
+                WHERE recordID = :recordID
+                AND dependencyID = :dependencyID';
+            $res = $this->db->prepared_query($strSQL, $vars);
+        }
+        else
+        {
+            $vars = array(':recordID' => $this->recordID,
+                        ':dependencyID' => $dependencyID,
+                        ':stepID' => $stepID);
+            $strSQL = 'SELECT * FROM step_dependencies
+                RIGHT JOIN records_workflow_state USING (stepID)
+                LEFT JOIN workflow_steps USING (stepID)
+                LEFT JOIN dependencies USING (dependencyID)
+                WHERE recordID = :recordID
+                AND dependencyID = :dependencyID
+                AND stepID = :stepID';
+            $res = $this->db->prepared_query($strSQL, $vars);
+        }
 
         if(count($res) == 0) {
             http_response_code(409);


### PR DESCRIPTION
## Summary
This provides a mechanism to provide "strict actions", which can reduce confusion in very specific circumstances.

Background: In order to fulfill an action, two conditions must be fulfilled: 1) a workflow step requirement (aka dependency) must be currently active, and 2) the action is valid for the current step.

The combination of the two conditions are ideally unique, as duplication implies an inefficient business workflow. In some workflows, process owners may elect to intentionally duplicate the conditions. Confusion can potentially occur if a record is on different steps that require the same conditions AND an older page state exists (via open window) AND the user(s) tokens have not expired.

This PR adds an optional `stepID` parameter in `api/formWorkflow/[digit]/apply` to provide a strict pathway for process owners who decide to set up their workflows this way.


## Impact
This makes changes to a critical function and related API, FormWorkflow.php: handleAction(), however it's implemented using a backward-compatible approach (optional function parameter).

## Testing
This automated test has been expanded to provide coverage: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/93
