### PR TITLE
form.js: Support custom callbacks

### DIFF
--- a/LEAF_Request_Portal/js/form.js
+++ b/LEAF_Request_Portal/js/form.js
@@ -11,7 +11,8 @@ var LeafForm = function (containerID) {
   var htmlFormID = prefixID + "record";
   var dialog;
   var recordID = 0;
-  var postModifyCallback;
+  var postModifyCallback; // Primary callback for core feature
+  var postModifyCallbacks = []; // Secondary callbacks
   let rootURL = "";
   let errorCount = 0;
 
@@ -55,6 +56,26 @@ var LeafForm = function (containerID) {
 
   function setPostModifyCallback(func) {
     postModifyCallback = func;
+  }
+
+  function addPostModifyCallback(func) {
+    let idx = postModifyCallbacks.findIndex(cb => cb.toString() == func.toString());
+    if(idx == -1) {
+      postModifyCallbacks.push(func);
+    }
+  }
+
+  // removePostModifyCallback removes a registered callback
+  function removePostModifyCallback(func) {
+    if(func.toString() == postModifyCallback.toString()) {
+      postModifyCallback == undefined;
+      return;
+    }
+
+    let idx = postModifyCallbacks.findIndex(cb => cb.toString() == func.toString());
+    if(idx >= 0) {
+      postModifyCallbacks.splice(idx, 1);
+    }
   }
 
   function sanitize(input = "") {
@@ -863,6 +884,9 @@ var LeafForm = function (containerID) {
         if (postModifyCallback != undefined) {
           postModifyCallback();
         }
+        postModifyCallbacks.forEach(fn => {
+          fn();
+        });
         $("#" + dialog.btnSaveID)
           .empty()
           .html(temp);
@@ -977,6 +1001,8 @@ var LeafForm = function (containerID) {
 
     setRecordID: setRecordID,
     setPostModifyCallback: setPostModifyCallback,
+    addPostModifyCallback: addPostModifyCallback,
+    removePostModifyCallback: removePostModifyCallback,
     doModify: doModify,
     getForm: getForm,
     initCustom: initCustom,


### PR DESCRIPTION
## Summary
This provides more flexibility for field developers.

This adds two new methods to `form.js`, `addPostModifyCallback` and `removePostModifyCallback` to control function execution after form.js sends its HTTP POST request.

## Impact
No changes to existing functionality.

## Testing
Customizations such as https://github.com/department-of-veterans-affairs/LEAF-Developer-Examples/blob/a53ce742621e2cc862cb1eeb2fd934ea9e132493/forms/custom_fields/auto_update_title_with_form_data.md function as intended.
