### PR TITLE
workflow.js: Pass data to callback

### DIFF
--- a/LEAF_Request_Portal/js/workflow.js
+++ b/LEAF_Request_Portal/js/workflow.js
@@ -119,7 +119,11 @@ var LeafWorkflow = function (containerID, CSRFToken) {
 
                             getWorkflow(currRecordID);
                             if (actionSuccessCallback !== undefined) {
-                                actionSuccessCallback();
+                                actionSuccessCallback({
+                                    actionType: data.actionType,
+                                    dependencyID: data.dependencyID,
+                                    comment: data.comment
+                                });
                             }
 
                             let new_note;
@@ -852,6 +856,12 @@ var LeafWorkflow = function (containerID, CSRFToken) {
 
     /**
      * @memberOf LeafWorkflow
+     * func accepts 1 argument:
+     *     data - {
+     *                 actionType: the action type that was exectued
+     *                 dependencyID: the dependencyID associated with the action
+     *                 comment: the comment associated with the action
+     *            }
      */
     function setActionSuccessCallback(func) {
         actionSuccessCallback = func;
@@ -859,11 +869,11 @@ var LeafWorkflow = function (containerID, CSRFToken) {
 
     /**
      * @memberOf LeafWorkflow
-     * func should accept 2 arguments:
+     * func accepts 2 arguments:
      *     data - {
      *                 idx: index matching the current action for data.step.dependencyActions[]
      *                 step: data related to the current step
-     *               }
+     *            }
      *     completeAction - to be executed in order to complete the workflow action
      */
     function setActionPreconditionFunc(func) {


### PR DESCRIPTION
## Summary
This provides more flexibility for field developers.

This expands the `setActionSuccessCallback` to provide relevant data to custom callbacks.

The new data structure is:
```
     *     data - {
     *                 actionType: the action type that was exectued
     *                 dependencyID: the dependencyID associated with the action
     *                 comment: the comment associated with the action
     *            }
```

## Impact
No changes to existing functionality.

## Testing
Customizations such as https://github.com/department-of-veterans-affairs/LEAF-Developer-Examples/blob/a31887eae44aa60dc8acffff9363f47bae85371c/forms/custom_fields/workflow_run_function_after_action.md function as intended.

It would be sufficient to check the output of the "data" parameter matches the above definition:
```html
<script>

workflow.setActionSuccessCallback(async (data) => {

    console.log(data);

});

</script>
```
