### PR TITLE
Improve form search UX

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -1030,7 +1030,12 @@ var LeafFormSearch = function (containerID) {
                 break;
             case "data":
                 let resultFilter =
-                    "?x-filterData=indicatorID,categoryName,name,format";
+                    "?x-filterData=indicatorID,categoryName,name,format,description";
+                let urlParams = new URLSearchParams(window.location.search);
+                if(urlParams.has('dev')) {
+                    resultFilter += '&dev';
+                }
+                
                 url =
                     rootURL === ""
                         ? `./api/form/indicator/list${resultFilter}`
@@ -1053,17 +1058,30 @@ var LeafFormSearch = function (containerID) {
                         indicators +=
                             '<option value="' +
                             ALL_OC_EMPLOYEE_DATA_FIELDS +
-                            '">Any Org. Chart employee field</option>';
+                            '">Any Employee field</option>';
+
+                        // Organize by form type
+                        let indicatorsByForm = {};
                         for (var i in res) {
-                            indicators +=
-                                '<option value="' +
-                                res[i].indicatorID +
-                                '">' +
-                                res[i].categoryName +
-                                ": " +
-                                res[i].name +
-                                "</option>";
+                            if(indicatorsByForm[res[i].categoryName] == undefined) {
+                                indicatorsByForm[res[i].categoryName] = [];
+                            }
+                            indicatorsByForm[res[i].categoryName].push(res[i]);
                         }
+
+                        Object.keys(indicatorsByForm).forEach(key => {
+                            indicators += `<optgroup label="${key}">`;
+
+                            indicatorsByForm[key].forEach(res => {
+                                let preferLabel = res.description;
+                                if(preferLabel == '') {
+                                    preferLabel = res.name;
+                                }
+                                indicators += `<option value="${res.indicatorID}">${res.name}</option>`;
+                            });
+                            indicators += '</optgroup>';
+                        });
+
                         indicators += "</select><br />";
                         $("#" + prefixID + "widgetTerm_" + widgetID).after(
                             indicators
@@ -1130,7 +1148,7 @@ var LeafFormSearch = function (containerID) {
                                             prefixID +
                                             "widgetCod_" +
                                             widgetID +
-                                            '" value="=" /> IS'
+                                            '" value="=" /> CONTAINS'
                                     );
                                     $(
                                         "#" +
@@ -1749,7 +1767,7 @@ var LeafFormSearch = function (containerID) {
                 .children[0].children[2].setAttribute("colspan", "2"); // Resize col
             document.getElementById(
                 prefixID + "searchTerms"
-            ).children[0].children[2].style.width = "175px";
+            ).children[0].children[2].style.width = "225px";
             document.getElementById(
                 prefixID + "searchTerms"
             ).children[0].children[3].style.width = "130px";

--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -4234,6 +4234,11 @@ class Form
         // check for orphaned indicators
         foreach ($res as $item)
         {
+            // Skip built-in forms unless requested to avoid clutter
+            if(substr($item['categoryID'], 0, 5) == 'leaf_' && !isset($_GET['dev'])) {
+                continue;
+            }
+
             if (!$this->isIndicatorOrphan($item, $isActiveIndicator))
             {
                 // make sure the field's category isn't a member of a deleted category


### PR DESCRIPTION
## Summary
This improves usability in the form search widget.

The form search widget provides a dropdown list of form fields. This can be difficult to read because each field is prefixed with the name of the form.

This groups form fields by their form type using <optgroup> tags so that the list of fields do not need to be prefixed with the form name, retaining the ability to search by form name and making the list easier to read.

This also prioritizes showing the field's "Short Label" if present.

Built-in LEAF forms such as LEAF-S and LEAF Programmer Access have been hidden by default, and can be exposed by adding the HTTP GET parameter `dev` to the URL, similar to https://github.com/department-of-veterans-affairs/LEAF/pull/2386

## Impact
This changes the layout of the "Data Field" search term. Notify end-users of the change, especially how the embedded search function works.

## Testing
TBD
