### PR TITLE
LEAF 4841 mass actions - fix for data and dependency field search

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_mass_action.tpl
@@ -568,7 +568,7 @@ function addTerms(leafFormQuery) {
 
     if (isJSON) {
         for (let i = 0; i < advSearch.length; i++) {
-            if (advSearch[i]?.id === 'data') {
+            if (advSearch[i]?.id === 'data' || advSearch[i]?.id === 'dependencyID') {
                 leafFormQuery.addDataTerm(advSearch[i].id, advSearch[i].indicatorID, advSearch[i].operator, advSearch[i].match);
             } else {
                 leafFormQuery.addTerm(advSearch[i].id, advSearch[i].operator, advSearch[i].match);


### PR DESCRIPTION
## Summary
Adds required alternate handling of data and dependency advanced search filters.
These terms are added with the method addDataTerm rather than addTerm.  

## Impact
Mass Actions.
Fix for 'Data Field...' and 'Requirement ...' (dependencies) filter options

## Testing
Confirm that Mass Actions
Data Field (either any standard data field or specific data fields) filters return expected results

