### PR TITLE
Enhance/leaf 4760/email editor improvements

### DIFF
--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -43,6 +43,9 @@
     height:360px;
     display:none;
 }
+.trumbowyg-save-button.trumbowyg-textual-button {
+    display: none; /* trumbowyg custom defined btn only used for key shortcut Ctrl+S save */
+}
 .CodeMirror-code {
     font-size: .7rem;
 }

--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -181,7 +181,7 @@ div.CodeMirror-merge-pane-label-right {
     padding: 0.5rem;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.75rem;
 }
 #fileBrowser > h3 {
     width: 100%;
@@ -194,14 +194,19 @@ div.CodeMirror-merge-pane-label-right {
 #fileList > ul.reports {
     margin-bottom: 1rem;
 }
+#fileList hr {
+    margin: 1rem 0;
+}
+.templates_header {
+    font-weight: bold;
+    font-size: 0.875rem;
+    color: #252f3e;
+}
 .leaf-ul {
     width: 100%;
-    min-height: 300px;
+    margin: 0.5rem 0 0 0;
     padding: 0 0 0 1rem;
     overflow: auto;
-}
-.leaf-ul:first-child {
-    margin-top: 0;
 }
 .leaf-ul > li {
     width: 100%;
@@ -586,7 +591,13 @@ fieldset {
     color: #c00000;
     visibility: hidden;
 }
-
+#subject_smarty_vars_notice, #body_smarty_vars_notice {
+    color:#c00000;
+    background-color:#fff;
+    margin: 1rem 0 -1.5rem 0;
+    padding:0.5rem;
+    line-height: 1.2;
+}
 
 
 

--- a/LEAF_Request_Portal/admin/css/mod_templates_reports.css
+++ b/LEAF_Request_Portal/admin/css/mod_templates_reports.css
@@ -201,13 +201,14 @@ div.CodeMirror-merge-pane-label-right {
     margin: 1rem 0;
 }
 .templates_header {
+    margin-bottom: 0.5rem;
     font-weight: bold;
     font-size: 0.875rem;
     color: #252f3e;
 }
 .leaf-ul {
     width: 100%;
-    margin: 0.5rem 0 0 0;
+    margin: 0;
     padding: 0 0 0 1rem;
     overflow: auto;
 }
@@ -594,14 +595,27 @@ fieldset {
     color: #c00000;
     visibility: hidden;
 }
-#subject_smarty_vars_notice, #body_smarty_vars_notice {
-    color:#c00000;
-    background-color:#fff;
-    margin: 1rem 0 -1.5rem 0;
-    padding:0.5rem;
-    line-height: 1.2;
+#field_use_notice {
+    color:#b00000;
+    margin-bottom: 0.5rem;
 }
-
+#to_cc_smarty_vars_notice {
+    margin: 0 -0.5rem;
+    padding: 0.5rem;
+}
+#to_cc_smarty_vars_notice, #subject_smarty_vars_notice, #body_smarty_vars_notice {
+    color:#b00000;
+    font-weight: bolder;
+    background-color:#fffbc8;
+    line-height: 1.3;
+}
+#subject_smarty_vars_notice, #body_smarty_vars_notice {
+    margin: 1rem 0 -1.5rem 0;
+    padding: 0.5rem 0.5rem 0.75rem;
+}
+#to_cc_smarty_vars_notice span, #subject_smarty_vars_notice span, #body_smarty_vars_notice span {
+    font-weight: normal;
+}
 
 
 @media only screen and (max-width:1024px) {

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -31,10 +31,10 @@
                         <p>
                             Enter email addresses, one per line. Users will be
                             emailed each time this template is used in any workflow.&nbsp;
-                            <div id="field_use_notice" style="display: none; color:#c00000;">
+                            <div id="field_use_notice" style="display: none;">
                             Please note that only orgchart employee formats are supported in this section.
                             </div>
-                            <div id="to_cc_smarty_vars_notice" style="display:none;color:#c00000;">
+                            <div id="to_cc_smarty_vars_notice" style="display:none">
                                 Potential Variable errors in To/Cc: <span id="to_cc_field_errors"></span><br>
                                 <span style="color:#000;">Example: {{$variable}}</span>
                             </div>

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -36,7 +36,7 @@
                             </div>
                             <div id="to_cc_smarty_vars_notice" style="display:none;color:#c00000;">
                                 Potential Variable errors in To/Cc: <span id="to_cc_field_errors"></span><br>
-                                <span style="color:#000;">{{$variable}}</span>
+                                <span style="color:#000;">Example: {{$variable}}</span>
                             </div>
                         </p>
                         <label for="emailToCode" id="emailTo" class="emailToCc">Email To:</label>
@@ -51,7 +51,7 @@
                 </div>
                 <div id="subject_smarty_vars_notice" style="display:none;">
                     Potential Variable errors in Subject: <span id="subject_field_errors"></span><br>
-                    <span style="color:#000;">{{$variable}}</span>
+                    <span style="color:#000;">Example: {{$variable}}</span>
                 </div>
                 <label for="code_mirror_subject_editor" id="subject">Subject</label>
                 <div id="divSubject">
@@ -64,7 +64,7 @@
                 </div>
                 <div id="body_smarty_vars_notice" style="display:none;">
                     Potential Variable errors in Body: <span id="body_field_errors"></span><br>
-                    <span style="color:#000;">{{$variable}}</span>
+                    <span style="color:#000;">Example: {{$variable}}</span>
                 </div>
                 <label for="code_mirror_template_editor" id="filename" class="email">Body</label>
                 <div id="emailBodyCode">
@@ -1376,6 +1376,78 @@
         }
     }
 
+    function registerVariablesPlugin() {
+        const defaultOptions = {
+            source: [
+                'recordID',
+                'fullTitle',
+                'fullTitle_insecure',
+                'truncatedTitle',
+                'truncatedTitle_insecure',
+                'formType',
+                'lastStatus',
+                'comment',
+                'service',
+                'siteRoot',
+                'field.#',
+            ],
+            formatVariable: formatVariable,
+        };
+
+        $.extend(
+            true, $.trumbowyg,
+            {
+                langs: {
+                    en: { addVariables: 'Variables' }
+                },
+                plugins: {
+                    addVariables: {
+                        init: function(trumbowyg) {
+                            trumbowyg.o.plugins.addVariables = $.extend(
+                                true, {},
+                                defaultOptions,
+                                trumbowyg.o.plugins.addVariables || {}
+                            );
+
+                            const ddDef = {
+                                dropdown: makeDropdown(trumbowyg.o.plugins.addVariables.source, trumbowyg),
+                                title: 'Add variables',
+                                text: 'Variables',
+                                hasIcon: false
+                            }
+                            trumbowyg.addBtnDef('addVariables', ddDef);
+                        }
+                    }
+                }
+            }
+        );
+
+        function formatVariable(srcItem) {
+            return '\{\{$' + srcItem + '}}';
+        }
+
+        function makeDropdown(sourceArray, trumbowyg) {
+            let dd = [];
+            sourceArray.forEach((ele, idx) => {
+                const d = {
+                    fn: function() {
+                        trumbowyg.execCmd(
+                            "insertHTML",
+                            trumbowyg.o.plugins.addVariables.formatVariable(ele)
+                        );
+                        return true;
+                    },
+                    text: ele,
+                    hasIcon: false,
+                };
+
+                trumbowyg.addBtnDef(ele, d);
+                dd.push(ele);
+            });
+            return dd;
+        }
+    }
+
     //jQuery plugins for WYSWYG.
     function useTrumbowygEmailEditor() {
         toggleEditorElements(true);
@@ -1393,7 +1465,7 @@
                     key: 'S', //config setting implies Ctrl+
                     text: 'Save',
                     hasIcon: false,
-                },
+                }
             },
             btns: [
                 'formatting', 'bold', 'italic', 'underline', '|',
@@ -1401,6 +1473,7 @@
                 'link', '|',
                 'foreColor', 'backColor', '|',
                 'justifyLeft', 'justifyCenter', 'justifyRight',
+                'addVariables',
                 'save'
             ],
         }).on('tbwblur', () => checkFieldEntries(null, false));
@@ -1522,6 +1595,8 @@
 
     //loads components when the document loads
     $(document).ready(function() {
+        registerVariablesPlugin();
+
         getIndicators(); //get indicators to make format table
         getForms(); //get forms for quick search and indicator format info
 

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -1295,6 +1295,11 @@
         });
         subjectEditor.on('blur', (cm) => checkFieldEntries(cm, false));
         addCodeMirrorAria('subjectCode');
+
+        setTimeout(() => {
+            checkFieldEntries(codeEditor, false);
+            checkFieldEntries(subjectEditor, false);
+        });
     }
     // Displays  user's history when creating, merge, and so on
     function viewHistory() {
@@ -1423,7 +1428,7 @@
         );
 
         function formatVariable(srcItem) {
-            return '\{\{$' + srcItem + '}}';
+            return '\{\{$' + srcItem + '}} ';
         }
 
         function makeDropdown(sourceArray, trumbowyg) {
@@ -1556,6 +1561,7 @@
                 }
             }
         });
+        checkFieldEntries(null, false);
         document.getElementById('btn_useCodeMirror').focus();
     }
 

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -1650,35 +1650,15 @@
                     success: function (customTemplates) { //array of file names in templates/email/custom_override
                         let customClass = '';
                         let selectedAttr = '';
-                        let buffer = '<div class="templates_header">Standard Events</div><ul class="leaf-ul">';
 
+                        let buffer = '';
                         let filesMobile = `<label for="template_file_select">Template Files:</label>
-                            <div class="template_select_container">
-                                <select id="template_file_select" class="templateFiles">
-                                    <optgroup label="Standard Events">`;
+                            <div class="template_select_container"><select id="template_file_select" class="templateFiles">`;
 
                         if (Array.isArray(customTemplates)) {
-                            standardTemplates.forEach(t => {
-                                customClass = customTemplates.includes(t.fileName) ? ' class="custom_file"' : '';
-                                selectedAttr = t.fileName === currentFile ? ' selected' : '';
-
-                                // Construct the li element for non-mobile buffer
-                                buffer += `<li>
-                                    <div class="template_files">
-                                        <a href="#" role="button" data-file="${t.fileName}">${t.displayName}</a> <span${customClass}>(custom)</span>
-                                    </div>
-                                </li>`;
-
-                                // Construct the option element for filesMobile
-                                filesMobile += `<option value="${t.fileName}"${selectedAttr}>
-                                    ${t.displayName + (customClass ? ' (custom)' : '')}</option>`;
-                            });
-
-                            buffer += '</ul>';
-                            filesMobile += '</optgroup>';
-
                             if (userTemplates.length > 0) {
-                                buffer += '<hr><div class="templates_header">Custom Events</div><ul class="leaf-ul">';
+                                buffer += '<div class="templates_header">Custom Events</div><ul class="leaf-ul">';
+
                                 filesMobile += '<optgroup label="Custom Events">';
 
                                 userTemplates.forEach(t => {
@@ -1696,11 +1676,31 @@
                                     filesMobile += `<option value="${t.fileName}">${t.displayName + (customClass ? ' (custom)' : '')}</option>`;
                                 });
 
-                                buffer += '</ul>';
+                                buffer += '</ul><hr>';
                                 filesMobile += '</optgroup>';
                             }
 
-                            filesMobile += '</select></div>'
+                            buffer += '<div class="templates_header">Standard Events</div><ul class="leaf-ul">';
+                            filesMobile += `<optgroup label="Standard Events">`;
+
+                            standardTemplates.forEach(t => {
+                                customClass = customTemplates.includes(t.fileName) ? ' class="custom_file"' : '';
+                                selectedAttr = t.fileName === currentFile ? ' selected' : '';
+
+                                // Construct the li element for non-mobile buffer
+                                buffer += `<li>
+                                    <div class="template_files">
+                                        <a href="#" role="button" data-file="${t.fileName}">${t.displayName}</a> <span${customClass}>(custom)</span>
+                                    </div>
+                                </li>`;
+
+                                // Construct the option element for filesMobile
+                                filesMobile += `<option value="${t.fileName}"${selectedAttr}>
+                                    ${t.displayName + (customClass ? ' (custom)' : '')}</option>`;
+                            });
+
+                            buffer += '</ul>';
+                            filesMobile += '</optgroup></select></div>';
 
                         } else {
                             buffer += '<li>Internal error occurred. If this persists, contact your Primary Admin.</li>';

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -34,6 +34,10 @@
                             <div id="field_use_notice" style="display: none; color:#c00000;">
                             Please note that only orgchart employee formats are supported in this section.
                             </div>
+                            <div id="to_cc_smarty_vars_notice" style="display:none;color:#c00000;">
+                                Potential Variable errors in To/Cc: <span id="to_cc_field_errors"></span><br>
+                                <span style="color:#000;">{{$variable}}</span>
+                            </div>
                         </p>
                         <label for="emailToCode" id="emailTo" class="emailToCc">Email To:</label>
                         <div id="divEmailTo">
@@ -45,6 +49,10 @@
                         </div>
                     </fieldset>
                 </div>
+                <div id="subject_smarty_vars_notice" style="display:none;">
+                    Potential Variable errors in Subject: <span id="subject_field_errors"></span><br>
+                    <span style="color:#000;">{{$variable}}</span>
+                </div>
                 <label for="code_mirror_subject_editor" id="subject">Subject</label>
                 <div id="divSubject">
                     <div class="compared-label-content">
@@ -53,6 +61,10 @@
                     </div>
                     <textarea id="subjectCode"></textarea>
                     <div id="subjectCompare"></div>
+                </div>
+                <div id="body_smarty_vars_notice" style="display:none;">
+                    Potential Variable errors in Body: <span id="body_field_errors"></span><br>
+                    <span style="color:#000;">{{$variable}}</span>
                 </div>
                 <label for="code_mirror_template_editor" id="filename" class="email">Body</label>
                 <div id="emailBodyCode">
@@ -247,7 +259,7 @@
     let subjectEditor;
     let dialog_message;
 
-    let currentName;
+    let currentLabel;
     let currentFile;
     let currentSubjectFile;
     let currentEmailToFile;
@@ -317,28 +329,90 @@
     * used on load and as a listener on email To CC fields
     * displays a message if non-orgchart employee format indicators are referenced in these areas
     */
-    function checkFieldEntries() {
-        const elTextareaTo = document.getElementById("emailToCode");
-        const elTextareaCc = document.getElementById("emailCcCode");
-        const elTextInput = (elTextareaTo?.value || "") + "\r\n" + (elTextareaCc?.value || "");
-        if(elTextInput !== "") {
-            const fieldReg = /field\.\d*/g;
-            const fieldMatches = elTextInput.match(fieldReg);
-            let elNotice = document.getElementById("field_use_notice");
-            if (elNotice !== null) {
-                if(fieldMatches?.length > 0) {
-                    const ids = fieldMatches.map(m => +m.slice(m.indexOf(".") + 1));
-                    let includesNonOrgchartEmp = false;
-                    for(let i = 0; i < ids.length; i++) {
-                        const id = ids[i];
-                        if(allowedToCcFormats?.[indicatorFormats[id]] !== 1) {
-                            includesNonOrgchartEmp = true;
-                            break;
-                        }
+    function checkFieldEntries(cm = null, orgEmployeeOnly = true) {
+        const smartyVarReg = /\{.*?\}?\}/g;
+        let smartyErrors = [];
+        let varMatches = [];
+
+        if (orgEmployeeOnly === true) {
+            //to and cc textareas only support orgchart employee format
+            const elTextareaTo = document.getElementById("emailToCode");
+            const elTextareaCc = document.getElementById("emailCcCode");
+            const elTextInput = (elTextareaTo?.value || "") + "\r\n" + (elTextareaCc?.value || "");
+
+            let elFormatNotice = document.getElementById("field_use_notice");
+            let elVariableNotice = document.getElementById("to_cc_smarty_vars_notice");
+            let elErrors = document.getElementById('to_cc_field_errors');
+            varMatches = elTextInput.match(smartyVarReg) ?? [];
+
+            let includesNonOrgchartEmp = false;
+            for(let i = 0; i < varMatches.length; i++) {
+                const m = varMatches[i];
+                if(typeof m === 'string' && m.includes('field.')) {
+                    const id = m.match(/\d{1,}/g)?.[0];
+                    if (!/^\{\{\$\S/.test(m) || !m.endsWith('}}')) {
+                        smartyErrors.push(m);
                     }
-                    elNotice.style.display = includesNonOrgchartEmp ? "block" : "none";
+                    if(allowedToCcFormats?.[indicatorFormats?.[id]] !== 1) {
+                        includesNonOrgchartEmp = true;
+                        break;
+                    }
                 } else {
-                    elNotice.style.display = "none";
+                    includesNonOrgchartEmp = true;
+                    break;
+                }
+            }
+            if(elFormatNotice !== null) {
+                elFormatNotice.style.display = includesNonOrgchartEmp === true ? 'block' : 'none';
+            }
+
+            if (elVariableNotice !== null && elErrors !== null) {
+                if (smartyErrors.length > 0) {
+                    elVariableNotice.style.display = 'block';
+                    elErrors.textContent = smartyErrors.join(',');
+                } else {
+                    elVariableNotice.style.display = 'none';
+                    elErrors.textContent = '';
+                }
+            }
+
+
+        } else {
+            let elVariableNotice = null
+            let elErrors = null
+            let content = '';
+
+            if(cm !== null) { //subject or code editor mode body
+                content = getCodeEditorValue(cm);
+                const textareaID = (cm.getTextArea()?.id ?? '').toLowerCase();
+                if(textareaID === 'subjectcode') {
+                    elVariableNotice = document.getElementById("subject_smarty_vars_notice");
+                    elErrors = document.getElementById('subject_field_errors');
+                } else {
+                    elVariableNotice = document.getElementById("body_smarty_vars_notice");
+                    elErrors = document.getElementById('body_field_errors');
+                }
+
+            } else {
+                content = document.querySelector('#emailBodyCode + div textarea.trumbowyg-textarea')?.value ?? '';
+                elVariableNotice = document.getElementById("body_smarty_vars_notice");
+                elErrors = document.getElementById('body_field_errors');
+            }
+
+            varMatches = content.match(smartyVarReg) ?? [];
+            varMatches.forEach(m => {
+                if (!/^\{\{\$\S/.test(m) || !m.endsWith('}}')) {
+                    smartyErrors.push(m);
+                }
+            });
+
+            if (elVariableNotice !== null && elErrors !== null) {
+                if (smartyErrors.length > 0) {
+                    elVariableNotice.style.display = 'block';
+                    elErrors.textContent = smartyErrors.join(', ');
+                } else {
+                    elVariableNotice.style.display = 'none';
+                    elErrors.textContent = '';
                 }
             }
         }
@@ -701,13 +775,13 @@
         let templateEmailCcFile = urlParams.get('emailCcFile');
 
         if (fileName !== null && parentFile !== null && templateSubjectFile == 'undefined' && templateName == 'undefined') {
-            loadContent(currentName, templateFile, currentSubjectFile, currentEmailToFile, currentEmailCcFile);
+            loadContent(currentLabel, templateFile, currentSubjectFile, currentEmailToFile, currentEmailCcFile);
             compareHistoryFile(fileName, parentFile, false);
         } else if (fileName !== null && parentFile !== null && templateSubjectFile !== null) {
             loadContent(templateName, templateFile, templateSubjectFile, templateEmailToFile, templateEmailCcFile);
             compareHistoryFile(fileName, parentFile, false);
         } else if (templateSubjectFile == 'undefined') {
-            loadContent(currentName, templateFile, currentSubjectFile, currentEmailToFile, currentEmailCcFile);
+            loadContent(currentLabel, templateFile, currentSubjectFile, currentEmailToFile, currentEmailCcFile);
         } else if (templateFile !== null) {
             loadContent(templateName, templateFile, templateSubjectFile, templateEmailToFile, templateEmailCcFile);
         } else {
@@ -856,20 +930,20 @@
         url.searchParams.delete('parentFile');
         window.history.replaceState(null, null, url.toString());
         if(load === true) {
-            loadContent(currentName, currentFile, currentSubjectFile, currentEmailToFile, currentEmailCcFile);
+            loadContent(currentLabel, currentFile, currentSubjectFile, currentEmailToFile, currentEmailCcFile);
         }
     }
 
     /**
     * Used in editing view to load content and associated history records.
     * Prepares codeEditor. Updates the display area, url, and current content global variables.
-    * @param {string} name - description of event being loaded. eg Send Back
+    * @param {string} label - label of template being loaded. eg Send Back
     * @param {string} file - body template name. eg LEAF_send_back_body.tpl
     * @param {string} subjectFile - subject template name. eg LEAF_send_back_subject.tpl
     * @param {string} emailToFile - eg LEAF_send_back_emailTo.tpl
     * @param {string} emailCcFile - eg LEAF_send_back_emailCc.tpl
     */
-    function loadContent(name, file, subjectFile, emailToFile, emailCcFile) {
+    function loadContent(label, file, subjectFile, emailToFile, emailCcFile) {
         //current T editor val if it exists
         const trumbowValue = document.querySelector(
             '#emailBodyCode + div textarea.trumbowyg-textarea'
@@ -898,7 +972,7 @@
             return;
         }
 
-        if (ignorePrompt) { //true only on page load
+        if (ignorePrompt === true) { //true only on page load
             ignorePrompt = false;
         } else {
             const emailToData = document.getElementById('emailToCode').value;
@@ -919,13 +993,13 @@
         $('.CodeMirror').remove();
 
         initEditor();
-        currentName = name;
+        currentLabel = label;
         currentFile = file;
         currentSubjectFile = subjectFile;
         currentEmailToFile = emailToFile;
         currentEmailCcFile = emailCcFile;
         $('#codeContainer').css('display', 'none');
-        $('#emailTemplateHeader').html(currentName);
+        $('#emailTemplateHeader').html(currentLabel);
         if (typeof subjectFile === 'undefined' || subjectFile === null || subjectFile === '') {
             $('#subject, #emailLists, #emailTo, #emailCc').hide();
             $('#divSubject, #divEmailTo, #divEmailCc').hide().prop('disabled', true);
@@ -991,7 +1065,7 @@
         if(file) {
             let url = new URL(window.location.href);
             url.searchParams.set('file', file);
-            url.searchParams.set('name', name);
+            url.searchParams.set('name', label);
             url.searchParams.set('subjectFile', subjectFile);
             url.searchParams.set('emailToFile', emailToFile);
             url.searchParams.set('emailCcFile', emailCcFile);
@@ -1191,6 +1265,7 @@
                 }
             }
         });
+        codeEditor.on('blur', (cm) => checkFieldEntries(cm, false));
         addCodeMirrorAria('code');
 
         subjectEditor = CodeMirror.fromTextArea(document.getElementById("subjectCode"), {
@@ -1218,6 +1293,7 @@
                 }
             }
         });
+        subjectEditor.on('blur', (cm) => checkFieldEntries(cm, false));
         addCodeMirrorAria('subjectCode');
     }
     // Displays  user's history when creating, merge, and so on
@@ -1248,7 +1324,7 @@
         if(typeof currentFile === 'string') {
             try {
                 fetch(`../api/workflow/customEvents`)
-                .then(res => res.json()
+                .then(res => res.json())
                 .then(data => {
                     const events = Array.isArray(data) ? data : [];
                     const sliceEnd = -('_body.tpl'.length);
@@ -1266,7 +1342,7 @@
                             if (+NotifyGroup > 0) {
                                 try {
                                     fetch('../api/group/list')
-                                    .then(res => res.json()
+                                    .then(res => res.json())
                                     .then(data => {
                                         const groups = data;
                                         const groupName = groups.find(g => +NotifyGroup === g.groupID)?.name || '';
@@ -1276,8 +1352,7 @@
                                         }
                                         elInfo.innerHTML = arrNotices.join('');
                                         elInfo.style.display = arrNotices.length > 0 ? 'flex' : 'none';
-                                    }).catch(err => console.log(err))
-                                    ).catch(err => console.log(err));
+                                    }).catch(err => console.log(err));
                                 } catch (err) {
                                     console.log(err);
                                 }
@@ -1293,8 +1368,7 @@
                         elInfo.innerHTML = '';
                         elInfo.style.display = 'none';
                     }
-                }).catch(err => console.log(err))
-                ).catch(err => console.log(err));
+                }).catch(err => console.log(err));
 
             } catch (err) {
                 console.log(err);
@@ -1308,14 +1382,28 @@
         const data = getCodeEditorValue(codeEditor);
         $('#editor_trumbowyg').val(data);
         $('#editor_trumbowyg').trumbowyg({
+            btnsDef: {
+                save: {
+                    fn: function() {
+                        const saveEl = document.getElementById('save_button');
+                        if(saveEl !== null) {
+                            saveEl.dispatchEvent(new Event('click'));
+                        }
+                    },
+                    key: 'S', //config setting implies Ctrl+
+                    text: 'Save',
+                    hasIcon: false,
+                },
+            },
             btns: [
                 'formatting', 'bold', 'italic', 'underline', '|',
                 'unorderedList', 'orderedList', '|',
                 'link', '|',
-                'foreColor', '|',
-                'justifyLeft', 'justifyCenter', 'justifyRight'
+                'foreColor', 'backColor', '|',
+                'justifyLeft', 'justifyCenter', 'justifyRight',
+                'save'
             ],
-        });
+        }).on('tbwblur', () => checkFieldEntries(null, false));
         $('.trumbowyg-box').css({
             'min-height': '130px',
             'margin': '0.5rem 0'
@@ -1452,44 +1540,87 @@
             'genericDialogbutton_cancelchange'
         );
 
-        // Get initial email templates for page from database
+        // Get array of email templates records from portal.email_templates table
         $.ajax({
             type: 'GET',
             url: '../api/emailTemplates',
-            success: function (res) {
+            success: function (emailTemplateRecords) {
+                const sortedTemplates = emailTemplateRecords.toSorted((a, b) => {
+                    const labelA = a.displayName.toLowerCase();
+                    const labelB = b.displayName.toLowerCase();
+                    return labelA < labelB ? -1 : labelA > labelB ? 1 : 0;
+                });
+                let standardTemplates = [];
+                let userTemplates = [];
+                let recordFilenameTable = {};
+                sortedTemplates.forEach(rec => {
+                    recordFilenameTable[rec.fileName] = { ...rec };
+                    if(rec.fileName.startsWith("LEAF_")) {
+                        standardTemplates.push(rec);
+                    } else {
+                        userTemplates.push(rec);
+                    }
+                });
+
                 $.ajax({
                     type: 'GET',
                     url: '../api/emailTemplates/custom',
                     dataType: 'json',
-                    success: function (customTemplates) {
-                        let buffer = '<ul class="leaf-ul">';
+                    success: function (customTemplates) { //array of file names in templates/email/custom_override
+                        let customClass = '';
+                        let selectedAttr = '';
+                        let buffer = '<div class="templates_header">Standard Events</div><ul class="leaf-ul">';
+
                         let filesMobile = `<label for="template_file_select">Template Files:</label>
-                            <div class="template_select_container"><select id="template_file_select" class="templateFiles">`;
+                            <div class="template_select_container">
+                                <select id="template_file_select" class="templateFiles">
+                                    <optgroup label="Standard Events">`;
 
                         if (Array.isArray(customTemplates)) {
-                            let customClass = '';
-                            for (let i in res) {
-                                customClass = customTemplates.includes(res[i].fileName) ? ' class="custom_file"' : '';
+                            standardTemplates.forEach(t => {
+                                customClass = customTemplates.includes(t.fileName) ? ' class="custom_file"' : '';
+                                selectedAttr = t.fileName === currentFile ? ' selected' : '';
 
-                                // Construct the option element with data- attributes for filesMobile
-                                filesMobile += '<option data-template-data=\'' + JSON.stringify({
-                                    displayName: res[i].displayName,
-                                    fileName: res[i].fileName,
-                                    subjectFileName: res[i].subjectFileName || '',
-                                    emailToFileName: res[i].emailToFileName || '',
-                                    emailCcFileName: res[i].emailCcFileName || '',
-                                }) + '\'>' + res[i].displayName + (customClass ? ' (custom)' : '') + '</option>';
-
-                                // Construct the li element for buffer
+                                // Construct the li element for non-mobile buffer
                                 buffer += `<li>
                                     <div class="template_files">
-                                        <a href="#" role="button" data-template-index="${i}" data-file="${res[i].fileName}">${res[i].displayName}</a> <span${customClass}>(custom)</span>
+                                        <a href="#" role="button" data-file="${t.fileName}">${t.displayName}</a> <span${customClass}>(custom)</span>
                                     </div>
                                 </li>`;
+
+                                // Construct the option element for filesMobile
+                                filesMobile += `<option value="${t.fileName}"${selectedAttr}>
+                                    ${t.displayName + (customClass ? ' (custom)' : '')}</option>`;
+                            });
+
+                            buffer += '</ul>';
+                            filesMobile += '</optgroup>';
+
+                            if (userTemplates.length > 0) {
+                                buffer += '<hr><div class="templates_header">Custom Events</div><ul class="leaf-ul">';
+                                filesMobile += '<optgroup label="Custom Events">';
+
+                                userTemplates.forEach(t => {
+                                    customClass = customTemplates.includes(t.fileName) ? ' class="custom_file"' : '';
+                                    selectedAttr = t.fileName === currentFile ? ' selected' : '';
+
+                                    // Construct the li element for non-mobile buffer
+                                    buffer += `<li>
+                                        <div class="template_files">
+                                            <a href="#" role="button" data-file="${t.fileName}">${t.displayName}</a> <span${customClass}>(custom)</span>
+                                        </div>
+                                    </li>`;
+
+                                    // Construct the option element for filesMobile
+                                    filesMobile += `<option value="${t.fileName}">${t.displayName + (customClass ? ' (custom)' : '')}</option>`;
+                                });
+
+                                buffer += '</ul>';
+                                filesMobile += '</optgroup>';
                             }
 
-                            filesMobile += '</select></div>';
-                            buffer += '</ul>';
+                            filesMobile += '</select></div>'
+
                         } else {
                             buffer += '<li>Internal error occurred. If this persists, contact your Primary Admin.</li>';
                             filesMobile += '<div>Internal error occurred. If this persists, contact your Primary Admin.</div>';
@@ -1498,18 +1629,17 @@
                         $('#fileList').html(buffer);
                         $('.filesMobile').html(filesMobile);
 
-                        // Attach onchange event handler to templateFiles select element
-                        $('.template_select_container').on('change', 'select.templateFiles', function () {
-                            let selectedOption = $(this).find(':selected');
-                            let templateData = selectedOption.data('template-data');
-                            if (templateData) {
-                                // Call the loadContent function with the required parameters
+                        // Attach onchange event handler to templateFiles select element (mobile nav)
+                        $('.template_select_container').on('change', function (event) {
+                            let fName = event.target?.value;
+                            let template = recordFilenameTable[fName] ?? null;
+                            if (template !== null) {
                                 loadContent(
-                                    templateData.displayName,
-                                    templateData.fileName,
-                                    templateData.subjectFileName,
-                                    templateData.emailToFileName,
-                                    templateData.emailCcFileName
+                                    template.displayName,
+                                    template.fileName,
+                                    template.subjectFileName,
+                                    template.emailToFileName,
+                                    template.emailCcFileName
                                 );
                             }
                         });
@@ -1517,16 +1647,17 @@
                         // Attach click event handler to template links in the buffer
                         $('.template_files a').on('click', function (e) {
                             e.preventDefault();
-                            let templateIndex = $(this).data('template-index');
-                            let template = res[templateIndex];
-                            // Call the loadContent function with the required parameters
-                            loadContent(
-                                template.displayName,
-                                template.fileName,
-                                template.subjectFileName || '',
-                                template.emailToFileName || '',
-                                template.emailCcFileName || ''
-                            );
+                            let fName = $(this).data('file');
+                            let template = recordFilenameTable[fName] ?? null;
+                            if (template !== null) {
+                                loadContent(
+                                    template.displayName,
+                                    template.fileName,
+                                    template.subjectFileName || '',
+                                    template.emailToFileName || '',
+                                    template.emailCcFileName || ''
+                                );
+                            }
                         });
                     },
                     error: function (error) {

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -695,7 +695,7 @@
             url: '../api/applet',
             success: function (res) {
                 let buffer = '<ul class="leaf-ul reports">';
-                let bufferExamples = '<div class="leaf-bold">Examples</div><ul class="leaf-ul">';
+                let bufferExamples = '<div class="templates_header">Examples</div><ul class="leaf-ul">';
                 let filesMobile = '<label for="template_file_select">Template Files:</label><select id="template_file_select">';
                 
                 for (let i in res) {


### PR DESCRIPTION
## Summary
Variety of UX and feature improvements for Portal Admin -> Email Template Editor

Email Templates are now better organized for improved user navigation experience.
Templates associated with Custom defined workflow events are easily distinguishable from Standard built-in workflow events in both the left aside lists and mobile select dropdown.  They are also both alphabetized.

A hidden save button has been registered to the Trumbowig Editor to re-add the Ctrl-S save shortcut that was unintentionally removed when this editor was added.

A dropdown plugin has been registered to the Trumbowig Editor to allow easier selection and insertion of available template variables.

The method used to check the format of ToCc field.id entries has been expanded upon to also check To/Cc, Subject and Body template areas for common errors in template variable syntax and provide an obvious warning and formatting example.  This will help avoid errors that could cause a failure to substitute variables as expected or emailing failures.


## Impact
Changes impact the Email Template Editor.  The associated CSS file is also used in the Template Editor, Reports Editor.

## Testing
Custom and Standard email templates should be listed alphabetically in their own categories.  This include both left side list and mobile dropdown.

TextEditor (body) - user can save using Ctrl+S key shortcuts.

User can add smarty variables at the cursor location with the 'variables' dropdown menu.

Incorrect variable formats in the To/Cc, Subject or Body sections should result in obvious warnings that show the content that triggered the warning along with an example of a correct format
