### PR TITLE
LEAF-4881 - CodeQL: Ignore example

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -5,3 +5,4 @@ paths-ignore:
   - 'servlets/digital-signature/**'
   - 'servlets/digital-signing/**'
   - 'test/**'
+  - 'LEAF_Request_Portal/scripts/custom_js/TEMPLATE_*'


### PR DESCRIPTION
## Summary
This resolves a CodeQL false-positive related to syntax errors.

The file prefixed with `TEMPLATE_` intentionally contains invalid JS, as it's an example.

## Impact
n/a

## Testing
n/a
