### PR TITLE
formSearch.js: Scrub html and use preferred label

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -194,6 +194,17 @@ var LeafFormSearch = function (containerID) {
         }
     }
 
+    function scrubHTML(input) {
+        if(input == undefined) {
+            return '';
+        }
+        let t = new DOMParser().parseFromString(input, 'text/html').body;
+        while(input != t.textContent) {
+            return scrubHTML(t.textContent);
+        }
+        return t.textContent;
+    }
+
     /**
      * @memberOf LeafFormSearch
      * prevQuery - optional JSON object
@@ -1077,7 +1088,7 @@ var LeafFormSearch = function (containerID) {
                                 if(preferLabel == '') {
                                     preferLabel = res.name;
                                 }
-                                indicators += `<option value="${res.indicatorID}">${res.name}</option>`;
+                                indicators += `<option value="${res.indicatorID}">${scrubHTML(preferLabel)}</option>`;
                             });
                             indicators += '</optgroup>';
                         });


### PR DESCRIPTION
## Summary
This helps ensure formatting remains consistent within the Data Field dropdown list, especially in Chromium based browsers.

This also corrects an incomplete implementation from https://github.com/department-of-veterans-affairs/LEAF/pull/2745, where the "Short Label" was not prioritized.

## Impact
This changes the layout of the "Data Field" search term. Notify end-users of the change, especially how the embedded search function works.

## Testing
- [ ] Text is not formatted in the dropdown
  1. Navigate to the form editor
  2. Edit a field name (It should not have a short label defined)
  3. Apply either Text align center OR align right
  4. In Chrome/Edge:
     1. Navigate to the homepage
     2. Select "Advanced Options"
     3. Change "Current Status" to "Data Field"
     4. Scroll down to the field associated with the one in step 2. It should not have any text formatting applied.

- [ ] Short labels appear in the dropdown
  1. Navigate to the form editor
  2. Edit a field name
  3. Add a short label (it must be different from the field name)
  4. Navigate to the homepage
  5. Select "Advanced Options"
  6. Change "Current Status" to "Data Field"
  7. Scroll down to the field associated with the one in step 2. Only the short label should appear.