### PR TITLE
Add missing response codes

### DIFF
--- a/LEAF_Nexus/api/RESTfulResponse.php
+++ b/LEAF_Nexus/api/RESTfulResponse.php
@@ -71,8 +71,11 @@ abstract class RESTfulResponse
                 $DELETE_vars = [];
                 parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
 
-                if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken']) // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
-                    || hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
+                if (hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
+                    $this->output($this->delete($action));
+                }
+                // Workaround: Not sure why using hash_equals() || hash_equals() causes a failed test
+                else if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken'])) { // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
                     $this->output($this->delete($action));
                 }
                 else

--- a/LEAF_Nexus/api/RESTfulResponse.php
+++ b/LEAF_Nexus/api/RESTfulResponse.php
@@ -62,6 +62,7 @@ abstract class RESTfulResponse
                 }
                 else
                 {
+                    http_response_code(401);
                     $this->output('Invalid Token.');
                 }
 
@@ -76,6 +77,7 @@ abstract class RESTfulResponse
                 }
                 else
                 {
+                    http_response_code(401);
                     $this->output('Invalid Token.');
                 }
 

--- a/LEAF_Nexus/api/RESTfulResponse.php
+++ b/LEAF_Nexus/api/RESTfulResponse.php
@@ -56,7 +56,7 @@ abstract class RESTfulResponse
 
                 break;
             case 'POST':
-                if ($_POST['CSRFToken'] == $_SESSION['CSRFToken'])
+                if (hash_equals($_SESSION['CSRFToken'], $_POST['CSRFToken']))
                 {
                     $this->output($this->post($action));
                 }
@@ -71,8 +71,8 @@ abstract class RESTfulResponse
                 $DELETE_vars = [];
                 parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
 
-                if ($_GET['CSRFToken'] == $_SESSION['CSRFToken'] // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
-                    || $DELETE_vars['CSRFToken'] == $_SESSION['CSRFToken']) {
+                if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken']) // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
+                    || hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
                     $this->output($this->delete($action));
                 }
                 else

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -47,7 +47,7 @@ abstract class RESTfulResponse
 
                 break;
             case 'POST':
-                if ($_POST['CSRFToken'] == $_SESSION['CSRFToken']) {
+                if (hash_equals($_SESSION['CSRFToken'], $_POST['CSRFToken'])) {
                     $return_value = $this->output($this->post($action));
                 } else {
                     http_response_code(401);
@@ -59,8 +59,8 @@ abstract class RESTfulResponse
                 $DELETE_vars = [];
                 parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
 
-                if ($_GET['CSRFToken'] == $_SESSION['CSRFToken'] // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
-                    || $DELETE_vars['CSRFToken'] == $_SESSION['CSRFToken']) {
+                if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken']) // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
+                    || hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
                     $return_value = $this->output($this->delete($action));
                 } else {
                     http_response_code(401);

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -59,10 +59,15 @@ abstract class RESTfulResponse
                 $DELETE_vars = [];
                 parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
 
-                if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken']) // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
-                    || hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
+                if (hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
                     $return_value = $this->output($this->delete($action));
-                } else {
+                }
+                // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
+                // Workaround: Not sure why using hash_equals() || hash_equals() causes a failed test
+                else if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken'])) {
+                    $return_value = $this->output($this->delete($action));
+                }
+                else {
                     http_response_code(401);
                     $return_value = $this->output('Invalid Token.');
                 }

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -50,6 +50,7 @@ abstract class RESTfulResponse
                 if ($_POST['CSRFToken'] == $_SESSION['CSRFToken']) {
                     $return_value = $this->output($this->post($action));
                 } else {
+                    http_response_code(401);
                     $return_value = $this->output('Invalid Token.');
                 }
 
@@ -62,6 +63,7 @@ abstract class RESTfulResponse
                     || $DELETE_vars['CSRFToken'] == $_SESSION['CSRFToken']) {
                     $return_value = $this->output($this->delete($action));
                 } else {
+                    http_response_code(401);
                     $return_value = $this->output('Invalid Token.');
                 }
 


### PR DESCRIPTION
## Summary
This improves error handling by returning an appropriate HTTP error code when the CSRFToken doesn't match.

This also improves CSRFToken security by using a string comparison function that's [more resistant to timing attacks](https://www.php.net/manual/en/function.hash-equals.php).

## Impact
This may cause $.ajax().error() to capture "new" errors -- which it's supposed to do.

## Testing
Sending an invalid CSRFToken (e.g. https://github.com/department-of-veterans-affairs/LEAF-Developer-Examples/tree/master/forms#create-a-new-record---example) returns HTTP 401.

- [ ] Automated tests pass