### PR TITLE
LEAF-4905 - INC39443060 - LEAF library not loading

### DIFF
--- a/LEAF_Request_Portal/admin/templates/view_form_library.tpl
+++ b/LEAF_Request_Portal/admin/templates/view_form_library.tpl
@@ -71,7 +71,6 @@ $(function() {
     $('#simplexhrDialog').dialog({minWidth: ($(window).width() * .78) + 30});
 
     query = new LeafFormQuery();
-    query.useJSONP(true);
     query.setRootURL('<!--{$LEAF_DOMAIN}-->LEAF/library/');
     query.onSuccess(function(res) {
         data = res;


### PR DESCRIPTION
## Summary
The LEAF Library is blank and not displaying any results.  In the past I could view a national list of LEAF forms available for downloading. Looked into the inspector window and found an error in the console "SyntaxError: Unexpected token 'j', "jsonpCallb"... is not valid JSON". 

PR that causes this: https://github.com/department-of-veterans-affairs/LEAF/pull/2758/files



## Impact
Leaf library was not able to load due to a code update, this gets around this issue for now since jsonp is not needed on this page.

## Testing
This is not testable on development and needs to be done on non production. Go to Academy/Demo1 and Academy/Demo2. Demo 1 has the fix in place and Demo 2 has the original code. IF there is a better way to test this please let me know.