### PR TITLE
Report Builder: File download link

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -62,27 +62,30 @@ switch ($action) {
 
             $indicator = $form->getIndicator($indicatorID, $series, $recordID);
             $recordInfo = $form->getRecordInfo($recordID);
+
+            $t_form->left_delimiter = '<!--{';
+            $t_form->right_delimiter = '}-->';
+            $t_form->assign('recordID', $recordID);
+            $t_form->assign('series', $series);
+            $t_form->assign('serviceID', (int)$recordInfo['serviceID']);
+            $t_form->assign('recorder', XSSHelpers::sanitizeHTML($_SESSION['name']));
+            $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
+            $t_form->assign('form', $indicator);
+            $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
+            $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
+            $t_form->assign('orgchartImportTag', $settings['orgchartImportTags'][0]);
+            $t_form->assign('max_filesize', ini_get('upload_max_filesize'));
+
             if ($indicator[$_GET['indicatorID']]['isWritable'] == 1)
             {
-                $t_form->left_delimiter = '<!--{';
-                $t_form->right_delimiter = '}-->';
-                $t_form->assign('recordID', $recordID);
-                $t_form->assign('series', $series);
-                $t_form->assign('serviceID', (int)$recordInfo['serviceID']);
-                $t_form->assign('recorder', XSSHelpers::sanitizeHTML($_SESSION['name']));
-                $t_form->assign('CSRFToken', $_SESSION['CSRFToken']);
-                $t_form->assign('form', $indicator);
-                $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
-                $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
-                $t_form->assign('orgchartImportTag', $settings['orgchartImportTags'][0]);
                 $t_form->assign('subindicatorsTemplate', customTemplate('subindicators.tpl'));
-                $t_form->assign('max_filesize', ini_get('upload_max_filesize'));
-                $t_form->display(customTemplate('ajaxForm.tpl'));
             }
             else
             {
-                echo '<img src="dynicons/?img=emblem-readonly.svg&amp;w=96" alt="" style="float: left" /><div style="font: 36px verdana">This field is currently read-only OR the field is not associated with any forms on this request.</div>';
+                $t_form->assign('subindicatorsTemplate', customTemplate('print_subindicators.tpl'));
             }
+
+            $t_form->display(customTemplate('ajaxForm.tpl'));
         }
 
         break;

--- a/LEAF_Request_Portal/templates/view_reports.tpl
+++ b/LEAF_Request_Portal/templates/view_reports.tpl
@@ -1,3 +1,4 @@
+<script src="../libs/js/LEAF/sensitiveIndicator.js"></script>
 <div id="step_1" style="<!--{if $query != '' && $indicators != ''}-->display: none; <!--{/if}-->width: fit-content; width: -moz-fit-content; background-color: white; border: 1px solid black; margin: 2em auto; padding: 0px">
     <div style="background-color: #003a6b; color: white; padding: 4px; font-size: 22px; font-weight: bold">
         Step 1: Develop search filter


### PR DESCRIPTION
## Summary
This resolves a usability issue in the Report Builder where a person who has read access, but not write access, sees the error message "This field is currently read-only..." instead of being able to download the file.

This addresses the issue by rendering a standard read-only view instead of showing the error message.

A new import, sensitiveIndicator.js, was added to the Report Builder to facilitate the sensitive field UX within the Report Builder.

## Impact
The original error message also mentions the condition "...OR the field is not associated with any forms on this request", however this might be limited relevance now.

## Testing
Prerequisites:
1. Record A contains an attached file
2. The current user does not have access to write to Record A
3. Generate a report that includes the file attachment as a column

- [ ] In the report, after clicking the name of the file, a download link is provided
- [ ] The file is also downloadable if the file attachment field is marked as a Sensitive Data field