### PR TITLE
LEAF 4960 Enable deeper customization of printview templates

### DIFF
--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -390,6 +390,8 @@ switch ($action) {
             $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
             $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
             $t_form->assign('is_admin', $login->checkGroup(1));
+            $t_form->assign('printSubindicatorsTemplate', customTemplate('print_subindicators.tpl'));
+            $t_form->assign('printSubindicatorsAjaxTemplate', customTemplate('print_subindicators_ajax.tpl'));
 
             switch ($action) {
                 case 'internalonlyview':

--- a/LEAF_Request_Portal/ajaxIndex.php
+++ b/LEAF_Request_Portal/ajaxIndex.php
@@ -107,7 +107,9 @@ switch ($action) {
                 $t_form->assign('indicator', $indicator[$indicatorID]);
                 $t_form->assign('orgchartPath', $site_paths['orgchart_path']);
                 $t_form->assign('portal_url', ABSOLUTE_PORT_PATH.'/');
-                $t_form->display('print_subindicators_ajax.tpl');
+                $t_form->assign('printSubindicatorsTemplate', customTemplate('print_subindicators.tpl'));
+                $t_form->assign('printSubindicatorsAjaxTemplate', customTemplate('print_subindicators_ajax.tpl'));
+                $t_form->display(customTemplate('print_subindicators_ajax.tpl'));
             }
         }
 

--- a/LEAF_Request_Portal/templates/print_form_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_form_ajax.tpl
@@ -36,7 +36,7 @@
 </div>
 
 <div class="printmainform">
-    <!--{include file="print_subindicators.tpl" form=$form orgchartPath=$orgchartPath}-->
+    <!--{include file=$printSubindicatorsTemplate form=$form orgchartPath=$orgchartPath}-->
 </div>
 
 

--- a/LEAF_Request_Portal/templates/print_subindicators.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators.tpl
@@ -76,7 +76,7 @@
             </div>
             <div class="printResponse<!--{if $indicator.is_sensitive == 1}--> sensitiveIndicator<!--{/if}-->" id="xhrIndicator_<!--{$indicator.indicatorID|strip_tags}-->_<!--{$indicator.series|strip_tags}-->">
 
-                <!--{include file="print_subindicators_ajax.tpl"}-->
+                <!--{include file=$printSubindicatorsAjaxTemplate}-->
             </div><!-- end print reponse -->
         </div><!-- end print sublabel -->
         </div><!-- end print block -->

--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -276,4 +276,4 @@
             })
         </script>
         <!--{/if}-->
-        <!--{include file="print_subindicators.tpl" form=$indicator.child depth=$depth+4 recordID=$recordID}-->
+        <!--{include file=$printSubindicatorsTemplate form=$indicator.child depth=$depth+4 recordID=$recordID}-->


### PR DESCRIPTION
## Summary
This enables more customization options for field developers.

This makes it easier to customize the following templates:
- print_subindicators.tpl
- print_subindicators_ajax.tpl


## Impact
Minimal performance impact for non-customized sites due to additional customTemplate() lookups.

## Testing
- [ ] Standard sites work normally

Prerequisites:
- LEAF record contains multiple nested subfields

1. Open a LEAF record
2. Navigate to Admin Panel -> LEAF Template Editor
3. Add unique text, AAAAA, at the top of `print_subindicators`
4. Add unique text, BBBBB, at the top of `print_subindicators_ajax`
5. Refresh the record from step 1
6. You should expect to see AAAAA and BBBBB in the document

- [ ] Sites with modified templates work correctly