### PR TITLE
LEAF 4959 Improve editor timestamps

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_file_manager.tpl
@@ -65,7 +65,7 @@ function showFiles() {
                 }},
                 {name: 'Last Modified', indicatorID: 'lastModified', editable: false, callback: function(data, blob) {
                     let modTime = new Date(blob[data.recordID].modifiedTime * 1000);
-                    $('#'+data.cellContainerID).html(modTime.toLocaleDateString());
+                    $('#'+data.cellContainerID).html(modTime.toLocaleDateString() + ' ' + modTime.toLocaleTimeString());
                 }},
                 {name: '', indicatorID: 'delete', editable: false, callback: function(data, blob) {
                     $('#'+data.cellContainerID).html(`<a href="#" onclick="deleteFile('${blob[data.recordID].file}')">Delete</a>`);

--- a/LEAF_Request_Portal/admin/templates/mod_templates.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates.tpl
@@ -374,7 +374,7 @@
                     let fileParentName = '';
                     let fileName = '';
                     let whoChangedFile = '';
-                    let fileCreated = [];
+                    let fileCreated = '';
 
                     let accordion = '<div id="file_history_container">' +
                     '<div class="file_history_titles">' +
@@ -386,12 +386,13 @@
                         fileParentName = res[i].file_parent_name;
                         fileName = res[i].file_name;
                         whoChangedFile = res[i].file_modify_by;
-                        fileCreated = (res[i].file_created || '').split(' ');
+                        let createDate = new Date(parseInt(res[i].filemtime) * 1000);
+                        fileCreated = createDate.toLocaleDateString() + '<br />' + createDate.toLocaleTimeString();
+
                         accordion +=
                             `<button type="button" class="file_history_options_wrapper" onclick="compareHistoryFile('${fileName}','${fileParentName}', true)">
                                 <div class="file_history_options_date">
-                                    <div>${fileCreated?.[0] || ''}</div>
-                                    <div>${fileCreated?.[1] || ''}</div>
+                                    <div>${fileCreated}</div>
                                 </div>
                                 <div class="file_history_options_author">${whoChangedFile}</div>
                             </button>`;

--- a/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_email.tpl
@@ -605,7 +605,7 @@
                     let fileParentName = '';
                     let fileName = '';
                     let whoChangedFile = '';
-                    let fileCreated = [];
+                    let fileCreated = '';
 
                     let accordion = '<div id="file_history_container">' +
                         '<div class="file_history_titles">' +
@@ -617,13 +617,13 @@
                         fileParentName = res[i].file_parent_name;
                         fileName = res[i].file_name;
                         whoChangedFile = res[i].file_modify_by;
-                        fileCreated = (res[i].file_created || '').split(' ');
+                        let createDate = new Date(parseInt(res[i].filemtime) * 1000);
+                        fileCreated = createDate.toLocaleDateString() + '<br />' + createDate.toLocaleTimeString();
 
                         accordion +=
                             `<button type="button" class="file_history_options_wrapper" onclick="compareHistoryFile('${fileName}','${fileParentName}', true)">
                                 <div class="file_history_options_date">
-                                    <div>${fileCreated?.[0] || ''}</div>
-                                    <div>${fileCreated?.[1] || ''}</div>
+                                    <div>${fileCreated}</div>
                                 </div>
                                 <div class="file_history_options_author">${whoChangedFile}</div>
                             </button>`;

--- a/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_templates_reports.tpl
@@ -405,7 +405,7 @@
                     let fileParentName = '';
                     let fileName = '';
                     let whoChangedFile = '';
-                    let fileCreated = [];
+                    let fileCreated = '';
 
                     let accordion = '<div id="file_history_container">' +
                         '<div class="file_history_titles">' +
@@ -417,13 +417,13 @@
                         fileParentName = res[i].file_parent_name;
                         fileName = res[i].file_name;
                         whoChangedFile = res[i].file_modify_by;
-                        fileCreated = (res[i].file_created || '').split(' ');
+                        let createDate = new Date(parseInt(res[i].filemtime) * 1000);
+                        fileCreated = createDate.toLocaleDateString() + '<br />' + createDate.toLocaleTimeString();
 
                         accordion +=
                             `<button type="button" class="file_history_options_wrapper" onclick="compareHistoryFile('${fileName}','${fileParentName}', true)">
                                 <div class="file_history_options_date">
-                                    <div>${fileCreated?.[0] || ''}</div>
-                                    <div>${fileCreated?.[1] || ''}</div>
+                                    <div>${fileCreated}</div>
                                 </div>
                                 <div class="file_history_options_author">${whoChangedFile}</div>
                             </button>`;

--- a/LEAF_Request_Portal/sources/TemplateFileHistory.php
+++ b/LEAF_Request_Portal/sources/TemplateFileHistory.php
@@ -140,9 +140,9 @@ class TemplateFileHistory
 
 
     /**
-     * Summary of getTemplateFileHistory
+     * getTemplateFileHistory retrieves a list of modified version of $templateFile, and includes basic file stat information
      * @param mixed $templateFile
-     * @return mixed
+     * @return array
      */
     public function getTemplateFileHistory(string $templateFile): array
     {
@@ -158,8 +158,13 @@ class TemplateFileHistory
                   FROM `template_history_files`
                   WHERE file_parent_name = :template_file
                   ORDER BY `file_id` DESC';
+        $data = $this->db->prepared_query($sql, $vars);
 
-        return $this->db->prepared_query($sql, $vars);
+        foreach($data as $i => $v) {
+            $data[$i]['filemtime'] = filemtime($v['file_path']);
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
## Summary
This improves usability for admins by presenting timestamps in their own time zone.

This also updates the File Manager to include the time when files were last modified.

## Opportunities
Remove the database column template_history_files.file_created and associated references.

## Impact
No other dependencies

## Testing
- [ ] In the Template Editor, Email Template Editor, and LEAF Programmer, file modification times are presented in your local timezone
  - Note that the development environment is missing files in the Template Editor. Seeing "Invalid Date" in the view_homepage history is OK.
- [ ] In the File Manager, the last modified time appears in the "Last Modified" column
