### PR TITLE
api/form/query: Remove trailing space in "resolved by" responses

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -4016,7 +4016,7 @@ class Form
                 foreach ($res2 as $item) {
                     $userMetadata = json_decode($item['userMetadata'], true);
                     $nameResolved =  isset($userMetadata) && trim("{$userMetadata['firstName']} {$userMetadata['lastName']}") !== "" ?
-                        "{$userMetadata['firstName']} {$userMetadata['lastName']} " : $item['resolvedBy'];
+                        "{$userMetadata['firstName']} {$userMetadata['lastName']}" : $item['resolvedBy'];
                     $data[$item['recordID']]['recordResolutionBy']['resolvedBy'] = $nameResolved;
                 }
             }


### PR DESCRIPTION
## Summary
This removes a trailing space in the "Resolved By" response, most typically found in the Report Builder -> Step 2: Data column "Resolved By".

The extra space is a problem in API responses, where implementations expect precisely formatted text.

## Impact
N/A

## Testing
Prerequisite:
- At least one record has been resolved

1. Navigate to the Report Builder
2. Set filter: Current Status IS Resolved
3. Select data column: "Resolved By"
4. After generating the report, the names in the "Resolved By" column do not include a trailing space in the individual's name
