### PR TITLE
Handle null CSRF edge case

### DIFF
--- a/LEAF_Nexus/api/RESTfulResponse.php
+++ b/LEAF_Nexus/api/RESTfulResponse.php
@@ -56,6 +56,10 @@ abstract class RESTfulResponse
 
                 break;
             case 'POST':
+                if (!isset($_POST['CSRFToken'])) {
+                    $_POST['CSRFToken'] = '';
+                }
+
                 if (hash_equals($_SESSION['CSRFToken'], $_POST['CSRFToken']))
                 {
                     $this->output($this->post($action));
@@ -71,11 +75,15 @@ abstract class RESTfulResponse
                 $DELETE_vars = [];
                 parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
 
-                if (isset($DELETE_vars['CSRFToken']) && hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
+                if (!isset($DELETE_vars['CSRFToken'])) {
+                    $DELETE_vars['CSRFToken'] = '';
+                }
+
+                if (hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
                     $this->output($this->delete($action));
                 }
                 // Workaround: Not sure why using hash_equals() || hash_equals() causes a failed test
-                else if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken'])) { // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
+                else if (isset($_GET['CSRFToken']) && hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken'])) { // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
                     $this->output($this->delete($action));
                 }
                 else

--- a/LEAF_Request_Portal/api/RESTfulResponse.php
+++ b/LEAF_Request_Portal/api/RESTfulResponse.php
@@ -47,6 +47,10 @@ abstract class RESTfulResponse
 
                 break;
             case 'POST':
+                if (!isset($_POST['CSRFToken'])) {
+                    $_POST['CSRFToken'] = '';
+                }
+
                 if (hash_equals($_SESSION['CSRFToken'], $_POST['CSRFToken'])) {
                     $return_value = $this->output($this->post($action));
                 } else {
@@ -59,12 +63,15 @@ abstract class RESTfulResponse
                 $DELETE_vars = [];
                 parse_str(file_get_contents('php://input', false, null, 0, 8192), $DELETE_vars); // only parse the first 8192 characters (arbitrary limit)
 
-                if (isset($DELETE_vars['CSRFToken']) && hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
+                if (!isset($DELETE_vars['CSRFToken'])) {
+                    $DELETE_vars['CSRFToken'] = '';
+                }
+                
+                if (hash_equals($_SESSION['CSRFToken'], $DELETE_vars['CSRFToken'])) {
                     $return_value = $this->output($this->delete($action));
                 }
                 // Deprecation warning: The _GET implementation should be removed in favor of $DELETE_vars
-                // Workaround: Not sure why using hash_equals() || hash_equals() causes a failed test
-                else if (hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken'])) {
+                else if (isset($_GET['CSRFToken']) && hash_equals($_SESSION['CSRFToken'], $_GET['CSRFToken'])) {
                     $return_value = $this->output($this->delete($action));
                 }
                 else {


### PR DESCRIPTION
## Summary
This improves the accuracy of error responses.

This resolves an edge case introduced in https://github.com/department-of-veterans-affairs/LEAF/pull/2761 where a null CSRF token results in an error 500 instead of the expected error 401.

## Impact
Minimal since this does not change the overall logic, as a missing or invalid CSRF token results in an error.

## Testing
This automated test was added to provide coverage: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/128
