### PR TITLE
Leaf 4985 - sanitizing $_POST values

### DIFF
--- a/app/libs/loaders/Leaf_autoloader.php
+++ b/app/libs/loaders/Leaf_autoloader.php
@@ -111,6 +111,16 @@ if (count($_GET) > 0) {
     }
 }
 
+// Sanitize all $_POST input
+if (count($_POST) > 0) {
+    $keys = array_keys($_POST);
+    foreach ($keys as $key) {
+        if (is_string($_POST[$key])) {
+            $_POST[$key] = htmlentities($_POST[$key], ENT_QUOTES);
+        }
+    }
+}
+
 if (session_id() == '') {
     $session_db = new Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB, true);
 


### PR DESCRIPTION
## Summary
This is to remediate some fortify scan issues that came up. There is no front end changes it just ensures that user supplied data is scrubbed before being used or stored.

## Impact
Potentially if someone was supply data that wasn't being scrubbed before it may change what they see now that it is getting scrubbed.

## Testing
N/A - there are no manual or end2end tests for this.