### PR TITLE
LEAF-4998 - Restrict coach-key functionality on platform sites

### DIFF
--- a/LEAF_Request_Portal/auth_domain/LEAF_coach_key.php
+++ b/LEAF_Request_Portal/auth_domain/LEAF_coach_key.php
@@ -4,6 +4,13 @@ require_once getenv('APP_LIBS_PATH') . '/loaders/Leaf_autoloader.php';
 
 ini_set('display_errors', 1);
 
+// Restrict platform sites
+if(strpos(ABSOLUTE_PORT_PATH, DOMAIN_PATH.'/platform') !== false) {
+    echo 'Error: platform sites restricted';
+    http_response_code(403);
+    exit;
+}
+
 $db_national = new App\Leaf\Db(DIRECTORY_HOST, DIRECTORY_USER, DIRECTORY_PASS, DIRECTORY_DB);
 
 $login->setBaseDir('../');


### PR DESCRIPTION
## Summary
This prepares the platform for future use-cases that require specific oversight controls.

## Impact
This prevents the coach-key functionality from working on `platform/*` sites, which should be communicated to the LEAF team.

## Testing
Must test on pre-prod. When running the coach key on `platform/*` sites, expect to see "Error: platform sites restricted" (HTTP 403).
