### PR TITLE
LEAF-4999 - Control track changes

### DIFF
--- a/LEAF_Request_Portal/sources/Form.php
+++ b/LEAF_Request_Portal/sources/Form.php
@@ -1117,7 +1117,7 @@ class Form
                       ':indicatorID' => $key,
                       ':series' => $series, );
 
-        $sql = "SELECT `format`, `data` FROM `data`
+        $sql = "SELECT `format`, `trackChanges`, `data` FROM `data`
             LEFT JOIN `indicators` USING (`indicatorID`)
             WHERE `recordID`=:recordID AND `indicators`.`indicatorID`=:indicatorID AND `series`=:series";
 
@@ -1125,7 +1125,7 @@ class Form
 
         if(empty($res)) {
             $vf = array(":indicatorID" => $key);
-            $sqlf = "SELECT `format` FROM `indicators` WHERE `indicatorID`=:indicatorID";
+            $sqlf = "SELECT `format`, `trackChanges` FROM `indicators` WHERE `indicatorID`=:indicatorID";
             $res =  $this->db->prepared_query($sqlf, $vf);
         }
 
@@ -1177,7 +1177,7 @@ class Form
                                             VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID)
                                             ON DUPLICATE KEY UPDATE data=:data, metadata=:metadata, timestamp=:timestamp, userID=:userID', $vars);
 
-        if (!$duplicate) {
+        if (!$duplicate && $res[0]['trackChanges']) {
             $vars[':userDisplay'] = $this->login->getName();
             $this->db->prepared_query('INSERT INTO data_history (recordID, indicatorID, series, data, metadata, timestamp, userID, userDisplay)
                                                    VALUES (:recordID, :indicatorID, :series, :data, :metadata, :timestamp, :userID, :userDisplay)', $vars);

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2025041000-2025081400.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2025041000-2025081400.sql
@@ -1,0 +1,26 @@
+START TRANSACTION;
+
+INSERT INTO `dependencies` (`dependencyID`, `description`)
+VALUES ('-4', 'LEAF Agent');
+
+ALTER TABLE `indicators`
+ADD `trackChanges` tinyint NOT NULL DEFAULT '1';
+
+
+UPDATE `settings` SET `data` = '2025081400' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+/**** Revert DB *****
+START TRANSACTION;
+
+DELETE FROM `dependencies`
+WHERE ((`dependencyID` = '-4'));
+
+ALTER TABLE `indicators`
+DROP `trackChanges`;
+
+UPDATE `settings` SET `data` = '2025041000' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
## Summary
:warning: Deployment: This includes a database schema change, which must be applied prior to this patch.

This enables form fields to be used as an efficient data store for ephemeral content.

The LEAF Agent logs metadata server-side, however relevant data is difficult to review for admins. This uses form fields to make metadata such as the "Timestamp for last successful run" and specific error logs more accessible to admins. However since the metadata can be updated as frequently as once every 10 seconds, this can unnecessarily bloat the local database's changelog.

The new portal database column `indicators.trackChanges` provides server-side control to avoid maintaining a full changelog for specific indicators. The direct change is still logged via timestamp and userID.

## Impact
Track changes is enabled by default to avoid impact on all sites. There is no user-facing control for this option, and even when track changes is disabled, the last modified timestamp and related userID is still tracked.

## Testing
In the development environment:
1. Reset and update the database by running the API tester
2. Navigate to the Request Portal (Standard Test DB)
3. Open request # 957
4. Change the Single line text field to `ABCDE`
5. Refresh the page
6. Check the history for the Single line text field
7. You should expect to see a log entry with the change you just made.
8. Navigate to the database: leaf_portal_API_testing.indicators
9. Edit indicatorID # 3, and change `trackChanges` to 0
10. Navigate back to request # 957
11. Change the Single line text field to `12345`
12. Check the history for the Single line text field (note refresh is not needed because the history button is already visible)
13. You should not expect to see a new log entry
