### PR TITLE
LEAF-5003 - uriencode double slashes

### DIFF
--- a/LEAF_Request_Portal/js/formQuery.js
+++ b/LEAF_Request_Portal/js/formQuery.js
@@ -244,6 +244,7 @@ var LeafFormQuery = function () {
   function encodeReadableURI(url) {
     url = url.replaceAll('+', '%2b');
     url = url.replaceAll('#', '%23');
+    url = url.replaceAll('//', '%2f%2f');
     return url;
   }
 


### PR DESCRIPTION
## Summary
This resolves an issue where searching for a URL results in an error.

## Impact
Minimal since this URI encodes double slashes within the URL's query parameters, which generally expect URI encoded data.

## Testing
1. Change a record's title to `https://leaf.va.gov`
2. On the homepage, search for `https://leaf.va.gov`
3. You should expect to see the record from step 1
