### PR TITLE
enable clickable links in single-line text fields

### DIFF
--- a/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
+++ b/LEAF_Request_Portal/templates/print_subindicators_ajax.tpl
@@ -79,6 +79,12 @@
                 <!--{$indicator.value|sanitize}-->
             </span>
             <!--{$indicator.htmlPrint}-->
+            <script>
+                if(typeof enableUserContentLinks === 'function') {
+                    const element = document.getElementById("data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->");
+                    enableUserContentLinks(element);
+                }
+            </script>
         <!--{/if}-->
         <!--{if $indicator.format == 'number'}-->
             <span class="printResponse" id="data_<!--{$indicator.indicatorID}-->_<!--{$indicator.series}-->">


### PR DESCRIPTION
## Summary
This enables clickable URLs in single-line text fields.

Follows https://github.com/department-of-veterans-affairs/LEAF/pull/2687

## Impact
Minimal as this follows the same pattern in #2687. Sites with customized templates would need to manually include this change, or use the "Restore Original" feature.

## Testing
This automated test has been expanded to provide coverage: TBD