### PR TITLE
LEAF-4883 - formSearch.js: Scrub html

### DIFF
--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -1041,7 +1041,7 @@ var LeafFormSearch = function (containerID) {
                 break;
             case "data":
                 let resultFilter =
-                    "?x-filterData=indicatorID,categoryName,name,format,description";
+                    "?x-filterData=indicatorID,categoryName,name,format";
                 let urlParams = new URLSearchParams(window.location.search);
                 if(urlParams.has('dev')) {
                     resultFilter += '&dev';
@@ -1084,11 +1084,7 @@ var LeafFormSearch = function (containerID) {
                             indicators += `<optgroup label="${key}">`;
 
                             indicatorsByForm[key].forEach(res => {
-                                let preferLabel = res.description;
-                                if(preferLabel == '') {
-                                    preferLabel = res.name;
-                                }
-                                indicators += `<option value="${res.indicatorID}">${scrubHTML(preferLabel)}</option>`;
+                                indicators += `<option value="${res.indicatorID}">${scrubHTML(res.name)}</option>`;
                             });
                             indicators += '</optgroup>';
                         });

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -194,6 +194,17 @@ var LeafFormSearch = function (containerID) {
         }
     }
 
+    function scrubHTML(input) {
+        if(input == undefined) {
+            return '';
+        }
+        let t = new DOMParser().parseFromString(input, 'text/html').body;
+        while(input != t.textContent) {
+            return scrubHTML(t.textContent);
+        }
+        return t.textContent;
+    }
+
     /**
      * @memberOf LeafFormSearch
      * prevQuery - optional JSON object
@@ -1077,7 +1088,7 @@ var LeafFormSearch = function (containerID) {
                                 if(preferLabel == '') {
                                     preferLabel = res.name;
                                 }
-                                indicators += `<option value="${res.indicatorID}">${res.name}</option>`;
+                                indicators += `<option value="${res.indicatorID}">${scrubHTML(preferLabel)}</option>`;
                             });
                             indicators += '</optgroup>';
                         });

--- a/LEAF_Request_Portal/js/formSearch.js
+++ b/LEAF_Request_Portal/js/formSearch.js
@@ -1077,10 +1077,18 @@ var LeafFormSearch = function (containerID) {
                             if(indicatorsByForm[res[i].categoryName] == undefined) {
                                 indicatorsByForm[res[i].categoryName] = [];
                             }
+                            res[i].name = scrubHTML(res[i].name);
                             indicatorsByForm[res[i].categoryName].push(res[i]);
                         }
 
-                        Object.keys(indicatorsByForm).forEach(key => {
+                        var collator = new Intl.Collator("en", {
+                            numeric: true,
+                            sensitivity: "base",
+                        });
+                        let formNames = Object.keys(indicatorsByForm);
+                        formNames.sort();
+                        formNames.forEach(key => {
+                            indicatorsByForm[key].sort((a, b) => collator.compare(a.name, b.name));
                             indicators += `<optgroup label="${key}">`;
 
                             indicatorsByForm[key].forEach(res => {


### PR DESCRIPTION
Closed due to stuck code ql, Original PR: https://github.com/department-of-veterans-affairs/LEAF/pull/2759
## Summary
This helps ensure formatting remains consistent within the Data Field dropdown list, especially in Chromium based browsers.

This also sorts the data field list alphabetically, including form names.

## Impact
This changes the layout of the "Data Field" search term. Notify end-users of the change, especially how the embedded search function works.

## Testing
- [x] Text is not formatted in the dropdown
  1. Navigate to the form editor
  2. Edit a field name (It should not have a short label defined)
  3. Apply either Text align center OR align right
  4. In Chrome/Edge:
     1. Navigate to the homepage
     2. Select "Advanced Options"
     3. Change "Current Status" to "Data Field"
     4. Scroll down to the field associated with the one in step 2. It should not have any text formatting applied.
