### PR TITLE
LEAF-5028 - Grid Display in Emails

### DIFF
--- a/LEAF_Request_Portal/sources/FormWorkflow.php
+++ b/LEAF_Request_Portal/sources/FormWorkflow.php
@@ -1743,7 +1743,7 @@ class FormWorkflow
             $data = $field["data"];
             $emailValue = "";
 
-            $format = strtolower(explode(PHP_EOL, $field["format"])[0] ?? "");
+            $format = trim(strtolower(explode(PHP_EOL, $field["format"])[0] ?? ""));
             switch($format) {
                 case "grid":
                     if(!empty($data) && is_array(unserialize($data))){


### PR DESCRIPTION
Change that would have likely cause this issue. https://github.com/department-of-veterans-affairs/LEAF/commit/fade6d983e22713a613f1bde66aa610ebd662c47

## Summary
Please ensure your PR answers the following questions, where applicable.

How does this change help the customer or platform?
If this is a complex change: What's the implementation strategy? A flowchart or state diagram may be used as part of the summary.
Any special considerations or notes?

## Impact
What impact on other areas of the platform could this have, and are there mitigations? Consider if users need training or notification.

## Testing
1. Use the Input Formats on the dev env since this has a grid already
2. Set a trigger on the workflow item that sends an email. <img width="341" height="114" alt="image" src="https://github.com/user-attachments/assets/cdc5453d-c4ab-4429-882c-43252e56ac6e" />
3. In the email template editor set the field to show in the email (actual number may vary so please double check this) <img width="532" height="473" alt="image" src="https://github.com/user-attachments/assets/e82b4d21-f584-42ea-baa2-383871c4daea" />
4. Create or use an existing request. recordID=959 was non submitted but required some editing of the grid item




