### PR TITLE
INC40165247 LEAF 5029 - make sure Inbox button hashes remain unique

### DIFF
--- a/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
+++ b/LEAF_Request_Portal/templates/reports/LEAF_Inbox.tpl
@@ -342,7 +342,7 @@
                         roleID = 'assignedIndividual';
                         description = '* Assigned to an individual *';
                     } else {
-                        roleID = Sha1.hash(uDD.approverUID);
+                        roleID = Sha1.hash(uDD.approverUID + uDD.approverName);
                         description = scrubHTML(uDD.approverName);
                     }
                 }


### PR DESCRIPTION
## Summary
There have been a couple incidents over the last 1-2 months where a change in name case (for example, Charles III to Charles Iii) has caused issues in the inbox.  Event listeners to open the affected submenus do not work because the menus have the same ID.  This is because Inbox items are organized by name, while the hash used for the menu ids are based only on user emails.  This update adds the user name to the hash input so that button IDs are still unique in the rare case of there being requests pending different versions of the same user's name.

NOTE: we might need a more involving solution to this in the longer term.  While this issue seems rare, it is not ideal that a user would ever have more than one submenu.  This update quickly resolves a work-stoppage issue without a risker refactor of code associated with the inbox data structures.

## Impact
LEAF Inbox.  Handles a rare condition to ensure submenus continue to function as expected.  Should not otherwise cause any change in behavior.

## Testing
Dev env requestID 410 is still listed as 'available for test case'.
This issue and its resolution can currently be tested manually by going to Adminer,
leaf_portal_API_testing, data table, record with recordID 410, indicatorID 8.
Change the metadata lastname value from tester to TESTER.

Once this is done, there will be two menu sections for tester tester and tester TESTER in the inbox Role View.
Clicking either should open the menu to show the associated requests.
