### PR TITLE
LEAF 5056 update error message and fix typo

### DIFF
--- a/LEAF_Nexus/admin/templates/mod_system.tpl
+++ b/LEAF_Nexus/admin/templates/mod_system.tpl
@@ -100,7 +100,7 @@
                     CSRFToken: CSRFToken},
                     success: function(res) {
                         if(res['success'] !== true) {
-                            alert('Primary Admin must be a System Administrator');
+                            alert('Primary Admin field cannot be left blank');
                         } else {
                             location.reload();
                             alert('Settings Saved.');

--- a/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_account_updater.tpl
@@ -127,7 +127,7 @@ div [id^="LeafFormGrid"] table {
 <div>
     <h2>New Account Updater</h2>
     <p style="max-width: 850px;">
-    This utility will restore access for people who have been asigned a new Active Directory account.
+    This utility will restore access for people who have been assigned a new Active Directory account.
     It can be used to update the initiator of requests created under the old account, update the content of
     orgchart employee format questions to refer to the new account, and update group memberships.
     </p>


### PR DESCRIPTION
## Summary
When attempting to change the label for Leadership Nomenclature, if there is no Primary Admin set for the Nexus a warning message of "Primary Admin must be a System Administrator". This warning message is unclear and does not tell the user what the true issue is preventing them from changing the value.  

Update the warning message to read: Primary Admin field cannot be left blank.  This provides better clarification.

Other: fixes a spelling error (asigned to assigned) in the portal Account Updater.
Portal -> Admin -> Toolbox -> New Account Updater

## Impact
A more meaningful error/alert will display when attempting to update Nexus site preferences

## Testing
Confirm appropriate error verbiage and spelling fix with manual tests

Steps to reproduce:

Navigate to the Nexus
Click on OC Admin Panel
Select Setup Wizard
Click on Site Preferences
Change the value in Leadership Nomenclature
Click on Save
Receive warning message of "Primary Admin must be a System Administrator".
