### PR TITLE
Leaf 5065 - keeping db clean after dependency removal

### DIFF
--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -582,8 +582,8 @@ class Workflow
                 )
             )
         );
-        $strSQL = "UPDATE events 
-            SET eventID=:newEventID, eventDescription=:eventDescription, eventType=:eventType, eventData=:eventData 
+        $strSQL = "UPDATE events
+            SET eventID=:newEventID, eventDescription=:eventDescription, eventType=:eventType, eventData=:eventData
             WHERE eventID=:eventID";
         $this->db->prepared_query($strSQL, $vars);
 
@@ -889,46 +889,37 @@ class Workflow
         return true;
     }
 
-    public function unlinkDependency($stepID, $dependencyID)
+    /**
+     * @param mixed $stepID
+     * @param mixed $dependencyID
+     *
+     * @return bool|string
+     *
+     */
+    public function unlinkDependency($stepID, $dependencyID): bool|string
     {
-        if (!$this->login->checkGroup(1))
-        {
-            return 'Admin access required.';
+        $return_value = true;
+
+        if (!$this->login->checkGroup(1)) {
+            $return_value = 'Admin access required.';
+        } else if ($stepID < 0) {
+            $return_value = 'Restricted command.';
+        } else {
+            $this->deleteStepDependency($stepID, $dependencyID);
+            $this->cleanUpDbAfterDependencyDelete($stepID, $dependencyID);
+
+            $depVars = array(':dependencyID' => $dependencyID);
+            $dep = $this->db->prepared_query("SELECT `description` FROM dependencies WHERE dependencyID=:dependencyID", $depVars)[0];
+            $depDescr = $dep["description"];
+
+            $this->dataActionLogger->logAction(DataActions::DELETE, LoggableTypes::STEP_DEPENDENCY, [
+                new LogItem("workflows", "workflowID", $this->workflowID),
+                new LogItem("step_dependencies", "stepID",  $stepID),
+                new LogItem("step_dependencies", "dependencyID",  $dependencyID, $depDescr." (#".$dependencyID.")")
+            ]);
         }
 
-        // Don't allow changes to standardized components
-        if($stepID < 0) {
-            return 'Restricted command.';
-        }
-
-        $vars = array(':stepID' => $stepID,
-            ':dependencyID' => $dependencyID,
-        );
-        $res = $this->db->prepared_query('DELETE FROM step_dependencies
-    										WHERE stepID=:stepID
-    											AND dependencyID=:dependencyID', $vars);
-
-        // clean up database
-        $this->db->prepared_query('DELETE records_dependencies FROM records_dependencies
-    								INNER JOIN category_count USING (recordID)
-    								INNER JOIN categories USING (categoryID)
-    								INNER JOIN workflow_steps USING (workflowID)
-    								WHERE stepID=:stepID
-    									AND dependencyID=:dependencyID
-    									AND filled=0
-                                        AND records_dependencies.time IS NULL', $vars);
-
-        $depVars = array(':dependencyID' => $dependencyID);
-        $dep = $this->db->prepared_query("SELECT `description` FROM dependencies WHERE dependencyID=:dependencyID", $depVars)[0];
-        $depDescr = $dep["description"];
-
-        $this->dataActionLogger->logAction(DataActions::DELETE, LoggableTypes::STEP_DEPENDENCY, [
-            new LogItem("workflows", "workflowID", $this->workflowID),
-            new LogItem("step_dependencies", "stepID",  $stepID),
-            new LogItem("step_dependencies", "dependencyID",  $dependencyID, $depDescr." (#".$dependencyID.")")
-        ]);
-
-        return true;
+        return $return_value;
     }
 
     public function updateDependency($dependencyID, $description)
@@ -1722,4 +1713,64 @@ class Workflow
         return 1;
     }
 
+    /**
+     * @param int $stepID
+     * @param int $dependencyID
+     *
+     * @return void
+     *
+     */
+    private function cleanUpDbAfterDependencyDelete(int $stepID, int $dependencyID): void
+    {
+        $vars = array(':stepID' => $stepID,
+            ':dependencyID' => $dependencyID,
+        );
+        $sql = 'DELETE `records_dependencies`
+                FROM `records_dependencies`
+                INNER JOIN `category_count` USING (`recordID`)
+                INNER JOIN `categories` USING (`categoryID`)
+                INNER JOIN `workflow_steps` USING (`workflowID`)
+                WHERE `stepID` = :stepID
+                AND `dependencyID` = :dependencyID
+                AND `filled` = 0
+                AND `records_dependencies`.`time` IS NULL';
+
+        $this->db->prepared_query($sql, $vars);
+
+        // if deleting person designated or group designated then the indicator
+        // needs to be cleared in the workflow_steps table as well
+        if ($dependencyID === -1) {
+            unset($vars[':dependencyID']);
+            $sql2 = 'UPDATE `workflow_steps`
+                    SET `indicatorID_for_assigned_empUID` = NULL
+                    WHERE `stepID` = :stepID';
+        } else if ($dependencyID === -3) {
+            unset($vars[':dependencyID']);
+            $sql2 = 'UPDATE `workflow_steps`
+                    SET `indicatorID_for_assigned_groupID` = NULL
+                    WHERE `stepID` = :stepID';
+        }
+
+        $this->db->prepared_query($sql2, $vars);
+    }
+
+    /**
+     * @param int $stepID
+     * @param int $dependencyID
+     *
+     * @return void
+     *
+     */
+    private function deleteStepDependency(int $stepID, int $dependencyID): void
+    {
+        $vars = array(':stepID' => $stepID,
+            ':dependencyID' => $dependencyID,
+        );
+        $sql = 'DELETE
+                FROM `step_dependencies`
+                WHERE `stepID` = :stepID
+                AND `dependencyID` = :dependencyID';
+
+        $this->db->prepared_query($sql, $vars);
+    }
 }


### PR DESCRIPTION
## Summary
This ensures that the database is in the correct state after removing a data field from a workflow.

## Impact
After removing a data field from a workflow step if you re-add it to the same step you will need to reassign the indicatorID to it where as before it was still there.

## Testing
Not sure automated tests need to be completed for this or not. Best way to test this is to:
1. add a Person/Group designated to a workflow step
2. select the data field
3. remove the Person/Group
4. re-add the same thing just removed. 

If this is working properly you will need to select the data field again. (In production now when you re-add it the data field is already there from the last time)