### PR TITLE
Leaf 5083 - Prevent modification of reserved requirement IDs

### DIFF
--- a/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
+++ b/LEAF_Request_Portal/admin/templates/mod_workflow.tpl
@@ -1043,7 +1043,7 @@
                     <select id="dependencyID" name="dependencyID" title="Select a requiremement" onchange="updateSelectionStatus(this, 'req_select_status')">`;
 
                 var reservedDependencies = [-3, -2, -1, 1, 8];
-                var maskedDependencies = [5];
+                var maskedDependencies = [5, -4];
 
                 buffer += '<optgroup label="Custom Requirements" aria-label="Custom Requirements">';
                 for (let i in res) {

--- a/LEAF_Request_Portal/sources/Workflow.php
+++ b/LEAF_Request_Portal/sources/Workflow.php
@@ -931,11 +931,18 @@ class Workflow
         return true;
     }
 
+    // updateDependency updates the description associated with $dependencyID
     public function updateDependency($dependencyID, $description)
     {
         if (!$this->login->checkGroup(1))
         {
             return 'Admin access required.';
+        }
+
+        // Don't allow changes to standardized dependencies
+        if($dependencyID < 0) {
+            http_response_code(400);
+            return 'description may not be updated for this requirement';
         }
 
         $vars = array(':dependencyID' => $dependencyID,
@@ -980,6 +987,15 @@ class Workflow
         if (!$this->login->checkGroup(1))
         {
             return 'Admin access required.';
+        }
+
+        $reservedDependencyIDs = [
+            1, // Service Chief
+            8 // Quadrad
+        ];
+        if($dependencyID < 0 || in_array($dependencyID, $reservedDependencyIDs)) {
+            http_response_code(400);
+            return 'groups may not be added to this requirement';
         }
 
         $vars = array(':dependencyID' => $dependencyID,

--- a/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2025081400-2025100200.sql
+++ b/docker/mysql/db/db_upgrade/portal/Update_RMC_DB_2025081400-2025100200.sql
@@ -1,0 +1,17 @@
+START TRANSACTION;
+
+DELETE FROM `dependency_privs` WHERE `dependencyID` = '-4';
+UPDATE `dependencies` SET `description` = 'LEAF Agent' WHERE `dependencyID` = '-4';
+
+UPDATE `settings` SET `data` = '2025100200' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+
+/**** Revert DB *****
+START TRANSACTION;
+
+
+UPDATE `settings` SET `data` = '2025041000' WHERE `settings`.`setting` = 'dbversion';
+
+COMMIT;
+*/


### PR DESCRIPTION
## Summary
This prevents modification of reserved requirement IDs using server-side restrictions.

The reserved IDs are intended to be standardized to facilitate effective communication.

This also uses a database update to enforce consistency for the affected ID# `-4`, as well as hide the "LEAF Agent" requirement as an option.

## Impact
None because the affected requirement ID# `-4` has not been fully implemented.

## Testing
Automated test added: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/173
