### PR TITLE
LEAF-5067 - INC40265987 - Print to pdf not loading all data

### DIFF
--- a/LEAF_Request_Portal/js/formPrint.js
+++ b/LEAF_Request_Portal/js/formPrint.js
@@ -1202,6 +1202,7 @@ var printer = function () {
           "Request #" + recordID + " - " + requestInfo["title"] + ".pdf"
         );
       }
+      location.reload();
     }
 
     var indicatorCount = 0;

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -660,6 +660,80 @@ function doSubmit(recordID) {
         });
     }
 
+    function openContentForPrint(){
+        $('#formcontent').empty().html('');
+        $.ajax({
+            type: 'GET',
+            url: 'ajaxIndex.php?a=printview&recordID=<!--{$recordID|strip_tags}-->',
+            dataType: 'text', // IE9 issue
+            success: function(res) {
+                $('#formcontent').append(res);
+                // make box size more predictable
+                $('.printmainblock').each(function() {
+                    let boxSizer = {};
+                    $(this).find('.printsubheading').each(function() {
+                        layer = $(this).position().top;
+                        if (boxSizer[layer] == undefined) {
+                            boxSizer[layer] = $(this).height();
+                        }
+                        if ($(this).height() > boxSizer[layer]) {
+                            boxSizer[layer] = $(this).height();
+                        }
+                    });
+                    $(this).find('.printsubheading').each(function() {
+                        layer = $(this).position().top;
+                        if (boxSizer[layer] != undefined) {
+                            $(this).height(boxSizer[layer]);
+                        }
+                    });
+                });
+                handlePrintConditionalIndicators(formPrintConditions);
+            },
+            error: function(res) {
+                $('#formcontent').empty().html(res);
+            },
+            cache: false,
+            async: false,
+        });
+      
+        <!--{section name=i loop=$childforms}-->
+            $.ajax({
+                type: 'GET',
+                url: 'ajaxIndex.php?a=internalonlyview&recordID=<!--{$recordID|strip_tags}-->&childCategoryID=<!--{$childforms[i].childCategoryID|strip_tags}-->',
+                dataType: 'text', // IE9 issue
+                success: function(res) {
+                    $('#formcontent').append(res);
+                    // make box size more predictable
+                    $('.printmainblock').each(function() {
+                        let boxSizer = {};
+                        $(this).find('.printsubheading').each(function() {
+                            layer = $(this).position().top;
+                            if (boxSizer[layer] == undefined) {
+                                boxSizer[layer] = $(this).height();
+                            }
+                            if ($(this).height() > boxSizer[layer]) {
+                                boxSizer[layer] = $(this).height();
+                            }
+                        });
+                        $(this).find('.printsubheading').each(function() {
+                            layer = $(this).position().top;
+                            if (boxSizer[layer] != undefined) {
+                                $(this).height(boxSizer[layer]);
+                            }
+                        });
+                    });
+                    handlePrintConditionalIndicators(formPrintConditions);
+                },
+                error: function(res) {
+                    //$('#formcontent').empty().html(res);
+                },
+                cache: false,
+                async: false,
+            });
+        <!--{/section}-->
+
+    }
+
     function viewAccessLogsRead() {
         // presents logs as bullet points in a message window
         let viewAccessLogsRead = '<!--{foreach from=$accessLogs["read"] item=log}--> <li><!--{$log}--></li> <!--{/foreach}-->';
@@ -1385,7 +1459,10 @@ function doSubmit(recordID) {
         print = new printer();
 
         $('#btn_printForm').on('click', function() {
+            openContentForPrint();
             print.printForm(recordID);
+            //openContent('ajaxIndex.php?a=printview&recordID=<!--{$recordID|strip_tags}-->');
+
         });
         form.setRecordID(<!--{$recordID|strip_tags|escape}-->);
 

--- a/LEAF_Request_Portal/templates/print_form.tpl
+++ b/LEAF_Request_Portal/templates/print_form.tpl
@@ -656,7 +656,7 @@ function doSubmit(recordID) {
             error: function(res) {
                 $('#formcontent').empty().html(res);
             },
-            cache: false
+            cache: false,
         });
     }
 
@@ -1461,8 +1461,6 @@ function doSubmit(recordID) {
         $('#btn_printForm').on('click', function() {
             openContentForPrint();
             print.printForm(recordID);
-            //openContent('ajaxIndex.php?a=printview&recordID=<!--{$recordID|strip_tags}-->');
-
         });
         form.setRecordID(<!--{$recordID|strip_tags|escape}-->);
 


### PR DESCRIPTION
## Summary
When you have data on internal use forms this data is not saved on the print to pdf.  If you choose an internal use form and print it will only show the data from the internal use form. This is due to the data not being available. It appears this has been an issue for a long time.  The AEU said they had just started using the print to pdf.

The solution I came up with was just load all of the data on the page so when the pdf generation pulls the data it is available to pull. This prevents any issues of determining which form is currently loaded. Once the pdf is saved the page will be refreshed to reset it. This is a spot where I was not really able to get it to load the data back reliably. There are a lot of ajax calls for pulling in additional data that made this difficult to change.


## Impact
People using the print to pdf generation, this for some users could be a compliance issue

## Testing
Manual Testing is required for the pdf generation.

 On the dev box on record 959, if  you try and print to pdf on the master branch you will get an error similar to "#grid_55_1_959_output" and the data from the internal use is not shown. Note you may need to add some data in the grids on the main request and the grid internal.
