### PR TITLE
LEAF 5087 fix for nexus orgchart card menus

### DIFF
--- a/LEAF_Nexus/js/ui/position.js
+++ b/LEAF_Nexus/js/ui/position.js
@@ -86,7 +86,7 @@ position.prototype.initialize = function (parentContainerID) {
     const elContainer = elem.parentNode;
     const containerBounding = elContainer.getBoundingClientRect();
 
-    const mouseX = mouse.pageX;
+    const mouseX = mouse.pageX - window.scrollX;
     const mouseY = mouse.pageY - window.scrollY;
     const roundFix = 2;
     return (


### PR DESCRIPTION
## Summary
Uncovered during test cleanup.
Submenus in the Nexus Orgchart do not remain open when trying to access menu links and buttons if the page is scrolled.
Scroll distance needs to be taken into account when determining if the cursor is within the menu


## Impact
Nexus orgchart navigator and editing view

## Testing
Associated test branch PR
https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/174

