### PR TITLE
add use statement to prevent message error

### DIFF
--- a/LEAF_Request_Portal/scripts/updateDatabase.php
+++ b/LEAF_Request_Portal/scripts/updateDatabase.php
@@ -1,5 +1,6 @@
 <?php
 use App\Leaf\DbUpdate;
+use App\Leaf\XSSHelpers;
 /*
  * As a work of the United States government, this project is in the public domain within the United States.
  */


### PR DESCRIPTION
## Summary
Adds use statement for XSSHelpers class to prevent a 500 error associated with message display.
This issue did not affect actual update process.
There are also still some display issues associated with the way this is being used that can be addressed later (typically users do not manually update the DB via the dev console anymore).


## Impact
output of portal script updateDatabase.php


## Testing
go to 
portal -> admin -> dev console -> Update Database
Some information about the current DB version should be displayed.




